### PR TITLE
Convert #ivo files

### DIFF
--- a/CgfConverter/CgfConverter.csproj
+++ b/CgfConverter/CgfConverter.csproj
@@ -54,6 +54,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CryEngineCore\Chunks\ChunkDataStream_900.cs" />
     <Compile Include="CryEngineCore\Chunks\ChunkIvoSkin.cs" />
     <Compile Include="CryEngineCore\Chunks\ChunkIvoSkin_900.cs" />
     <Compile Include="CryEngineCore\Chunks\ChunkMeshSubsets_900.cs" />

--- a/CgfConverter/CgfConverter.csproj
+++ b/CgfConverter/CgfConverter.csproj
@@ -56,6 +56,7 @@
   <ItemGroup>
     <Compile Include="CryEngineCore\Chunks\ChunkIvoSkin.cs" />
     <Compile Include="CryEngineCore\Chunks\ChunkIvoSkin_900.cs" />
+    <Compile Include="CryEngineCore\Chunks\ChunkMeshSubsets_900.cs" />
     <Compile Include="CryEngineCore\Chunks\ChunkMesh_900.cs" />
     <Compile Include="CryEngine\CryEngine.cs" />
     <Compile Include="CryEngine\CryRender.cs" />

--- a/CgfConverter/CgfConverter.csproj
+++ b/CgfConverter/CgfConverter.csproj
@@ -54,6 +54,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CryEngineCore\Chunks\ChunkMesh_900.cs" />
     <Compile Include="CryEngine\CryEngine.cs" />
     <Compile Include="CryEngine\CryRender.cs" />
     <Compile Include="CryEngineCore\Chunks\ChunkBinaryXmlData.cs" />

--- a/CgfConverter/CgfConverter.csproj
+++ b/CgfConverter/CgfConverter.csproj
@@ -54,6 +54,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CryEngineCore\Chunks\ChunkIvoSkin.cs" />
+    <Compile Include="CryEngineCore\Chunks\ChunkIvoSkin_900.cs" />
     <Compile Include="CryEngineCore\Chunks\ChunkMesh_900.cs" />
     <Compile Include="CryEngine\CryEngine.cs" />
     <Compile Include="CryEngine\CryRender.cs" />

--- a/CgfConverter/CgfConverter.csproj
+++ b/CgfConverter/CgfConverter.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.CodeAnalysis.NetAnalyzers.5.0.3\build\Microsoft.CodeAnalysis.NetAnalyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.NetAnalyzers.5.0.3\build\Microsoft.CodeAnalysis.NetAnalyzers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -36,11 +37,11 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MathNet.Numerics, Version=4.12.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MathNet.Numerics.4.12.0\lib\net461\MathNet.Numerics.dll</HintPath>
+    <Reference Include="MathNet.Numerics, Version=4.15.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MathNet.Numerics.4.15.0\lib\net461\MathNet.Numerics.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -513,9 +514,6 @@
     <Compile Include="Structs\Structs.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="logo-50px-prod.ico" />
   </ItemGroup>
   <ItemGroup>
@@ -527,5 +525,20 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.NetAnalyzers.5.0.3\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.NetAnalyzers.5.0.3\analyzers\dotnet\cs\Microsoft.CodeAnalysis.NetAnalyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.NetAnalyzers.5.0.3\build\Microsoft.CodeAnalysis.NetAnalyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.NetAnalyzers.5.0.3\build\Microsoft.CodeAnalysis.NetAnalyzers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.NetAnalyzers.5.0.3\build\Microsoft.CodeAnalysis.NetAnalyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.NetAnalyzers.5.0.3\build\Microsoft.CodeAnalysis.NetAnalyzers.targets'))" />
+  </Target>
+  <Import Project="..\packages\Microsoft.CodeAnalysis.NetAnalyzers.5.0.3\build\Microsoft.CodeAnalysis.NetAnalyzers.targets" Condition="Exists('..\packages\Microsoft.CodeAnalysis.NetAnalyzers.5.0.3\build\Microsoft.CodeAnalysis.NetAnalyzers.targets')" />
 </Project>

--- a/CgfConverter/CryEngine/CryEngine.cs
+++ b/CgfConverter/CryEngine/CryEngine.cs
@@ -54,7 +54,7 @@ namespace CgfConverter
                     {
                         model.RootNode = rootNode = (rootNode ?? model.RootNode);  // Each model will have it's own rootnode.
 
-                        foreach (ChunkNode node in model.ChunkMap.Values.Where(c => c.ChunkType == ChunkTypeEnum.Node).Select(c => c as ChunkNode))
+                        foreach (ChunkNode node in model.ChunkMap.Values.Where(c => c.ChunkType == ChunkType.Node).Select(c => c as ChunkNode))
                         {
                             // Preserve existing parents
                             if (_nodeMap.ContainsKey(node.Name))
@@ -117,11 +117,11 @@ namespace CgfConverter
             // Get the material file name
             var allMaterialChunks = Models
                 .SelectMany(a => a.ChunkMap.Values)
-                .Where(c => c.ChunkType == ChunkTypeEnum.MtlName || c.ChunkType == ChunkTypeEnum.MtlNameIvo);
+                .Where(c => c.ChunkType == ChunkType.MtlName || c.ChunkType == ChunkType.MtlNameIvo);
             foreach (ChunkMtlName mtlChunk in allMaterialChunks)
             {
                 // Don't process child or collision materials for now
-                if (mtlChunk.MatType == MtlNameTypeEnum.Child || mtlChunk.MatType == MtlNameTypeEnum.Unknown1)
+                if (mtlChunk.MatType == MtlNameType.Child || mtlChunk.MatType == MtlNameType.Unknown1)
                     continue;
 
                 if (mtlChunk.Name.Contains(":"))
@@ -232,7 +232,7 @@ namespace CgfConverter
 
             foreach (ChunkMtlName mtlChunk in allMaterialChunks)
             {
-                if (mtlChunk.MatType != MtlNameTypeEnum.Library)
+                if (mtlChunk.MatType != MtlNameType.Library)
                 {
                     Materials.Add(Material.CreateDefaultMaterial(mtlChunk.Name));
                 }

--- a/CgfConverter/CryEngineCore/Chunks/Chunk.cs
+++ b/CgfConverter/CryEngineCore/Chunks/Chunk.cs
@@ -92,6 +92,8 @@ namespace CgfConverter.CryEngineCore
                     return Chunk.New<ChunkCompiledBones>(version);
                 case ChunkTypeEnum.MeshIvo:
                     return Chunk.New<ChunkMesh>(version);
+                case ChunkTypeEnum.IvoSkin:
+                    return Chunk.New<ChunkIvoSkin>(version);
                 // Old chunks
                 case ChunkTypeEnum.BoneNameList:
                     return Chunk.New<ChunkBoneNameList>(version);

--- a/CgfConverter/CryEngineCore/Chunks/Chunk.cs
+++ b/CgfConverter/CryEngineCore/Chunks/Chunk.cs
@@ -90,6 +90,8 @@ namespace CgfConverter.CryEngineCore
                     return Chunk.New<ChunkMtlName>(version);
                 case ChunkTypeEnum.CompiledBonesIvo:
                     return Chunk.New<ChunkCompiledBones>(version);
+                case ChunkTypeEnum.MeshIvo:
+                    return Chunk.New<ChunkMesh>(version);
                 // Old chunks
                 case ChunkTypeEnum.BoneNameList:
                     return Chunk.New<ChunkBoneNameList>(version);

--- a/CgfConverter/CryEngineCore/Chunks/Chunk.cs
+++ b/CgfConverter/CryEngineCore/Chunks/Chunk.cs
@@ -17,7 +17,7 @@ namespace CgfConverter.CryEngineCore
         internal Model _model;
 
         public uint Offset { get; internal set; }
-        public ChunkTypeEnum ChunkType { get; internal set; }
+        public ChunkType ChunkType { get; internal set; }
         internal uint Version;
         internal int ID;
         internal uint Size;
@@ -25,83 +25,83 @@ namespace CgfConverter.CryEngineCore
 
         internal Dictionary<long, byte> SkippedBytes = new Dictionary<long, byte> { };
 
-        public static Chunk New(ChunkTypeEnum chunkType, uint version)
+        public static Chunk New(ChunkType chunkType, uint version)
         {
             switch (chunkType)
             {
-                case ChunkTypeEnum.SourceInfo:
+                case ChunkType.SourceInfo:
                     return Chunk.New<ChunkSourceInfo>(version);
-                case ChunkTypeEnum.Timing:
+                case ChunkType.Timing:
                     return Chunk.New<ChunkTimingFormat>(version);
-                case ChunkTypeEnum.ExportFlags:
+                case ChunkType.ExportFlags:
                     return Chunk.New<ChunkExportFlags>(version);
-                case ChunkTypeEnum.MtlName:
+                case ChunkType.MtlName:
                     return Chunk.New<ChunkMtlName>(version);
-                case ChunkTypeEnum.DataStream:
+                case ChunkType.DataStream:
                     return Chunk.New<ChunkDataStream>(version);
-                case ChunkTypeEnum.Mesh:
+                case ChunkType.Mesh:
                     return Chunk.New<ChunkMesh>(version);
-                case ChunkTypeEnum.MeshSubsets:
+                case ChunkType.MeshSubsets:
                     return Chunk.New<ChunkMeshSubsets>(version);
-                case ChunkTypeEnum.Node:
+                case ChunkType.Node:
                     return Chunk.New<ChunkNode>(version);
-                case ChunkTypeEnum.Helper:
+                case ChunkType.Helper:
                     return Chunk.New<ChunkHelper>(version);
-                case ChunkTypeEnum.Controller:
+                case ChunkType.Controller:
                     return Chunk.New<ChunkController>(version);
-                case ChunkTypeEnum.SceneProps:
+                case ChunkType.SceneProps:
                     return Chunk.New<ChunkSceneProp>(version);
-                case ChunkTypeEnum.MeshPhysicsData:
+                case ChunkType.MeshPhysicsData:
                     return Chunk.New<ChunkMeshPhysicsData>(version);
-                case ChunkTypeEnum.BoneAnim:
+                case ChunkType.BoneAnim:
                     return Chunk.New<ChunkBoneAnim>(version);
                 // Compiled chunks
-                case ChunkTypeEnum.CompiledBones:
+                case ChunkType.CompiledBones:
                     return Chunk.New<ChunkCompiledBones>(version);
-                case ChunkTypeEnum.CompiledPhysicalProxies:
+                case ChunkType.CompiledPhysicalProxies:
                     return Chunk.New<ChunkCompiledPhysicalProxies>(version);
-                case ChunkTypeEnum.CompiledPhysicalBones:
+                case ChunkType.CompiledPhysicalBones:
                     return Chunk.New<ChunkCompiledPhysicalBones>(version);
-                case ChunkTypeEnum.CompiledIntSkinVertices:
+                case ChunkType.CompiledIntSkinVertices:
                     return Chunk.New<ChunkCompiledIntSkinVertices>(version);
-                case ChunkTypeEnum.CompiledMorphTargets:
+                case ChunkType.CompiledMorphTargets:
                     return Chunk.New<ChunkCompiledMorphTargets>(version);
-                case ChunkTypeEnum.CompiledExt2IntMap:
+                case ChunkType.CompiledExt2IntMap:
                     return Chunk.New<ChunkCompiledExtToIntMap>(version);
-                case ChunkTypeEnum.CompiledIntFaces:
+                case ChunkType.CompiledIntFaces:
                     return Chunk.New<ChunkCompiledIntFaces>(version);
                 // Star Citizen equivalents
-                case ChunkTypeEnum.CompiledBonesSC:
+                case ChunkType.CompiledBonesSC:
                     return Chunk.New<ChunkCompiledBones>(version);
-                case ChunkTypeEnum.CompiledPhysicalBonesSC:
+                case ChunkType.CompiledPhysicalBonesSC:
                     return Chunk.New<ChunkCompiledPhysicalBones>(version);
-                case ChunkTypeEnum.CompiledExt2IntMapSC:
+                case ChunkType.CompiledExt2IntMapSC:
                     return Chunk.New<ChunkCompiledExtToIntMap>(version);
-                case ChunkTypeEnum.CompiledIntFacesSC:
+                case ChunkType.CompiledIntFacesSC:
                     return Chunk.New<ChunkCompiledIntFaces>(version);
-                case ChunkTypeEnum.CompiledIntSkinVerticesSC:
+                case ChunkType.CompiledIntSkinVerticesSC:
                     return Chunk.New<ChunkCompiledIntSkinVertices>(version);
-                case ChunkTypeEnum.CompiledMorphTargetsSC:
+                case ChunkType.CompiledMorphTargetsSC:
                     return Chunk.New<ChunkCompiledMorphTargets>(version);
-                case ChunkTypeEnum.CompiledPhysicalProxiesSC:
+                case ChunkType.CompiledPhysicalProxiesSC:
                     return Chunk.New<ChunkCompiledPhysicalProxies>(version);
                 // SC IVO chunks
-                case ChunkTypeEnum.MtlNameIvo:
+                case ChunkType.MtlNameIvo:
                     return Chunk.New<ChunkMtlName>(version);
-                case ChunkTypeEnum.CompiledBonesIvo:
+                case ChunkType.CompiledBonesIvo:
                     return Chunk.New<ChunkCompiledBones>(version);
-                case ChunkTypeEnum.MeshIvo:
+                case ChunkType.MeshIvo:
                     return Chunk.New<ChunkMesh>(version);
-                case ChunkTypeEnum.IvoSkin:
+                case ChunkType.IvoSkin:
                     return Chunk.New<ChunkIvoSkin>(version);
                 // Old chunks
-                case ChunkTypeEnum.BoneNameList:
+                case ChunkType.BoneNameList:
                     return Chunk.New<ChunkBoneNameList>(version);
-                case ChunkTypeEnum.MeshMorphTarget:
+                case ChunkType.MeshMorphTarget:
                     return Chunk.New<ChunkMeshMorphTargets>(version);
-                case ChunkTypeEnum.BinaryXmlDataSC:
+                case ChunkType.BinaryXmlDataSC:
                     return Chunk.New<ChunkBinaryXmlData>(version);
-                case ChunkTypeEnum.Mtl:
+                case ChunkType.Mtl:
                     //Utils.Log(LogLevelEnum.Debug, "Mtl Chunk here");  // Obsolete.  Not used
                 default:
                     return new ChunkUnknown();
@@ -186,9 +186,9 @@ namespace CgfConverter.CryEngineCore
             reader.BaseStream.Seek(_header.Offset, 0);
 
             // Star Citizen files don't have the type, version, offset and ID at the start of a chunk, so don't read them.
-            if (_model.FileVersion == FileVersionEnum.CryTek_3_4 || _model.FileVersion == FileVersionEnum.CryTek_3_5)
+            if (_model.FileVersion == FileVersion.CryTek_3_4 || _model.FileVersion == FileVersion.CryTek_3_5)
             {
-                ChunkType = (ChunkTypeEnum)Enum.ToObject(typeof(ChunkTypeEnum), reader.ReadUInt32());
+                ChunkType = (ChunkType)Enum.ToObject(typeof(ChunkType), reader.ReadUInt32());
                 Version = reader.ReadUInt32();
                 Offset = reader.ReadUInt32();
                 ID = reader.ReadInt32();

--- a/CgfConverter/CryEngineCore/Chunks/ChunkCompiledPhysicalBones.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkCompiledPhysicalBones.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace CgfConverter.CryEngineCore
 {
-    public abstract class ChunkCompiledPhysicalBones : Chunk     //  0xACDC0000:  Bones info
+    public abstract class ChunkCompiledPhysicalBones : Chunk
     {
         public char[] Reserved;             // 32 byte array
         public CompiledPhysicalBone RootPhysicalBone;       // First bone in the data structure.  Usually Bip01

--- a/CgfConverter/CryEngineCore/Chunks/ChunkCompiledPhysicalBones_800.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkCompiledPhysicalBones_800.cs
@@ -2,7 +2,7 @@
 
 namespace CgfConverter.CryEngineCore
 {
-    public class ChunkCompiledPhysicalBones_800 : ChunkCompiledPhysicalBones     //  0xACDC0000:  Bones info
+    public class ChunkCompiledPhysicalBones_800 : ChunkCompiledPhysicalBones
     {
         public override void Read(BinaryReader b)
         {
@@ -29,8 +29,6 @@ namespace CgfConverter.CryEngineCore
             {
                 AddChildIDToParent(bone);
             }
-            SkinningInfo skin = GetSkinningInfo();
-            //skin.PhysicalBoneMeshes
         }
     }
 }

--- a/CgfConverter/CryEngineCore/Chunks/ChunkDataStream.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkDataStream.cs
@@ -7,7 +7,7 @@ namespace CgfConverter.CryEngineCore
         public uint Flags { get; set; } // not used, but looks like the start of the Data Stream chunk
         public uint Flags1 { get; set; } // not used.  UInt32 after Flags that looks like offsets
         public uint Flags2 { get; set; } // not used, looks almost like a filler.
-        public DataStreamTypeEnum DataStreamType { get; set; } // type of data (vertices, normals, uv, etc)
+        public DATASTREAMTYPE DataStreamType { get; set; } // type of data (vertices, normals, uv, etc)
         public uint NumElements { get; set; } // Number of data entries
         public uint BytesPerElement { get; set; } // Bytes per data entry
         public uint Reserved1 { get; set; }

--- a/CgfConverter/CryEngineCore/Chunks/ChunkDataStream.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkDataStream.cs
@@ -7,7 +7,7 @@ namespace CgfConverter.CryEngineCore
         public uint Flags { get; set; } // not used, but looks like the start of the Data Stream chunk
         public uint Flags1 { get; set; } // not used.  UInt32 after Flags that looks like offsets
         public uint Flags2 { get; set; } // not used, looks almost like a filler.
-        public DATASTREAMTYPE DataStreamType { get; set; } // type of data (vertices, normals, uv, etc)
+        public DatastreamType DataStreamType { get; set; } // type of data (vertices, normals, uv, etc)
         public uint NumElements { get; set; } // Number of data entries
         public uint BytesPerElement { get; set; } // Bytes per data entry
         public uint Reserved1 { get; set; }

--- a/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_800.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_800.cs
@@ -58,14 +58,14 @@ namespace CgfConverter.CryEngineCore
 
             Flags2 = b.ReadUInt32(); // another filler
             uint tmpdataStreamType = b.ReadUInt32();
-            DataStreamType = (DATASTREAMTYPE)Enum.ToObject(typeof(DATASTREAMTYPE), tmpdataStreamType);
+            DataStreamType = (DatastreamType)Enum.ToObject(typeof(DatastreamType), tmpdataStreamType);
             NumElements = b.ReadUInt32(); // number of elements in this chunk
 
-            if (_model.FileVersion == FileVersionEnum.CryTek_3_5 || _model.FileVersion == FileVersionEnum.CryTek_3_4)
+            if (_model.FileVersion == FileVersion.CryTek_3_5 || _model.FileVersion == FileVersion.CryTek_3_4)
             {
                 BytesPerElement = b.ReadUInt32();
             }
-            if (_model.FileVersion == FileVersionEnum.CryTek_3_6)
+            if (_model.FileVersion == FileVersion.CryTek_3_6)
             {
                 BytesPerElement = (uint)b.ReadInt16();        // Star Citizen 2.0 is using an int16 here now.
                 b.ReadInt16();                                       // unknown value.   Doesn't look like padding though.
@@ -78,7 +78,7 @@ namespace CgfConverter.CryEngineCore
             {
                 #region case DataStreamTypeEnum.VERTICES:
 
-                case DATASTREAMTYPE.VERTICES:  // Ref is 0x00000000
+                case DatastreamType.VERTICES:  // Ref is 0x00000000
                     Vertices = new Vector3[NumElements];
 
                     switch (BytesPerElement)
@@ -142,7 +142,7 @@ namespace CgfConverter.CryEngineCore
                 #endregion
                 #region case DataStreamTypeEnum.INDICES:
 
-                case DATASTREAMTYPE.INDICES:  // Ref is 
+                case DatastreamType.INDICES:  // Ref is 
                     Indices = new uint[NumElements];
 
                     if (BytesPerElement == 2)
@@ -164,7 +164,7 @@ namespace CgfConverter.CryEngineCore
                 #endregion
                 #region case DataStreamTypeEnum.NORMALS:
 
-                case DATASTREAMTYPE.NORMALS:
+                case DatastreamType.NORMALS:
                     Normals = new Vector3[NumElements];
                     for (int i = 0; i < NumElements; i++)
                     {
@@ -177,7 +177,7 @@ namespace CgfConverter.CryEngineCore
                 #endregion
                 #region case DataStreamTypeEnum.UVS:
 
-                case DATASTREAMTYPE.UVS:
+                case DatastreamType.UVS:
                     UVs = new UV[NumElements];
                     for (Int32 i = 0; i < NumElements; i++)
                     {
@@ -190,7 +190,7 @@ namespace CgfConverter.CryEngineCore
                 #endregion
                 #region case DataStreamTypeEnum.TANGENTS:
 
-                case DATASTREAMTYPE.TANGENTS:
+                case DatastreamType.TANGENTS:
                     Tangents = new Tangent[NumElements, 2];
                     Normals = new Vector3[NumElements];
                     for (int i = 0; i < NumElements; i++)
@@ -242,7 +242,7 @@ namespace CgfConverter.CryEngineCore
                 #endregion
                 #region case DataStreamTypeEnum.COLORS:
 
-                case DATASTREAMTYPE.COLORS:
+                case DatastreamType.COLORS:
                     switch (BytesPerElement)
                     {
                         case 3:
@@ -278,7 +278,7 @@ namespace CgfConverter.CryEngineCore
                 #endregion
                 #region case DataStreamTypeEnum.VERTSUVS:
 
-                case DATASTREAMTYPE.VERTSUVS:  // 3 half floats for verts, 3 half floats for normals, 2 half floats for UVs
+                case DatastreamType.VERTSUVS:  // 3 half floats for verts, 3 half floats for normals, 2 half floats for UVs
                     // Utils.Log(LogLevelEnum.Debug, "In VertsUVs...");
                     Vertices = new Vector3[NumElements];
                     Normals = new Vector3[NumElements];
@@ -416,7 +416,7 @@ namespace CgfConverter.CryEngineCore
                     break;
                 #endregion
                 #region case DataStreamTypeEnum.BONEMAP:
-                case DATASTREAMTYPE.BONEMAP:
+                case DatastreamType.BONEMAP:
                     SkinningInfo skin = GetSkinningInfo();
                     skin.HasBoneMapDatastream = true;
 
@@ -470,7 +470,7 @@ namespace CgfConverter.CryEngineCore
 
                 #endregion
                 #region DataStreamTypeEnum.Unknown1
-                case DATASTREAMTYPE.UNKNOWN1:
+                case DatastreamType.UNKNOWN1:
                     Tangents = new Tangent[NumElements, 2];
                     Normals = new Vector3[NumElements];
                     for (int i = 0; i < NumElements; i++)

--- a/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_800.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_800.cs
@@ -228,9 +228,6 @@ namespace CgfConverter.CryEngineCore
                                 //Normals[i].x = (Tangents[i,0].y * Tangents[i,1].z - Tangents[i,0].z * Tangents[i,1].y);
                                 //Normals[i].y = 0 - (Tangents[i,0].x * Tangents[i,1].z - Tangents[i,0].z * Tangents[i,1].x); 
                                 //Normals[i].z = (Tangents[i,0].x * Tangents[i,1].y - Tangents[i,0].y * Tangents[i,1].x);
-                                //Console.WriteLine("Tangent: {0:F6} {1:F6} {2:F6}", Tangents[i,0].x, Tangents[i, 0].y, Tangents[i, 0].z);
-                                //Console.WriteLine("Binormal: {0:F6} {1:F6} {2:F6}", Tangents[i, 1].x, Tangents[i, 1].y, Tangents[i, 1].z);
-                                //Console.WriteLine("Normal: {0:F6} {1:F6} {2:F6}", Normals[i].x, Normals[i].y, Normals[i].z);
                                 break;
                             default:
                                 throw new Exception("Need to add new Tangent Size");
@@ -316,7 +313,6 @@ namespace CgfConverter.CryEngineCore
                             }
                             break;
                         case 16:   // Dymek updated 
-                            //Console.WriteLine("method: (5), 3 half floats for verts, 3 colors, 2 half floats for UVs");
                             for (Int32 i = 0; i < NumElements; i++)
                             {
                                 ushort bver = 0;

--- a/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_800.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_800.cs
@@ -57,8 +57,8 @@ namespace CgfConverter.CryEngineCore
             base.Read(b);
 
             Flags2 = b.ReadUInt32(); // another filler
-            uint tmpdataStreamType = b.ReadUInt32();
-            DataStreamType = (DatastreamType)Enum.ToObject(typeof(DatastreamType), tmpdataStreamType);
+            uint dataStreamType = b.ReadUInt32();
+            DataStreamType = (DatastreamType)Enum.ToObject(typeof(DatastreamType), dataStreamType);
             NumElements = b.ReadUInt32(); // number of elements in this chunk
 
             if (_model.FileVersion == FileVersion.CryTek_3_5 || _model.FileVersion == FileVersion.CryTek_3_4)
@@ -279,7 +279,6 @@ namespace CgfConverter.CryEngineCore
                 #region case DataStreamTypeEnum.VERTSUVS:
 
                 case DatastreamType.VERTSUVS:  // 3 half floats for verts, 3 half floats for normals, 2 half floats for UVs
-                    // Utils.Log(LogLevelEnum.Debug, "In VertsUVs...");
                     Vertices = new Vector3[NumElements];
                     Normals = new Vector3[NumElements];
                     RGBColors = new IRGB[NumElements];

--- a/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_800.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_800.cs
@@ -149,8 +149,7 @@ namespace CgfConverter.CryEngineCore
                     {
                         for (int i = 0; i < NumElements; i++)
                         {
-                            Indices[i] = (uint)b.ReadUInt16();
-                            //Console.WriteLine("Indices {0}: {1}", i, Indices[i]);
+                            Indices[i] = b.ReadUInt16();
                         }
                     }
                     if (BytesPerElement == 4)
@@ -160,7 +159,6 @@ namespace CgfConverter.CryEngineCore
                             Indices[i] = b.ReadUInt32();
                         }
                     }
-                    //Utils.Log(LogLevelEnum.Debug, "Offset is {0:X}", b.BaseStream.Position);
                     break;
 
                 #endregion

--- a/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_800.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_800.cs
@@ -58,7 +58,7 @@ namespace CgfConverter.CryEngineCore
 
             Flags2 = b.ReadUInt32(); // another filler
             uint tmpdataStreamType = b.ReadUInt32();
-            DataStreamType = (DataStreamTypeEnum)Enum.ToObject(typeof(DataStreamTypeEnum), tmpdataStreamType);
+            DataStreamType = (DATASTREAMTYPE)Enum.ToObject(typeof(DATASTREAMTYPE), tmpdataStreamType);
             NumElements = b.ReadUInt32(); // number of elements in this chunk
 
             if (_model.FileVersion == FileVersionEnum.CryTek_3_5 || _model.FileVersion == FileVersionEnum.CryTek_3_4)
@@ -78,7 +78,7 @@ namespace CgfConverter.CryEngineCore
             {
                 #region case DataStreamTypeEnum.VERTICES:
 
-                case DataStreamTypeEnum.VERTICES:  // Ref is 0x00000000
+                case DATASTREAMTYPE.VERTICES:  // Ref is 0x00000000
                     Vertices = new Vector3[NumElements];
 
                     switch (BytesPerElement)
@@ -142,7 +142,7 @@ namespace CgfConverter.CryEngineCore
                 #endregion
                 #region case DataStreamTypeEnum.INDICES:
 
-                case DataStreamTypeEnum.INDICES:  // Ref is 
+                case DATASTREAMTYPE.INDICES:  // Ref is 
                     Indices = new uint[NumElements];
 
                     if (BytesPerElement == 2)
@@ -164,7 +164,7 @@ namespace CgfConverter.CryEngineCore
                 #endregion
                 #region case DataStreamTypeEnum.NORMALS:
 
-                case DataStreamTypeEnum.NORMALS:
+                case DATASTREAMTYPE.NORMALS:
                     Normals = new Vector3[NumElements];
                     for (int i = 0; i < NumElements; i++)
                     {
@@ -177,7 +177,7 @@ namespace CgfConverter.CryEngineCore
                 #endregion
                 #region case DataStreamTypeEnum.UVS:
 
-                case DataStreamTypeEnum.UVS:
+                case DATASTREAMTYPE.UVS:
                     UVs = new UV[NumElements];
                     for (Int32 i = 0; i < NumElements; i++)
                     {
@@ -190,7 +190,7 @@ namespace CgfConverter.CryEngineCore
                 #endregion
                 #region case DataStreamTypeEnum.TANGENTS:
 
-                case DataStreamTypeEnum.TANGENTS:
+                case DATASTREAMTYPE.TANGENTS:
                     Tangents = new Tangent[NumElements, 2];
                     Normals = new Vector3[NumElements];
                     for (int i = 0; i < NumElements; i++)
@@ -242,7 +242,7 @@ namespace CgfConverter.CryEngineCore
                 #endregion
                 #region case DataStreamTypeEnum.COLORS:
 
-                case DataStreamTypeEnum.COLORS:
+                case DATASTREAMTYPE.COLORS:
                     switch (BytesPerElement)
                     {
                         case 3:
@@ -278,7 +278,7 @@ namespace CgfConverter.CryEngineCore
                 #endregion
                 #region case DataStreamTypeEnum.VERTSUVS:
 
-                case DataStreamTypeEnum.VERTSUVS:  // 3 half floats for verts, 3 half floats for normals, 2 half floats for UVs
+                case DATASTREAMTYPE.VERTSUVS:  // 3 half floats for verts, 3 half floats for normals, 2 half floats for UVs
                     // Utils.Log(LogLevelEnum.Debug, "In VertsUVs...");
                     Vertices = new Vector3[NumElements];
                     Normals = new Vector3[NumElements];
@@ -416,7 +416,7 @@ namespace CgfConverter.CryEngineCore
                     break;
                 #endregion
                 #region case DataStreamTypeEnum.BONEMAP:
-                case DataStreamTypeEnum.BONEMAP:
+                case DATASTREAMTYPE.BONEMAP:
                     SkinningInfo skin = GetSkinningInfo();
                     skin.HasBoneMapDatastream = true;
 
@@ -470,7 +470,7 @@ namespace CgfConverter.CryEngineCore
 
                 #endregion
                 #region DataStreamTypeEnum.Unknown1
-                case DataStreamTypeEnum.UNKNOWN1:
+                case DATASTREAMTYPE.UNKNOWN1:
                     Tangents = new Tangent[NumElements, 2];
                     Normals = new Vector3[NumElements];
                     for (int i = 0; i < NumElements; i++)

--- a/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_80000800.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_80000800.cs
@@ -13,7 +13,7 @@ namespace CgfConverter.CryEngineCore
 
             this.Flags2 = Utils.SwapUIntEndian(b.ReadUInt32()); // another filler
             uint tmpdataStreamType = Utils.SwapUIntEndian(b.ReadUInt32());
-            this.DataStreamType = (DataStreamTypeEnum)Enum.ToObject(typeof(DataStreamTypeEnum), tmpdataStreamType);
+            this.DataStreamType = (DATASTREAMTYPE)Enum.ToObject(typeof(DATASTREAMTYPE), tmpdataStreamType);
             this.NumElements = Utils.SwapUIntEndian(b.ReadUInt32()); // number of elements in this chunk
             this.BytesPerElement = Utils.SwapUIntEndian(b.ReadUInt32());
 
@@ -24,7 +24,7 @@ namespace CgfConverter.CryEngineCore
             {
                 #region case DataStreamTypeEnum.VERTICES:
 
-                case DataStreamTypeEnum.VERTICES:  // Ref is 0x00000000
+                case DATASTREAMTYPE.VERTICES:  // Ref is 0x00000000
                     this.Vertices = new Vector3[this.NumElements];
 
                     switch (BytesPerElement)
@@ -43,7 +43,7 @@ namespace CgfConverter.CryEngineCore
                 #endregion
                 #region case DataStreamTypeEnum.INDICES:
 
-                case DataStreamTypeEnum.INDICES:  // Ref is 
+                case DATASTREAMTYPE.INDICES:  // Ref is 
                     this.Indices = new UInt32[NumElements];
 
                     if (this.BytesPerElement == 2)
@@ -65,7 +65,7 @@ namespace CgfConverter.CryEngineCore
                 #endregion
                 #region case DataStreamTypeEnum.NORMALS:
 
-                case DataStreamTypeEnum.NORMALS:
+                case DATASTREAMTYPE.NORMALS:
                     this.Normals = new Vector3[this.NumElements];
                     for (Int32 i = 0; i < NumElements; i++)
                     {
@@ -79,7 +79,7 @@ namespace CgfConverter.CryEngineCore
                 #endregion
                 #region case DataStreamTypeEnum.UVS:
 
-                case DataStreamTypeEnum.UVS:
+                case DATASTREAMTYPE.UVS:
                     this.UVs = new UV[this.NumElements];
                     for (Int32 i = 0; i < this.NumElements; i++)
                     {
@@ -91,7 +91,7 @@ namespace CgfConverter.CryEngineCore
                 #endregion
                 #region case DataStreamTypeEnum.TANGENTS:
 
-                case DataStreamTypeEnum.TANGENTS:
+                case DATASTREAMTYPE.TANGENTS:
                     this.Tangents = new Tangent[this.NumElements, 2];
                     this.Normals = new Vector3[this.NumElements];
                     for (Int32 i = 0; i < this.NumElements; i++)
@@ -133,7 +133,7 @@ namespace CgfConverter.CryEngineCore
                     break;
                 #endregion
                 #region case DataStreamTypeEnum.COLORS:
-                case DataStreamTypeEnum.COLORS:
+                case DATASTREAMTYPE.COLORS:
                     switch (this.BytesPerElement)
                     {
                         case 3:
@@ -167,7 +167,7 @@ namespace CgfConverter.CryEngineCore
                     break;
                 #endregion
                 #region case DataStreamTypeEnum.BONEMAP:
-                case DataStreamTypeEnum.BONEMAP:
+                case DATASTREAMTYPE.BONEMAP:
                     SkinningInfo skin = GetSkinningInfo();
                     skin.HasBoneMapDatastream = true;
 
@@ -220,7 +220,7 @@ namespace CgfConverter.CryEngineCore
 
                 #endregion
                 #region DataStreamTypeEnum.Unknown1
-                case DataStreamTypeEnum.UNKNOWN1:
+                case DATASTREAMTYPE.UNKNOWN1:
                     this.Tangents = new Tangent[this.NumElements, 2];
                     this.Normals = new Vector3[this.NumElements];
                     for (Int32 i = 0; i < NumElements; i++)

--- a/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_80000800.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_80000800.cs
@@ -13,7 +13,7 @@ namespace CgfConverter.CryEngineCore
 
             this.Flags2 = Utils.SwapUIntEndian(b.ReadUInt32()); // another filler
             uint tmpdataStreamType = Utils.SwapUIntEndian(b.ReadUInt32());
-            this.DataStreamType = (DATASTREAMTYPE)Enum.ToObject(typeof(DATASTREAMTYPE), tmpdataStreamType);
+            this.DataStreamType = (DatastreamType)Enum.ToObject(typeof(DatastreamType), tmpdataStreamType);
             this.NumElements = Utils.SwapUIntEndian(b.ReadUInt32()); // number of elements in this chunk
             this.BytesPerElement = Utils.SwapUIntEndian(b.ReadUInt32());
 
@@ -24,7 +24,7 @@ namespace CgfConverter.CryEngineCore
             {
                 #region case DataStreamTypeEnum.VERTICES:
 
-                case DATASTREAMTYPE.VERTICES:  // Ref is 0x00000000
+                case DatastreamType.VERTICES:  // Ref is 0x00000000
                     this.Vertices = new Vector3[this.NumElements];
 
                     switch (BytesPerElement)
@@ -43,7 +43,7 @@ namespace CgfConverter.CryEngineCore
                 #endregion
                 #region case DataStreamTypeEnum.INDICES:
 
-                case DATASTREAMTYPE.INDICES:  // Ref is 
+                case DatastreamType.INDICES:  // Ref is 
                     this.Indices = new UInt32[NumElements];
 
                     if (this.BytesPerElement == 2)
@@ -65,7 +65,7 @@ namespace CgfConverter.CryEngineCore
                 #endregion
                 #region case DataStreamTypeEnum.NORMALS:
 
-                case DATASTREAMTYPE.NORMALS:
+                case DatastreamType.NORMALS:
                     this.Normals = new Vector3[this.NumElements];
                     for (Int32 i = 0; i < NumElements; i++)
                     {
@@ -79,7 +79,7 @@ namespace CgfConverter.CryEngineCore
                 #endregion
                 #region case DataStreamTypeEnum.UVS:
 
-                case DATASTREAMTYPE.UVS:
+                case DatastreamType.UVS:
                     this.UVs = new UV[this.NumElements];
                     for (Int32 i = 0; i < this.NumElements; i++)
                     {
@@ -91,7 +91,7 @@ namespace CgfConverter.CryEngineCore
                 #endregion
                 #region case DataStreamTypeEnum.TANGENTS:
 
-                case DATASTREAMTYPE.TANGENTS:
+                case DatastreamType.TANGENTS:
                     this.Tangents = new Tangent[this.NumElements, 2];
                     this.Normals = new Vector3[this.NumElements];
                     for (Int32 i = 0; i < this.NumElements; i++)
@@ -133,7 +133,7 @@ namespace CgfConverter.CryEngineCore
                     break;
                 #endregion
                 #region case DataStreamTypeEnum.COLORS:
-                case DATASTREAMTYPE.COLORS:
+                case DatastreamType.COLORS:
                     switch (this.BytesPerElement)
                     {
                         case 3:
@@ -167,7 +167,7 @@ namespace CgfConverter.CryEngineCore
                     break;
                 #endregion
                 #region case DataStreamTypeEnum.BONEMAP:
-                case DATASTREAMTYPE.BONEMAP:
+                case DatastreamType.BONEMAP:
                     SkinningInfo skin = GetSkinningInfo();
                     skin.HasBoneMapDatastream = true;
 
@@ -220,7 +220,7 @@ namespace CgfConverter.CryEngineCore
 
                 #endregion
                 #region DataStreamTypeEnum.Unknown1
-                case DATASTREAMTYPE.UNKNOWN1:
+                case DatastreamType.UNKNOWN1:
                     this.Tangents = new Tangent[this.NumElements, 2];
                     this.Normals = new Vector3[this.NumElements];
                     for (Int32 i = 0; i < NumElements; i++)

--- a/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_801.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_801.cs
@@ -133,9 +133,6 @@ namespace CgfConverter.CryEngineCore
                                 //this.Normals[i].x = (Tangents[i,0].y * Tangents[i,1].z - Tangents[i,0].z * Tangents[i,1].y);
                                 //this.Normals[i].y = 0 - (Tangents[i,0].x * Tangents[i,1].z - Tangents[i,0].z * Tangents[i,1].x); 
                                 //this.Normals[i].z = (Tangents[i,0].x * Tangents[i,1].y - Tangents[i,0].y * Tangents[i,1].x);
-                                //Console.WriteLine("Tangent: {0:F6} {1:F6} {2:F6}", Tangents[i,0].x, Tangents[i, 0].y, Tangents[i, 0].z);
-                                //Console.WriteLine("Binormal: {0:F6} {1:F6} {2:F6}", Tangents[i, 1].x, Tangents[i, 1].y, Tangents[i, 1].z);
-                                //Console.WriteLine("Normal: {0:F6} {1:F6} {2:F6}", Normals[i].x, Normals[i].y, Normals[i].z);
                                 break;
                             default:
                                 throw new Exception("Need to add new Tangent Size");
@@ -218,7 +215,6 @@ namespace CgfConverter.CryEngineCore
                             }
                             break;
                         case 16:   // Dymek updated this.
-                            //Console.WriteLine("method: (5), 3 half floats for verts, 3 colors, 2 half floats for UVs");
                             for (int i = 0; i < NumElements; i++)
                             {
                                 ushort bver = 0;

--- a/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_801.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_801.cs
@@ -6,18 +6,17 @@ namespace CgfConverter.CryEngineCore
 {
     public class ChunkDataStream_801 : ChunkDataStream
     {
-        // Spriggan models, not sure which game.  Also Crucible.  SC, MWO uses 0800
         public override void Read(BinaryReader b)
         {
             base.Read(b);
 
             Flags2 = b.ReadUInt32(); // another filler
-            uint tmpdataStreamType = b.ReadUInt32();
-            DataStreamType = (DatastreamType)Enum.ToObject(typeof(DatastreamType), tmpdataStreamType);
+            uint datastreamType = b.ReadUInt32();
+            DataStreamType = (DatastreamType)Enum.ToObject(typeof(DatastreamType), datastreamType);
             SkipBytes(b, 4);
             NumElements = b.ReadUInt32(); // number of elements in this chunk
 
-            BytesPerElement = b.ReadUInt32(); // bytes per element
+            BytesPerElement = b.ReadUInt32();
 
             SkipBytes(b, 8);
 
@@ -28,7 +27,7 @@ namespace CgfConverter.CryEngineCore
                     Vertices = new Vector3[NumElements];
                     if (BytesPerElement == 12)
                     {
-                        for (Int32 i = 0; i < NumElements; i++)
+                        for (int i = 0; i < NumElements; i++)
                         {
                             Vertices[i].x = b.ReadSingle();
                             Vertices[i].y = b.ReadSingle();
@@ -37,7 +36,7 @@ namespace CgfConverter.CryEngineCore
                     } else 
                     if (BytesPerElement == 8)
                     {
-                        for (Int32 i = 0; i < NumElements; i++)
+                        for (int i = 0; i < NumElements; i++)
                         {
                             Half xshort = new Half();
                             xshort.bits = b.ReadUInt16();
@@ -57,18 +56,18 @@ namespace CgfConverter.CryEngineCore
                     break;
 
                 case DatastreamType.INDICES: 
-                    Indices = new UInt32[NumElements];
+                    Indices = new uint[NumElements];
 
                     if (BytesPerElement == 2)
                     {
-                        for (Int32 i = 0; i < NumElements; i++)
+                        for (int i = 0; i < NumElements; i++)
                         {
-                            Indices[i] = (UInt32)b.ReadUInt16();
+                            Indices[i] = (uint)b.ReadUInt16();
                         }
                     }
                     if (BytesPerElement == 4)
                     {
-                        for (Int32 i = 0; i < NumElements; i++)
+                        for (int i = 0; i < NumElements; i++)
                         {
                             Indices[i] = b.ReadUInt32();
                         }
@@ -77,7 +76,7 @@ namespace CgfConverter.CryEngineCore
 
                 case DatastreamType.NORMALS:
                     Normals = new Vector3[NumElements];
-                    for (Int32 i = 0; i < NumElements; i++)
+                    for (int i = 0; i < NumElements; i++)
                     {
                         Normals[i].x = b.ReadSingle();
                         Normals[i].y = b.ReadSingle();
@@ -88,7 +87,7 @@ namespace CgfConverter.CryEngineCore
 
                 case DatastreamType.UVS:
                     UVs = new UV[NumElements];
-                    for (Int32 i = 0; i < NumElements; i++)
+                    for (int i = 0; i < NumElements; i++)
                     {
                         UVs[i].U = b.ReadSingle();
                         UVs[i].V = b.ReadSingle();
@@ -99,7 +98,7 @@ namespace CgfConverter.CryEngineCore
                 case DatastreamType.TANGENTS:
                     Tangents = new Tangent[NumElements, 2];
                     Normals = new Vector3[NumElements];
-                    for (Int32 i = 0; i < NumElements; i++)
+                    for (int i = 0; i < NumElements; i++)
                     {
                         switch (BytesPerElement)
                         {
@@ -150,7 +149,7 @@ namespace CgfConverter.CryEngineCore
                     {
                         case 3:
                             RGBColors = new IRGB[NumElements];
-                            for (Int32 i = 0; i < NumElements; i++)
+                            for (int i = 0; i < NumElements; i++)
                             {
                                 RGBColors[i].r = b.ReadByte();
                                 RGBColors[i].g = b.ReadByte();
@@ -160,7 +159,7 @@ namespace CgfConverter.CryEngineCore
 
                         case 4:
                             RGBAColors = new IRGBA[NumElements];
-                            for (Int32 i = 0; i < NumElements; i++)
+                            for (int i = 0; i < NumElements; i++)
                             {
                                 RGBAColors[i].r = b.ReadByte();
                                 RGBAColors[i].g = b.ReadByte();
@@ -170,7 +169,7 @@ namespace CgfConverter.CryEngineCore
                             break;
                         default:
                             Utils.Log("Unknown Color Depth");
-                            for (Int32 i = 0; i < NumElements; i++)
+                            for (int i = 0; i < NumElements; i++)
                             {
                                 SkipBytes(b, BytesPerElement);
                             }
@@ -189,7 +188,7 @@ namespace CgfConverter.CryEngineCore
                     switch (BytesPerElement)  // new Star Citizen files
                     {
                         case 20:  // Dymek wrote this.  Used in 2.6 skin files.  3 floats for vertex position, 4 bytes for normals, 2 halfs for UVs.  Normals are calculated from Tangents
-                            for (Int32 i = 0; i < NumElements; i++)
+                            for (int i = 0; i < NumElements; i++)
                             {
                                 Vertices[i].x = b.ReadSingle();
                                 Vertices[i].y = b.ReadSingle();
@@ -220,7 +219,7 @@ namespace CgfConverter.CryEngineCore
                             break;
                         case 16:   // Dymek updated this.
                             //Console.WriteLine("method: (5), 3 half floats for verts, 3 colors, 2 half floats for UVs");
-                            for (Int32 i = 0; i < NumElements; i++)
+                            for (int i = 0; i < NumElements; i++)
                             {
                                 ushort bver = 0;
                                 float ver = 0;
@@ -262,8 +261,6 @@ namespace CgfConverter.CryEngineCore
                                 Normals[i].y = (2 * (quat.y * quat.z - quat.x * quat.w));
                                 Normals[i].z = (2 * (quat.z * quat.z + quat.w * quat.w)) - 1;
 
-
-                                // UVs ABSOLUTELY should use the Half structures.
                                 Half uvu = new Half();
                                 uvu.bits = b.ReadUInt16();
                                 UVs[i].U = uvu.ToSingle();
@@ -309,7 +306,7 @@ namespace CgfConverter.CryEngineCore
                             break;
                         default:
                             Utils.Log("Unknown VertUV structure");
-                            for (Int32 i = 0; i < NumElements; i++)
+                            for (int i = 0; i < NumElements; i++)
                             {
                                 SkipBytes(b, BytesPerElement);
                             }
@@ -376,7 +373,7 @@ namespace CgfConverter.CryEngineCore
                 case DatastreamType.UNKNOWN1:
                     Tangents = new Tangent[NumElements, 2];
                     Normals = new Vector3[NumElements];
-                    for (Int32 i = 0; i < NumElements; i++)
+                    for (int i = 0; i < NumElements; i++)
                     {
                         Tangents[i, 0].w = b.ReadSByte() / 127.0;
                         Tangents[i, 0].x = b.ReadSByte() / 127.0;
@@ -426,7 +423,7 @@ namespace CgfConverter.CryEngineCore
             short intnum = short.Parse(sfracPart, System.Globalization.NumberStyles.AllowHexSpecifier);
             var intbytes = BitConverter.GetBytes(intnum);
             string intbinary = Convert.ToString(intbytes[0], 2).PadLeft(8, '0');
-            string binaryIntPart = intbinary;
+            //string binaryIntPart = intbinary;
 
             short num = short.Parse(sfracPart, System.Globalization.NumberStyles.AllowHexSpecifier);
             var bytes = BitConverter.GetBytes(num);
@@ -440,8 +437,7 @@ namespace CgfConverter.CryEngineCore
                 if (binaryFracPart[i] == '0') continue;
                 dec += (float)Math.Pow(2, (i + 1) * (-1));
             }
-            float number = 0;
-            number = (float)intPart + dec;
+            float number = (float)intPart + dec; ;
             /*if (intPart > 0) { number = (float)intPart + dec; }
             if (intPart < 0) { number = (float)intPart - dec; }
             if (intPart == 0) { number =  dec; }*/

--- a/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_801.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_801.cs
@@ -13,7 +13,7 @@ namespace CgfConverter.CryEngineCore
 
             Flags2 = b.ReadUInt32(); // another filler
             uint tmpdataStreamType = b.ReadUInt32();
-            DataStreamType = (DataStreamTypeEnum)Enum.ToObject(typeof(DataStreamTypeEnum), tmpdataStreamType);
+            DataStreamType = (DATASTREAMTYPE)Enum.ToObject(typeof(DATASTREAMTYPE), tmpdataStreamType);
             SkipBytes(b, 4);
             NumElements = b.ReadUInt32(); // number of elements in this chunk
 
@@ -24,7 +24,7 @@ namespace CgfConverter.CryEngineCore
             // Now do loops to read for each of the different Data Stream Types.  If vertices, need to populate Vector3s for example.
             switch (DataStreamType)
             {
-                case DataStreamTypeEnum.VERTICES:
+                case DATASTREAMTYPE.VERTICES:
                     Vertices = new Vector3[NumElements];
                     if (BytesPerElement == 12)
                     {
@@ -56,7 +56,7 @@ namespace CgfConverter.CryEngineCore
 
                     break;
 
-                case DataStreamTypeEnum.INDICES: 
+                case DATASTREAMTYPE.INDICES: 
                     Indices = new UInt32[NumElements];
 
                     if (BytesPerElement == 2)
@@ -75,7 +75,7 @@ namespace CgfConverter.CryEngineCore
                     }
                     break;
 
-                case DataStreamTypeEnum.NORMALS:
+                case DATASTREAMTYPE.NORMALS:
                     Normals = new Vector3[NumElements];
                     for (Int32 i = 0; i < NumElements; i++)
                     {
@@ -86,7 +86,7 @@ namespace CgfConverter.CryEngineCore
                     //Utils.Log(LogLevelEnum.Debug, "Offset is {0:X}", b.BaseStream.Position);
                     break;
 
-                case DataStreamTypeEnum.UVS:
+                case DATASTREAMTYPE.UVS:
                     UVs = new UV[NumElements];
                     for (Int32 i = 0; i < NumElements; i++)
                     {
@@ -96,7 +96,7 @@ namespace CgfConverter.CryEngineCore
                     //Utils.Log(LogLevelEnum.Debug, "Offset is {0:X}", b.BaseStream.Position);
                     break;
 
-                case DataStreamTypeEnum.TANGENTS:
+                case DATASTREAMTYPE.TANGENTS:
                     Tangents = new Tangent[NumElements, 2];
                     Normals = new Vector3[NumElements];
                     for (Int32 i = 0; i < NumElements; i++)
@@ -145,7 +145,7 @@ namespace CgfConverter.CryEngineCore
                     // Utils.Log(LogLevelEnum.Debug, "Offset is {0:X}", b.BaseStream.Position);
                     break;
 
-                case DataStreamTypeEnum.COLORS:
+                case DATASTREAMTYPE.COLORS:
                     switch (BytesPerElement)
                     {
                         case 3:
@@ -180,7 +180,7 @@ namespace CgfConverter.CryEngineCore
 
                 #region case DataStreamTypeEnum.VERTSUVS:
 
-                case DataStreamTypeEnum.VERTSUVS:  // 3 half floats for verts, 3 half floats for normals, 2 half floats for UVs
+                case DATASTREAMTYPE.VERTSUVS:  // 3 half floats for verts, 3 half floats for normals, 2 half floats for UVs
                     // Utils.Log(LogLevelEnum.Debug, "In VertsUVs...");
                     Vertices = new Vector3[NumElements];
                     Normals = new Vector3[NumElements];
@@ -318,7 +318,7 @@ namespace CgfConverter.CryEngineCore
                     break;
                 #endregion
                 #region case DataStreamTypeEnum.BONEMAP:
-                case DataStreamTypeEnum.BONEMAP:
+                case DATASTREAMTYPE.BONEMAP:
                     SkinningInfo skin = GetSkinningInfo();
                     skin.HasBoneMapDatastream = true;
 
@@ -373,7 +373,7 @@ namespace CgfConverter.CryEngineCore
 
                 #endregion
                 #region DataStreamTypeEnum.Unknown1
-                case DataStreamTypeEnum.UNKNOWN1:
+                case DATASTREAMTYPE.UNKNOWN1:
                     Tangents = new Tangent[NumElements, 2];
                     Normals = new Vector3[NumElements];
                     for (Int32 i = 0; i < NumElements; i++)

--- a/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_801.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_801.cs
@@ -13,7 +13,7 @@ namespace CgfConverter.CryEngineCore
 
             Flags2 = b.ReadUInt32(); // another filler
             uint tmpdataStreamType = b.ReadUInt32();
-            DataStreamType = (DATASTREAMTYPE)Enum.ToObject(typeof(DATASTREAMTYPE), tmpdataStreamType);
+            DataStreamType = (DatastreamType)Enum.ToObject(typeof(DatastreamType), tmpdataStreamType);
             SkipBytes(b, 4);
             NumElements = b.ReadUInt32(); // number of elements in this chunk
 
@@ -24,7 +24,7 @@ namespace CgfConverter.CryEngineCore
             // Now do loops to read for each of the different Data Stream Types.  If vertices, need to populate Vector3s for example.
             switch (DataStreamType)
             {
-                case DATASTREAMTYPE.VERTICES:
+                case DatastreamType.VERTICES:
                     Vertices = new Vector3[NumElements];
                     if (BytesPerElement == 12)
                     {
@@ -56,7 +56,7 @@ namespace CgfConverter.CryEngineCore
 
                     break;
 
-                case DATASTREAMTYPE.INDICES: 
+                case DatastreamType.INDICES: 
                     Indices = new UInt32[NumElements];
 
                     if (BytesPerElement == 2)
@@ -75,7 +75,7 @@ namespace CgfConverter.CryEngineCore
                     }
                     break;
 
-                case DATASTREAMTYPE.NORMALS:
+                case DatastreamType.NORMALS:
                     Normals = new Vector3[NumElements];
                     for (Int32 i = 0; i < NumElements; i++)
                     {
@@ -86,7 +86,7 @@ namespace CgfConverter.CryEngineCore
                     //Utils.Log(LogLevelEnum.Debug, "Offset is {0:X}", b.BaseStream.Position);
                     break;
 
-                case DATASTREAMTYPE.UVS:
+                case DatastreamType.UVS:
                     UVs = new UV[NumElements];
                     for (Int32 i = 0; i < NumElements; i++)
                     {
@@ -96,7 +96,7 @@ namespace CgfConverter.CryEngineCore
                     //Utils.Log(LogLevelEnum.Debug, "Offset is {0:X}", b.BaseStream.Position);
                     break;
 
-                case DATASTREAMTYPE.TANGENTS:
+                case DatastreamType.TANGENTS:
                     Tangents = new Tangent[NumElements, 2];
                     Normals = new Vector3[NumElements];
                     for (Int32 i = 0; i < NumElements; i++)
@@ -145,7 +145,7 @@ namespace CgfConverter.CryEngineCore
                     // Utils.Log(LogLevelEnum.Debug, "Offset is {0:X}", b.BaseStream.Position);
                     break;
 
-                case DATASTREAMTYPE.COLORS:
+                case DatastreamType.COLORS:
                     switch (BytesPerElement)
                     {
                         case 3:
@@ -180,7 +180,7 @@ namespace CgfConverter.CryEngineCore
 
                 #region case DataStreamTypeEnum.VERTSUVS:
 
-                case DATASTREAMTYPE.VERTSUVS:  // 3 half floats for verts, 3 half floats for normals, 2 half floats for UVs
+                case DatastreamType.VERTSUVS:  // 3 half floats for verts, 3 half floats for normals, 2 half floats for UVs
                     // Utils.Log(LogLevelEnum.Debug, "In VertsUVs...");
                     Vertices = new Vector3[NumElements];
                     Normals = new Vector3[NumElements];
@@ -318,7 +318,7 @@ namespace CgfConverter.CryEngineCore
                     break;
                 #endregion
                 #region case DataStreamTypeEnum.BONEMAP:
-                case DATASTREAMTYPE.BONEMAP:
+                case DatastreamType.BONEMAP:
                     SkinningInfo skin = GetSkinningInfo();
                     skin.HasBoneMapDatastream = true;
 
@@ -373,7 +373,7 @@ namespace CgfConverter.CryEngineCore
 
                 #endregion
                 #region DataStreamTypeEnum.Unknown1
-                case DATASTREAMTYPE.UNKNOWN1:
+                case DatastreamType.UNKNOWN1:
                     Tangents = new Tangent[NumElements, 2];
                     Normals = new Vector3[NumElements];
                     for (Int32 i = 0; i < NumElements; i++)

--- a/CgfConverter/CryEngineCore/Chunks/ChunkDatastream_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkDatastream_900.cs
@@ -1,14 +1,74 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace CgfConverter.CryEngineCore
 {
-    class ChunkDatastream_900 : ChunkDataStream
+    class ChunkDataStream_900 : ChunkDataStream
     {
-        public override void Read(BinaryReader reader)
+        public ChunkDataStream_900(uint numberOfElements)
         {
-            base.Read(reader);
+            NumElements = numberOfElements;
+        }
+        public override void Read(BinaryReader b)
+        {
+            base.Read(b);
 
+            uint dataStreamType = b.ReadUInt32();
+            DataStreamType = (DatastreamType)Enum.ToObject(typeof(DatastreamType), dataStreamType);
+            BytesPerElement = b.ReadUInt32();
 
+            switch (DataStreamType) 
+            {
+                case DatastreamType.IVOINDICES:
+                    Indices = new uint[NumElements];
+                    if (BytesPerElement == 2)
+                    {
+                        for (int i = 0; i < NumElements; i++)
+                        {
+                            Indices[i] = b.ReadUInt16();
+                        }
+                    } 
+                    else if (BytesPerElement == 4)
+                    {
+                        for (int i = 0; i < NumElements; i++)
+                        {
+                            Indices[i] = b.ReadUInt32();
+                        }
+                    }
+                    break;
+                case DatastreamType.IVOVERTSUVS:
+                    Vertices = new Vector3[NumElements];
+                    Normals = new Vector3[NumElements];
+                    RGBColors = new IRGB[NumElements];
+                    UVs = new UV[NumElements];
+                    switch (BytesPerElement)  // new Star Citizen files
+                    {
+                        case 20:
+                            for (int i = 0; i < NumElements; i++)
+                            {
+                                Vertices[i].x = b.ReadSingle();
+                                Vertices[i].y = b.ReadSingle();
+                                Vertices[i].z = b.ReadSingle(); // For some reason, skins are an extra 1 meter in the z direction.
+
+                                // Normals are stored in a signed byte, prob div by 127.
+                                Normals[i].x = (float)b.ReadSByte() / 127;
+                                Normals[i].y = (float)b.ReadSByte() / 127;
+                                Normals[i].z = (float)b.ReadSByte() / 127;
+                                b.ReadSByte(); // Should be FF.
+
+                                Half uvu = new Half();
+                                uvu.bits = b.ReadUInt16();
+                                UVs[i].U = uvu.ToSingle();
+
+                                Half uvv = new Half();
+                                uvv.bits = b.ReadUInt16();
+                                UVs[i].V = uvv.ToSingle();
+                            }
+                            break;
+                            
+                    }
+                    break;
+            }
         }
     }
 }

--- a/CgfConverter/CryEngineCore/Chunks/ChunkDatastream_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkDatastream_900.cs
@@ -1,0 +1,14 @@
+﻿using System.IO;
+
+namespace CgfConverter.CryEngineCore
+{
+    class ChunkDatastream_900 : ChunkDataStream
+    {
+        public override void Read(BinaryReader reader)
+        {
+            base.Read(reader);
+
+
+        }
+    }
+}

--- a/CgfConverter/CryEngineCore/Chunks/ChunkDatastream_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkDatastream_900.cs
@@ -27,6 +27,10 @@ namespace CgfConverter.CryEngineCore
                         {
                             Indices[i] = b.ReadUInt16();
                         }
+                        if (NumElements % 2 == 1)
+                        {
+                            SkipBytes(b, 2);
+                        }
                     } 
                     else if (BytesPerElement == 4)
                     {

--- a/CgfConverter/CryEngineCore/Chunks/ChunkExportFlags_1.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkExportFlags_1.cs
@@ -10,7 +10,7 @@ namespace CgfConverter.CryEngineCore
             base.Read(b);
 
             UInt32 tmpExportFlag = b.ReadUInt32();
-            this.ChunkType = (ChunkTypeEnum)Enum.ToObject(typeof(ChunkTypeEnum), tmpExportFlag);
+            this.ChunkType = (ChunkType)Enum.ToObject(typeof(ChunkType), tmpExportFlag);
             this.Version = b.ReadUInt32();
             this.ChunkOffset = b.ReadUInt32();
             this.ID = b.ReadInt32();

--- a/CgfConverter/CryEngineCore/Chunks/ChunkHeader_744.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkHeader_744.cs
@@ -8,7 +8,7 @@ namespace CgfConverter.CryEngineCore
         public override void Read(BinaryReader reader)
         {
             uint headerType = reader.ReadUInt32();
-            ChunkType = (ChunkTypeEnum)headerType;
+            ChunkType = (ChunkType)headerType;
             Version = reader.ReadUInt32();
             Offset = reader.ReadUInt32();
             ID = reader.ReadInt32();

--- a/CgfConverter/CryEngineCore/Chunks/ChunkHeader_745.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkHeader_745.cs
@@ -8,7 +8,7 @@ namespace CgfConverter.CryEngineCore
         public override void Read(BinaryReader reader)
         {
             uint headerType = reader.ReadUInt32();
-            ChunkType = (ChunkTypeEnum)headerType;
+            ChunkType = (ChunkType)headerType;
             Version = reader.ReadUInt32();
             Offset = reader.ReadUInt32();
             ID = reader.ReadInt32();

--- a/CgfConverter/CryEngineCore/Chunks/ChunkHeader_746.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkHeader_746.cs
@@ -8,7 +8,7 @@ namespace CgfConverter.CryEngineCore
         public override void Read(BinaryReader reader)
         {
             uint headerType = reader.ReadUInt16() + 0xCCCBF000;
-            ChunkType = (ChunkTypeEnum)headerType;
+            ChunkType = (ChunkType)headerType;
             Version = reader.ReadUInt16();
             ID = reader.ReadInt32();
             Size = reader.ReadUInt32();

--- a/CgfConverter/CryEngineCore/Chunks/ChunkHeader_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkHeader_900.cs
@@ -8,7 +8,7 @@ namespace CgfConverter.CryEngineCore
         public override void Read(BinaryReader reader)
         {
             uint headerType = reader.ReadUInt32();
-            ChunkType = (ChunkTypeEnum)headerType;
+            ChunkType = (ChunkType)headerType;
             Version = reader.ReadUInt32();
             Offset = (uint)reader.ReadUInt64();  // All other versions use uint.  No idea why uint64 is needed.
             // 0x900 version chunks no longer have chunk IDs.  Use a randon mumber for now.

--- a/CgfConverter/CryEngineCore/Chunks/ChunkHelper.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkHelper.cs
@@ -6,7 +6,7 @@
     public abstract class ChunkHelper : Chunk
     {
         public string Name;
-        public HelperTypeEnum HelperType;
+        public HelperType HelperType;
         public Vector3 Pos;
         public Matrix44 Transform;
 

--- a/CgfConverter/CryEngineCore/Chunks/ChunkHelper_744.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkHelper_744.cs
@@ -9,7 +9,7 @@ namespace CgfConverter.CryEngineCore
         {
             base.Read(b);
 
-            this.HelperType = (HelperTypeEnum)Enum.ToObject(typeof(HelperTypeEnum), b.ReadUInt32());
+            this.HelperType = (HelperType)Enum.ToObject(typeof(HelperType), b.ReadUInt32());
             if (this.Version == 0x744)  // only has the Position.
             {
                 this.Pos.x = b.ReadSingle();
@@ -30,7 +30,7 @@ namespace CgfConverter.CryEngineCore
                     }
                 }
                 this.Name = new string(tmpName, 0, stringLength);
-                this.HelperType = (HelperTypeEnum)Enum.ToObject(typeof(HelperTypeEnum), b.ReadUInt32());
+                this.HelperType = (HelperType)Enum.ToObject(typeof(HelperType), b.ReadUInt32());
                 this.Pos.x = b.ReadSingle();
                 this.Pos.y = b.ReadSingle();
                 this.Pos.z = b.ReadSingle();

--- a/CgfConverter/CryEngineCore/Chunks/ChunkIvoSkin.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkIvoSkin.cs
@@ -1,0 +1,14 @@
+﻿namespace CgfConverter.CryEngineCore
+{
+    public class ChunkIvoSkin : Chunk
+    {
+        GeometryInfo geometryInfo;
+        ChunkMesh meshChunk;
+        ChunkMeshSubsets meshSubsetsChunk;
+        ChunkDataStream indices;
+        ChunkDataStream vertsUvs;
+        ChunkDataStream colors;
+        ChunkDataStream tangents;
+
+    }
+}

--- a/CgfConverter/CryEngineCore/Chunks/ChunkIvoSkin_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkIvoSkin_900.cs
@@ -19,6 +19,9 @@ namespace CgfConverter.CryEngineCore.Chunks
             meshChunk.ChunkType = ChunkType.Mesh;
             meshChunk.Read(b);
             meshChunk.ID = 2;
+            meshChunk.MeshSubsets = 3;
+            meshChunk.IndicesData = 4;
+            meshChunk.VertsUVsData = 5;
             model.ChunkMap.Add(meshChunk.ID, meshChunk);
             
             SkipBytes(b, 120);
@@ -52,6 +55,26 @@ namespace CgfConverter.CryEngineCore.Chunks
             vertsUvsDatastreamChunk.Read(b);
             vertsUvsDatastreamChunk.ID = 5;
             model.ChunkMap.Add(vertsUvsDatastreamChunk.ID, vertsUvsDatastreamChunk);
+
+            // Colors datastream
+            ChunkDataStream_900 colors = new ChunkDataStream_900((uint)meshChunk.NumVertices);
+            colors._model = _model;
+            colors._header = _header;
+            colors._header.Offset = (uint)b.BaseStream.Position;
+            colors.ChunkType = ChunkType.DataStream;
+            colors.Read(b);
+            colors.ID = 6;
+            model.ChunkMap.Add(colors.ID, colors);
+
+            // Tangents datastream
+            ChunkDataStream_900 tangents = new ChunkDataStream_900((uint)meshChunk.NumVertices);
+            tangents._model = _model;
+            tangents._header = _header;
+            tangents._header.Offset = (uint)b.BaseStream.Position;
+            tangents.ChunkType = ChunkType.DataStream;
+            tangents.Read(b);
+            tangents.ID = 7;
+            model.ChunkMap.Add(tangents.ID, tangents);
         }
     }
 }

--- a/CgfConverter/CryEngineCore/Chunks/ChunkIvoSkin_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkIvoSkin_900.cs
@@ -26,7 +26,23 @@ namespace CgfConverter.CryEngineCore.Chunks
             subsetsChunk._header.Offset = (uint)b.BaseStream.Position;
             subsetsChunk.ID = 3; 
             subsetsChunk.Read(b);
-            
+
+            // Indices datastream
+            ChunkDataStream_900 indicesDatastreamChunk = new ChunkDataStream_900((uint)meshChunk.NumIndices);
+            indicesDatastreamChunk._model = _model;
+            indicesDatastreamChunk._header = _header;
+            indicesDatastreamChunk._header.Offset = (uint)b.BaseStream.Position;
+            indicesDatastreamChunk.ID = 4;
+            indicesDatastreamChunk.Read(b);
+
+            // VertsUV datastream
+            ChunkDataStream_900 vertsUvsDatastreamChunk = new ChunkDataStream_900((uint)meshChunk.NumVertices);
+            vertsUvsDatastreamChunk._model = _model;
+            vertsUvsDatastreamChunk._header = _header;
+            vertsUvsDatastreamChunk._header.Offset = (uint)b.BaseStream.Position;
+            vertsUvsDatastreamChunk.ID = 5;
+            vertsUvsDatastreamChunk.Read(b);
+
         }
     }
 }

--- a/CgfConverter/CryEngineCore/Chunks/ChunkIvoSkin_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkIvoSkin_900.cs
@@ -6,6 +6,8 @@ namespace CgfConverter.CryEngineCore.Chunks
     {
         public override void Read(BinaryReader b)
         {
+            var model = this._model;
+
             base.Read(b);
 
             SkipBytes(b, 4);
@@ -14,8 +16,10 @@ namespace CgfConverter.CryEngineCore.Chunks
             meshChunk._model = _model;
             meshChunk._header = _header;
             meshChunk._header.Offset = (uint)b.BaseStream.Position;
-            meshChunk.ID = 2;
+            meshChunk.ChunkType = ChunkType.Mesh;
             meshChunk.Read(b);
+            meshChunk.ID = 2;
+            model.ChunkMap.Add(meshChunk.ID, meshChunk);
             
             SkipBytes(b, 120);
 
@@ -24,25 +28,30 @@ namespace CgfConverter.CryEngineCore.Chunks
             subsetsChunk._model = _model;
             subsetsChunk._header = _header;
             subsetsChunk._header.Offset = (uint)b.BaseStream.Position;
-            subsetsChunk.ID = 3; 
+            subsetsChunk.ChunkType = ChunkType.MeshSubsets;
             subsetsChunk.Read(b);
+            subsetsChunk.ID = 3; 
+            model.ChunkMap.Add(subsetsChunk.ID, subsetsChunk);
 
             // Indices datastream
             ChunkDataStream_900 indicesDatastreamChunk = new ChunkDataStream_900((uint)meshChunk.NumIndices);
             indicesDatastreamChunk._model = _model;
             indicesDatastreamChunk._header = _header;
             indicesDatastreamChunk._header.Offset = (uint)b.BaseStream.Position;
-            indicesDatastreamChunk.ID = 4;
+            indicesDatastreamChunk.ChunkType = ChunkType.DataStream;
             indicesDatastreamChunk.Read(b);
+            indicesDatastreamChunk.ID = 4;
+            model.ChunkMap.Add(indicesDatastreamChunk.ID, indicesDatastreamChunk);
 
             // VertsUV datastream
             ChunkDataStream_900 vertsUvsDatastreamChunk = new ChunkDataStream_900((uint)meshChunk.NumVertices);
             vertsUvsDatastreamChunk._model = _model;
             vertsUvsDatastreamChunk._header = _header;
             vertsUvsDatastreamChunk._header.Offset = (uint)b.BaseStream.Position;
-            vertsUvsDatastreamChunk.ID = 5;
+            vertsUvsDatastreamChunk.ChunkType = ChunkType.DataStream;
             vertsUvsDatastreamChunk.Read(b);
-
+            vertsUvsDatastreamChunk.ID = 5;
+            model.ChunkMap.Add(vertsUvsDatastreamChunk.ID, vertsUvsDatastreamChunk);
         }
     }
 }

--- a/CgfConverter/CryEngineCore/Chunks/ChunkIvoSkin_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkIvoSkin_900.cs
@@ -1,0 +1,17 @@
+﻿using System.IO;
+
+namespace CgfConverter.CryEngineCore.Chunks
+{
+    class ChunkIvoSkin_900 : ChunkIvoSkin
+    {
+        public override void Read(BinaryReader b)
+        {
+            base.Read(b);
+            var geometryInfo = new GeometryInfo();
+
+            SkipBytes(b, 4);
+            ChunkMesh_900 meshChunk = new ChunkMesh_900();
+            meshChunk.Read(b);
+        }
+    }
+}

--- a/CgfConverter/CryEngineCore/Chunks/ChunkIvoSkin_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkIvoSkin_900.cs
@@ -13,12 +13,17 @@ namespace CgfConverter.CryEngineCore.Chunks
             ChunkMesh_900 meshChunk = new ChunkMesh_900();
             meshChunk._model = _model;
             meshChunk._header = _header;
+            meshChunk._header.Offset = (uint)b.BaseStream.Position;
             meshChunk.ID = 2;
             meshChunk.Read(b);
             
-            SkipBytes(b, 116);
+            SkipBytes(b, 120);
+
             ChunkMeshSubsets_900 subsetsChunk = new ChunkMeshSubsets_900(meshChunk.NumVertSubsets);
             // Create dummy header info here (ChunkType, version, size, offset)
+            subsetsChunk._model = _model;
+            subsetsChunk._header = _header;
+            subsetsChunk._header.Offset = (uint)b.BaseStream.Position;
             subsetsChunk.ID = 3; 
             subsetsChunk.Read(b);
             

--- a/CgfConverter/CryEngineCore/Chunks/ChunkIvoSkin_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkIvoSkin_900.cs
@@ -7,11 +7,21 @@ namespace CgfConverter.CryEngineCore.Chunks
         public override void Read(BinaryReader b)
         {
             base.Read(b);
-            var geometryInfo = new GeometryInfo();
 
             SkipBytes(b, 4);
+            
             ChunkMesh_900 meshChunk = new ChunkMesh_900();
+            meshChunk._model = _model;
+            meshChunk._header = _header;
+            meshChunk.ID = 2;
             meshChunk.Read(b);
+            
+            SkipBytes(b, 116);
+            ChunkMeshSubsets_900 subsetsChunk = new ChunkMeshSubsets_900(meshChunk.NumVertSubsets);
+            // Create dummy header info here (ChunkType, version, size, offset)
+            subsetsChunk.ID = 3; 
+            subsetsChunk.Read(b);
+            
         }
     }
 }

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMesh.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMesh.cs
@@ -46,12 +46,6 @@
         public Vector3 MinBound; // 800 minimum coordinate values
         public Vector3 MaxBound; // 800 Max coord values
 
-        /// <summary>
-        /// The actual geometry info for this mesh.
-        /// </summary>
-        public GeometryInfo GeometryInfo { get; set; }
-
-        //public ChunkMeshSubsets chunkMeshSubset; // pointer to the mesh subset that belongs to this mesh
         public override string ToString()
         {
             return $@"Chunk Type: {ChunkType}, ID: {ID:X}, Version: {Version}";

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMesh.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMesh.cs
@@ -1,50 +1,50 @@
 ﻿namespace CgfConverter.CryEngineCore
 {
-    public abstract class ChunkMesh : Chunk      //  cccc0000:  Object that points to the datastream chunk.
+    public abstract class ChunkMesh : Chunk
     {
         // public UInt32 Version;  // 623 Far Cry, 744 Far Cry, Aion, 800 Crysis
-        //public bool HasVertexWeights; // for 744
-        //public bool HasVertexColors; // 744
-        //public bool InWorldSpace; // 623
-        //public byte Reserved1;  // padding byte, 744
-        //public byte Reserved2;  // padding byte, 744
+        // public bool HasVertexWeights; // for 744
+        // public bool HasVertexColors; // 744
+        // public bool InWorldSpace; // 623
+        // public byte Reserved1;  // padding byte, 744
+        // public byte Reserved2;  // padding byte, 744
         public int Flags1 { get; set; }  // 800  Offset of this chunk. 
         public int Flags2 { get; set; }  // 801 and 802
         // public UInt32 ID;  // 800  Chunk ID
         public int NumVertices { get; set; } // 
         public int NumIndices { get; set; }  // Number of indices (each triangle has 3 indices, so this is the number of triangles times 3).
-        //public UInt32 NumUVs; // 744
-        //public UInt32 NumFaces; // 744
+        // public UInt32 NumUVs; // 744
+        // public UInt32 NumFaces; // 744
         // Pointers to various Chunk types
         //public ChunkMtlName Material; // 623, Material Chunk, never encountered?
-        public int NumVertSubsets { get; set; } // 801, Number of vert subsets
+        public uint NumVertSubsets { get; set; } // 801, Number of vert subsets
         public int VertsAnimID { get; set; }
         public int MeshSubsets { get; set; } // 800  Reference of the mesh subsets
         // public ChunkVertAnim VertAnims; // 744.  not implemented
-        //public Vertex[] Vertices; // 744.  not implemented
-        //public Face[,] Faces; // 744.  Not implemented
-        //public UV[] UVs; // 744 Not implemented
-        //public UVFace[] UVFaces; // 744 not implemented
+        // public Vertex[] Vertices; // 744.  not implemented
+        // public Face[,] Faces; // 744.  Not implemented
+        // public UV[] UVs; // 744 Not implemented
+        // public UVFace[] UVFaces; // 744 not implemented
         // public VertexWeight[] VertexWeights; // 744 not implemented
-        //public IRGB[] VertexColors; // 744 not implemented
-        public int VerticesData { get; set; } // 800, 801.  Need an array because some 801 files have NumVertSubsets
+        // public IRGB[] VertexColors; // 744 not implemented
+        public int VerticesData { get; set; }
         public int NumBuffs { get; set; }
-        public int NormalsData { get; set; } // 800
-        public int UVsData { get; set; } // 800
-        public int ColorsData { get; set; } // 800
-        public int Colors2Data { get; set; } // 800 
-        public int IndicesData { get; set; } // 800
-        public int TangentsData { get; set; } // 800
-        public int ShCoeffsData { get; set; } // 800
-        public int ShapeDeformationData { get; set; } //800
-        public int BoneMapData { get; set; } //800
-        public int FaceMapData { get; set; } // 800
-        public int VertMatsData { get; set; } // 800
-        public int MeshPhysicsData { get; set; } // 801
-        public int VertsUVsData { get; set; }    // 801
-        public int[] PhysicsData = new int[4]; // 800
-        public Vector3 MinBound; // 800 minimum coordinate values
-        public Vector3 MaxBound; // 800 Max coord values
+        public int NormalsData { get; set; }
+        public int UVsData { get; set; }
+        public int ColorsData { get; set; }
+        public int Colors2Data { get; set; }
+        public int IndicesData { get; set; }
+        public int TangentsData { get; set; }
+        public int ShCoeffsData { get; set; }
+        public int ShapeDeformationData { get; set; }
+        public int BoneMapData { get; set; }
+        public int FaceMapData { get; set; }
+        public int VertMatsData { get; set; }
+        public int MeshPhysicsData { get; set; }
+        public int VertsUVsData { get; set; }
+        public int[] PhysicsData = new int[4];
+        public Vector3 MinBound;
+        public Vector3 MaxBound;
 
         public override string ToString()
         {

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMeshSubsets.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMeshSubsets.cs
@@ -10,7 +10,7 @@ namespace CgfConverter.CryEngineCore
 
         // For bone ID meshes? Not sure where this is used yet.
         public uint NumberOfBoneIDs;
-        public UInt16[] BoneIDs;
+        public ushort[] BoneIDs;
 
         public override string ToString()
         {
@@ -23,7 +23,7 @@ namespace CgfConverter.CryEngineCore
             Utils.Log(LogLevelEnum.Verbose, "    ChunkType:       {0}", ChunkType);
             Utils.Log(LogLevelEnum.Verbose, "    Mesh SubSet ID:  {0:X}", ID);
             Utils.Log(LogLevelEnum.Verbose, "    Number of Mesh Subsets: {0}", NumMeshSubset);
-            for (Int32 i = 0; i < NumMeshSubset; i++)
+            for (int i = 0; i < NumMeshSubset; i++)
             {
                 Utils.Log(LogLevelEnum.Verbose, "        ** Mesh Subset:          {0}", i);
                 Utils.Log(LogLevelEnum.Verbose, "           First Index:          {0}", MeshSubsets[i].FirstIndex);

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMeshSubsets_800.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMeshSubsets_800.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 
 namespace CgfConverter.CryEngineCore
 {
@@ -9,21 +8,21 @@ namespace CgfConverter.CryEngineCore
         {
             base.Read(b);
 
-            this.Flags = b.ReadUInt32();   // Might be a ref to this chunk
-            this.NumMeshSubset = b.ReadUInt32();  // number of mesh subsets
-            this.SkipBytes(b, 8);
-            this.MeshSubsets = new MeshSubset[NumMeshSubset];
-            for (Int32 i = 0; i < NumMeshSubset; i++)
+            Flags = b.ReadUInt32();   // Might be a ref to this chunk
+            NumMeshSubset = b.ReadUInt32();  // number of mesh subsets
+            SkipBytes(b, 8);
+            MeshSubsets = new MeshSubset[NumMeshSubset];
+            for (int i = 0; i < NumMeshSubset; i++)
             {
-                this.MeshSubsets[i].FirstIndex = b.ReadInt32();
-                this.MeshSubsets[i].NumIndices = b.ReadInt32();
-                this.MeshSubsets[i].FirstVertex = b.ReadInt32();
-                this.MeshSubsets[i].NumVertices = b.ReadInt32();
-                this.MeshSubsets[i].MatID = b.ReadInt32();
-                this.MeshSubsets[i].Radius = b.ReadSingle();
-                this.MeshSubsets[i].Center.x = b.ReadSingle();
-                this.MeshSubsets[i].Center.y = b.ReadSingle();
-                this.MeshSubsets[i].Center.z = b.ReadSingle();
+                MeshSubsets[i].FirstIndex = b.ReadInt32();
+                MeshSubsets[i].NumIndices = b.ReadInt32();
+                MeshSubsets[i].FirstVertex = b.ReadInt32();
+                MeshSubsets[i].NumVertices = b.ReadInt32();
+                MeshSubsets[i].MatID = b.ReadInt32();
+                MeshSubsets[i].Radius = b.ReadSingle();
+                MeshSubsets[i].Center.x = b.ReadSingle();
+                MeshSubsets[i].Center.y = b.ReadSingle();
+                MeshSubsets[i].Center.z = b.ReadSingle();
             }
         }
     }

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMeshSubsets_800000800.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMeshSubsets_800000800.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 
 namespace CgfConverter.CryEngineCore
 {
@@ -9,21 +8,21 @@ namespace CgfConverter.CryEngineCore
         {
             base.Read(b);
 
-            this.Flags = Utils.SwapUIntEndian(b.ReadUInt32());   // Might be a ref to this chunk
-            this.NumMeshSubset = Utils.SwapUIntEndian(b.ReadUInt32());  // number of mesh subsets
-            this.SkipBytes(b, 8);
-            this.MeshSubsets = new MeshSubset[NumMeshSubset];
-            for (Int32 i = 0; i < NumMeshSubset; i++)
+            Flags = Utils.SwapUIntEndian(b.ReadUInt32());   // Might be a ref to this chunk
+            NumMeshSubset = Utils.SwapUIntEndian(b.ReadUInt32());  // number of mesh subsets
+            SkipBytes(b, 8);
+            MeshSubsets = new MeshSubset[NumMeshSubset];
+            for (int i = 0; i < NumMeshSubset; i++)
             {
-                this.MeshSubsets[i].FirstIndex = Utils.SwapIntEndian(b.ReadInt32());
-                this.MeshSubsets[i].NumIndices = Utils.SwapIntEndian(b.ReadInt32());
-                this.MeshSubsets[i].FirstVertex = Utils.SwapIntEndian(b.ReadInt32());
-                this.MeshSubsets[i].NumVertices = Utils.SwapIntEndian(b.ReadInt32());
-                this.MeshSubsets[i].MatID = Utils.SwapIntEndian(b.ReadInt32());
-                this.MeshSubsets[i].Radius = Utils.SwapSingleEndian(b.ReadSingle());
-                this.MeshSubsets[i].Center.x = Utils.SwapSingleEndian(b.ReadSingle());
-                this.MeshSubsets[i].Center.y = Utils.SwapSingleEndian(b.ReadSingle());
-                this.MeshSubsets[i].Center.z = Utils.SwapSingleEndian(b.ReadSingle());
+                MeshSubsets[i].FirstIndex = Utils.SwapIntEndian(b.ReadInt32());
+                MeshSubsets[i].NumIndices = Utils.SwapIntEndian(b.ReadInt32());
+                MeshSubsets[i].FirstVertex = Utils.SwapIntEndian(b.ReadInt32());
+                MeshSubsets[i].NumVertices = Utils.SwapIntEndian(b.ReadInt32());
+                MeshSubsets[i].MatID = Utils.SwapIntEndian(b.ReadInt32());
+                MeshSubsets[i].Radius = Utils.SwapSingleEndian(b.ReadSingle());
+                MeshSubsets[i].Center.x = Utils.SwapSingleEndian(b.ReadSingle());
+                MeshSubsets[i].Center.y = Utils.SwapSingleEndian(b.ReadSingle());
+                MeshSubsets[i].Center.z = Utils.SwapSingleEndian(b.ReadSingle());
             }
         }
     }

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMeshSubsets_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMeshSubsets_900.cs
@@ -4,20 +4,18 @@ namespace CgfConverter.CryEngineCore
 {
     class ChunkMeshSubsets_900 : ChunkMeshSubsets
     {
-        private int numVertSubsets;
-
-        public ChunkMeshSubsets_900(int numVertSubsets)
+        public ChunkMeshSubsets_900(uint numVertSubsets)
         {
-            this.numVertSubsets = numVertSubsets;
+            NumMeshSubset = numVertSubsets;
         }
 
         public override void Read(BinaryReader b)
         {
             base.Read(b);
 
-            NumMeshSubset = b.ReadUInt32();  // number of mesh subsets
-            MeshSubsets = new MeshSubset[numVertSubsets];
-            for (int i = 0; i < numVertSubsets; i++)
+            // NumMeshSubset = b.ReadUInt32();  // number of mesh subsets
+            MeshSubsets = new MeshSubset[NumMeshSubset];
+            for (int i = 0; i < NumMeshSubset; i++)
             {
                 MeshSubsets[i].MatID = b.ReadInt32();
                 MeshSubsets[i].FirstIndex = b.ReadInt32();

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMeshSubsets_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMeshSubsets_900.cs
@@ -13,7 +13,6 @@ namespace CgfConverter.CryEngineCore
         {
             base.Read(b);
 
-            // NumMeshSubset = b.ReadUInt32();  // number of mesh subsets
             MeshSubsets = new MeshSubset[NumMeshSubset];
             for (int i = 0; i < NumMeshSubset; i++)
             {
@@ -29,6 +28,5 @@ namespace CgfConverter.CryEngineCore
                 SkipBytes(b, 12);  // 3 unknowns; possibly floats;
             }
         }
-    
     }
 }

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMeshSubsets_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMeshSubsets_900.cs
@@ -1,0 +1,36 @@
+﻿using System.IO;
+
+namespace CgfConverter.CryEngineCore
+{
+    class ChunkMeshSubsets_900 : ChunkMeshSubsets
+    {
+        private int numVertSubsets;
+
+        public ChunkMeshSubsets_900(int numVertSubsets)
+        {
+            this.numVertSubsets = numVertSubsets;
+        }
+
+        public override void Read(BinaryReader b)
+        {
+            base.Read(b);
+
+            NumMeshSubset = b.ReadUInt32();  // number of mesh subsets
+            MeshSubsets = new MeshSubset[numVertSubsets];
+            for (int i = 0; i < numVertSubsets; i++)
+            {
+                MeshSubsets[i].MatID = b.ReadInt32();
+                MeshSubsets[i].FirstIndex = b.ReadInt32();
+                MeshSubsets[i].NumIndices = b.ReadInt32();
+                MeshSubsets[i].FirstVertex = b.ReadInt32();
+                MeshSubsets[i].NumVertices = b.ReadInt32();
+                MeshSubsets[i].Radius = b.ReadSingle();
+                MeshSubsets[i].Center.x = b.ReadSingle();
+                MeshSubsets[i].Center.y = b.ReadSingle();
+                MeshSubsets[i].Center.z = b.ReadSingle();
+                SkipBytes(b, 12);  // 3 unknowns; possibly floats;
+            }
+        }
+    
+    }
+}

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMesh_800.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMesh_800.cs
@@ -9,38 +9,38 @@ namespace CgfConverter.CryEngineCore
         {
             base.Read(b);
 
-            this.NumVertSubsets = 1;
-            this.SkipBytes(b, 8);
-            this.NumVertices = b.ReadInt32();
-            this.NumIndices = b.ReadInt32();   //  Number of indices
-            this.SkipBytes(b, 4);
-            this.MeshSubsets = b.ReadInt32();  // refers to ID in mesh subsets  1d for candle.  Just 1 for 0x800 type
-            this.SkipBytes(b, 4);
-            this.VerticesData = b.ReadInt32();  // ID of the datastream for the vertices for this mesh
-            this.NormalsData = b.ReadInt32();   // ID of the datastream for the normals for this mesh
-            this.UVsData = b.ReadInt32();     // refers to the ID in the Normals datastream?
-            this.ColorsData = b.ReadInt32();
-            this.Colors2Data = b.ReadInt32();
-            this.IndicesData = b.ReadInt32();
-            this.TangentsData = b.ReadInt32();
-            this.ShCoeffsData = b.ReadInt32();
-            this.ShapeDeformationData = b.ReadInt32();
-            this.BoneMapData = b.ReadInt32();
-            this.FaceMapData = b.ReadInt32();
-            this.VertMatsData = b.ReadInt32();
-            this.SkipBytes(b, 16);
-            for (Int32 i = 0; i < 4; i++)
+            NumVertSubsets = 1;
+            SkipBytes(b, 8);
+            NumVertices = b.ReadInt32();
+            NumIndices = b.ReadInt32();   //  Number of indices
+            SkipBytes(b, 4);
+            MeshSubsets = b.ReadInt32();  // refers to ID in mesh subsets  1d for candle.  Just 1 for 0x800 type
+            SkipBytes(b, 4);
+            VerticesData = b.ReadInt32();  // ID of the datastream for the vertices for this mesh
+            NormalsData = b.ReadInt32();   // ID of the datastream for the normals for this mesh
+            UVsData = b.ReadInt32();     // refers to the ID in the Normals datastream?
+            ColorsData = b.ReadInt32();
+            Colors2Data = b.ReadInt32();
+            IndicesData = b.ReadInt32();
+            TangentsData = b.ReadInt32();
+            ShCoeffsData = b.ReadInt32();
+            ShapeDeformationData = b.ReadInt32();
+            BoneMapData = b.ReadInt32();
+            FaceMapData = b.ReadInt32();
+            VertMatsData = b.ReadInt32();
+            SkipBytes(b, 16);
+            for (int i = 0; i < 4; i++)
             {
-                this.PhysicsData[i] = b.ReadInt32();
-                if (this.PhysicsData[i] != 0)
-                    this.MeshPhysicsData = this.PhysicsData[i];
+                PhysicsData[i] = b.ReadInt32();
+                if (PhysicsData[i] != 0)
+                    MeshPhysicsData = PhysicsData[i];
             }
-            this.MinBound.x = b.ReadSingle();
-            this.MinBound.y = b.ReadSingle();
-            this.MinBound.z = b.ReadSingle();
-            this.MaxBound.x = b.ReadSingle();
-            this.MaxBound.y = b.ReadSingle();
-            this.MaxBound.z = b.ReadSingle();
+            MinBound.x = b.ReadSingle();
+            MinBound.y = b.ReadSingle();
+            MinBound.z = b.ReadSingle();
+            MaxBound.x = b.ReadSingle();
+            MaxBound.y = b.ReadSingle();
+            MaxBound.z = b.ReadSingle();
         }
     }
 }

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMesh_80000800.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMesh_80000800.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 
 namespace CgfConverter.CryEngineCore
 {
@@ -30,7 +29,7 @@ namespace CgfConverter.CryEngineCore
             FaceMapData = Utils.SwapIntEndian(b.ReadInt32());
             VertMatsData = Utils.SwapIntEndian(b.ReadInt32());
             SkipBytes(b, 16);
-            for (Int32 i = 0; i < 4; i++)
+            for (int i = 0; i < 4; i++)
             {
                 PhysicsData[i] = Utils.SwapIntEndian(b.ReadInt32());
                 if (PhysicsData[i] != 0)

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMesh_801.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMesh_801.cs
@@ -12,7 +12,7 @@ namespace CgfConverter.CryEngineCore
             Flags2 = b.ReadInt32();
             NumVertices = b.ReadInt32();
             NumIndices = b.ReadInt32();
-            NumVertSubsets = b.ReadInt32();
+            NumVertSubsets = b.ReadUInt32();
             MeshSubsets = b.ReadInt32();           // Chunk ID of mesh subsets 
             VertsAnimID = b.ReadInt32();
             VerticesData = b.ReadInt32();

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMesh_801.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMesh_801.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 
 namespace CgfConverter.CryEngineCore
 {
@@ -9,36 +8,36 @@ namespace CgfConverter.CryEngineCore
         {
             base.Read(b);
 
-            this.Flags1 = b.ReadInt32();
-            this.Flags2 = b.ReadInt32();
-            this.NumVertices = b.ReadInt32();
-            this.NumIndices = b.ReadInt32();
-            this.NumVertSubsets = b.ReadInt32();
-            this.MeshSubsets = b.ReadInt32();           // Chunk ID of mesh subsets 
-            this.VertsAnimID = b.ReadInt32();
-            this.VerticesData = b.ReadInt32();
-            this.NormalsData = b.ReadInt32();           // Chunk ID of the datastream for the normals for this mesh
-            this.UVsData = b.ReadInt32();               // Chunk ID of the Normals datastream
-            this.ColorsData = b.ReadInt32();
-            this.Colors2Data = b.ReadInt32();
-            this.IndicesData = b.ReadInt32();
-            this.TangentsData = b.ReadInt32();
-            this.SkipBytes(b, 16);
-            for (Int32 i = 0; i < 4; i++)
+            Flags1 = b.ReadInt32();
+            Flags2 = b.ReadInt32();
+            NumVertices = b.ReadInt32();
+            NumIndices = b.ReadInt32();
+            NumVertSubsets = b.ReadInt32();
+            MeshSubsets = b.ReadInt32();           // Chunk ID of mesh subsets 
+            VertsAnimID = b.ReadInt32();
+            VerticesData = b.ReadInt32();
+            NormalsData = b.ReadInt32();           // Chunk ID of the datastream for the normals for this mesh
+            UVsData = b.ReadInt32();               // Chunk ID of the Normals datastream
+            ColorsData = b.ReadInt32();
+            Colors2Data = b.ReadInt32();
+            IndicesData = b.ReadInt32();
+            TangentsData = b.ReadInt32();
+            SkipBytes(b, 16);
+            for (int i = 0; i < 4; i++)
             {
-                this.PhysicsData[i] = b.ReadInt32();
+                PhysicsData[i] = b.ReadInt32();
             }
-            this.VertsUVsData = b.ReadInt32();          // This should be a vertsUV Chunk ID.
-            this.ShCoeffsData = b.ReadInt32();
-            this.ShapeDeformationData = b.ReadInt32();
-            this.BoneMapData = b.ReadInt32();
-            this.FaceMapData = b.ReadInt32();
-            this.MinBound.x = b.ReadSingle();
-            this.MinBound.y = b.ReadSingle();
-            this.MinBound.z = b.ReadSingle();
-            this.MaxBound.x = b.ReadSingle();
-            this.MaxBound.y = b.ReadSingle();
-            this.MaxBound.z = b.ReadSingle();
+            VertsUVsData = b.ReadInt32();          // This should be a vertsUV Chunk ID.
+            ShCoeffsData = b.ReadInt32();
+            ShapeDeformationData = b.ReadInt32();
+            BoneMapData = b.ReadInt32();
+            FaceMapData = b.ReadInt32();
+            MinBound.x = b.ReadSingle();
+            MinBound.y = b.ReadSingle();
+            MinBound.z = b.ReadSingle();
+            MaxBound.x = b.ReadSingle();
+            MaxBound.y = b.ReadSingle();
+            MaxBound.z = b.ReadSingle();
         }
     }
 }

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMesh_802.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMesh_802.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 
 namespace CgfConverter.CryEngineCore
 {
@@ -9,50 +8,50 @@ namespace CgfConverter.CryEngineCore
         {
             base.Read(b);
 
-            this.Flags1 = b.ReadInt32();
-            this.Flags2 = b.ReadInt32();
-            this.NumVertices = b.ReadInt32();
-            this.NumIndices = b.ReadInt32();
-            this.NumVertSubsets = b.ReadInt32();
-            this.MeshSubsets = b.ReadInt32();           // Chunk ID of mesh subsets 
-            this.SkipBytes(b, 4);
-            this.VerticesData = b.ReadInt32();
-            this.SkipBytes(b, 28);
-            this.NormalsData = b.ReadInt32();           // Chunk ID of the datastream for the normals for this mesh
-            this.SkipBytes(b, 28);
-            this.UVsData = b.ReadInt32();               // Chunk ID of the Normals datastream
-            this.SkipBytes(b, 28);
-            this.ColorsData = b.ReadInt32();
-            this.SkipBytes(b, 28);
-            this.Colors2Data = b.ReadInt32();
-            this.SkipBytes(b, 28);
-            this.IndicesData = b.ReadInt32();
-            this.SkipBytes(b, 28);
-            this.TangentsData = b.ReadInt32();
-            this.SkipBytes(b, 28);
-            this.SkipBytes(b, 16);
-            for (Int32 i = 0; i < 4; i++)
+            Flags1 = b.ReadInt32();
+            Flags2 = b.ReadInt32();
+            NumVertices = b.ReadInt32();
+            NumIndices = b.ReadInt32();
+            NumVertSubsets = b.ReadInt32();
+            MeshSubsets = b.ReadInt32();           // Chunk ID of MeshSubsets 
+            SkipBytes(b, 4);
+            VerticesData = b.ReadInt32();
+            SkipBytes(b, 28);
+            NormalsData = b.ReadInt32();           // Chunk ID of the datastream for the normals for this mesh
+            SkipBytes(b, 28);
+            UVsData = b.ReadInt32();               // Chunk ID of the Normals datastream
+            SkipBytes(b, 28);
+            ColorsData = b.ReadInt32();
+            SkipBytes(b, 28);
+            Colors2Data = b.ReadInt32();
+            SkipBytes(b, 28);
+            IndicesData = b.ReadInt32();
+            SkipBytes(b, 28);
+            TangentsData = b.ReadInt32();
+            SkipBytes(b, 28);
+            SkipBytes(b, 16);
+            for (int i = 0; i < 4; i++)
             {
-                this.PhysicsData[i] = b.ReadInt32();
+                PhysicsData[i] = b.ReadInt32();
             }
-            this.VertsUVsData = b.ReadInt32();          // This should be a vertsUV Chunk ID.
-            this.SkipBytes(b, 28);
-            this.ShCoeffsData = b.ReadInt32();
-            this.SkipBytes(b, 28);
-            this.ShapeDeformationData = b.ReadInt32();
-            this.SkipBytes(b, 28);
-            this.BoneMapData = b.ReadInt32();
-            this.SkipBytes(b, 28);
-            this.FaceMapData = b.ReadInt32();
-            this.SkipBytes(b, 28);
-            this.SkipBytes(b, 16);
-            this.SkipBytes(b, 96);                      // Lots of unknown data here.
-            this.MinBound.x = b.ReadSingle();
-            this.MinBound.y = b.ReadSingle();
-            this.MinBound.z = b.ReadSingle();
-            this.MaxBound.x = b.ReadSingle();
-            this.MaxBound.y = b.ReadSingle();
-            this.MaxBound.z = b.ReadSingle();
+            VertsUVsData = b.ReadInt32();          // This should be a vertsUV Chunk ID.
+            SkipBytes(b, 28);
+            ShCoeffsData = b.ReadInt32();
+            SkipBytes(b, 28);
+            ShapeDeformationData = b.ReadInt32();
+            SkipBytes(b, 28);
+            BoneMapData = b.ReadInt32();
+            SkipBytes(b, 28);
+            FaceMapData = b.ReadInt32();
+            SkipBytes(b, 28);
+            SkipBytes(b, 16);
+            SkipBytes(b, 96);                      // Lots of unknown data here.
+            MinBound.x = b.ReadSingle();
+            MinBound.y = b.ReadSingle();
+            MinBound.z = b.ReadSingle();
+            MaxBound.x = b.ReadSingle();
+            MaxBound.y = b.ReadSingle();
+            MaxBound.z = b.ReadSingle();
         }
     }
 }

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMesh_802.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMesh_802.cs
@@ -12,7 +12,7 @@ namespace CgfConverter.CryEngineCore
             Flags2 = b.ReadInt32();
             NumVertices = b.ReadInt32();
             NumIndices = b.ReadInt32();
-            NumVertSubsets = b.ReadInt32();
+            NumVertSubsets = b.ReadUInt32();
             MeshSubsets = b.ReadInt32();           // Chunk ID of MeshSubsets 
             SkipBytes(b, 4);
             VerticesData = b.ReadInt32();

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMesh_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMesh_900.cs
@@ -1,0 +1,24 @@
+﻿using System.IO;
+
+namespace CgfConverter.CryEngineCore
+{
+    public class ChunkMesh_900 : ChunkMesh
+    {
+        public override void Read(BinaryReader b)
+        {
+            // base.Read(b);
+            Flags1 = b.ReadInt32();
+            Flags2 = 0;
+            NumVertices = b.ReadInt32();
+            NumIndices = b.ReadInt32();
+            NumVertSubsets = b.ReadInt32();
+            SkipBytes(b, 4);
+            MinBound.x = b.ReadSingle();
+            MinBound.y = b.ReadSingle();
+            MinBound.z = b.ReadSingle();
+            MaxBound.x = b.ReadSingle();
+            MaxBound.y = b.ReadSingle();
+            MaxBound.z = b.ReadSingle();
+        }
+    }
+}

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMesh_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMesh_900.cs
@@ -10,7 +10,7 @@ namespace CgfConverter.CryEngineCore
             Flags2 = 0;
             NumVertices = b.ReadInt32();
             NumIndices = b.ReadInt32();
-            NumVertSubsets = b.ReadInt32();
+            NumVertSubsets = b.ReadUInt32();
             SkipBytes(b, 4);
             MinBound.x = b.ReadSingle();
             MinBound.y = b.ReadSingle();

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMesh_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMesh_900.cs
@@ -6,7 +6,6 @@ namespace CgfConverter.CryEngineCore
     {
         public override void Read(BinaryReader b)
         {
-            // base.Read(b);
             Flags1 = b.ReadInt32();
             Flags2 = 0;
             NumVertices = b.ReadInt32();
@@ -19,6 +18,13 @@ namespace CgfConverter.CryEngineCore
             MaxBound.x = b.ReadSingle();
             MaxBound.y = b.ReadSingle();
             MaxBound.z = b.ReadSingle();
+
+            ID = 2; // Node chunk ID = 1
+
+            VertsUVsData = 4;
+            NormalsData = 5;
+            TangentsData = 6;
+            ColorsData = 7;
         }
     }
 }

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMesh_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMesh_900.cs
@@ -23,8 +23,8 @@ namespace CgfConverter.CryEngineCore
 
             VertsUVsData = 4;
             NormalsData = 5;
-            TangentsData = 6;
-            ColorsData = 7;
+            ColorsData = 6;
+            TangentsData = 7;
         }
     }
 }

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMtlName.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMtlName.cs
@@ -3,7 +3,7 @@
     public abstract class ChunkMtlName : Chunk  
     {
         /// <summary> Type of Material associated with this name </summary>
-        public MtlNameTypeEnum MatType { get; internal set; }
+        public MtlNameType MatType { get; internal set; }
         /// <summary> Name of the Material </summary>
         public string Name { get; set; }
         public MtlNamePhysicsType[] PhysicsType { get; internal set; }

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMtlName_744.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMtlName_744.cs
@@ -13,7 +13,7 @@ namespace CgfConverter.CryEngineCore
             Name = b.ReadFString(128);
             NumChildren = b.ReadUInt32();
             PhysicsType = new MtlNamePhysicsType[NumChildren];
-            MatType = NumChildren == 0 ? MtlNameTypeEnum.Single : MtlNameTypeEnum.Library;
+            MatType = NumChildren == 0 ? MtlNameType.Single : MtlNameType.Library;
 
             for (int i = 0; i < NumChildren; i++)
             {

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMtlName_800.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMtlName_800.cs
@@ -9,7 +9,7 @@ namespace CgfConverter.CryEngineCore
         {
             base.Read(b);
 
-            MatType = (MtlNameTypeEnum)b.ReadUInt32();
+            MatType = (MtlNameType)b.ReadUInt32();
             // if 0x01, then material lib.  If 0x12, mat name.  This is actually a bitstruct.
             SkipBytes(b, 4);               // NFlags2
             Name = b.ReadFString(128);

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMtlName_80000800.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMtlName_80000800.cs
@@ -9,7 +9,7 @@ namespace CgfConverter.CryEngineCore
         {
             base.Read(b);
 
-            MatType = (MtlNameTypeEnum)Utils.SwapUIntEndian(b.ReadUInt32());
+            MatType = (MtlNameType)Utils.SwapUIntEndian(b.ReadUInt32());
             // if 0x01, then material lib.  If 0x12, mat name.  This is actually a bitstruct.
             SkipBytes(b, 4);               // NFlags2
             Name = b.ReadFString(128);

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMtlName_802.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMtlName_802.cs
@@ -13,7 +13,7 @@ namespace CgfConverter.CryEngineCore
             Name = b.ReadFString(128);
             NumChildren = b.ReadUInt32();
             PhysicsType = new MtlNamePhysicsType[NumChildren];
-            MatType = NumChildren == 0 ? MtlNameTypeEnum.Single : MtlNameTypeEnum.Library;
+            MatType = NumChildren == 0 ? MtlNameType.Single : MtlNameType.Library;
 
             for (int i = 0; i < NumChildren; i++)
             {

--- a/CgfConverter/CryEngineCore/Chunks/ChunkNode.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkNode.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace CgfConverter.CryEngineCore

--- a/CgfConverter/CryEngineCore/Chunks/ChunkSourceInfo_0.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkSourceInfo_0.cs
@@ -19,7 +19,7 @@ namespace CgfConverter.CryEngineCore
             uint peek = reader.ReadUInt32();
 
             // Try and detect SourceInfo type - if it's there, we need to skip ahead a few bytes
-            if ((peek == (uint)ChunkTypeEnum.SourceInfo) || (peek + 0xCCCBF000 == (uint)ChunkTypeEnum.SourceInfo))
+            if ((peek == (uint)ChunkType.SourceInfo) || (peek + 0xCCCBF000 == (uint)ChunkType.SourceInfo))
             {
                 this.SkipBytes(reader, 12);
             }
@@ -35,7 +35,7 @@ namespace CgfConverter.CryEngineCore
                 Utils.Log(LogLevelEnum.Warning, "{0:X}+{1:X}", this.Offset, this.Size);
             }
 
-            this.ChunkType = ChunkTypeEnum.SourceInfo; // this chunk doesn't actually have the chunktype header.
+            this.ChunkType = ChunkType.SourceInfo; // this chunk doesn't actually have the chunktype header.
             this.SourceFile = reader.ReadCString();
             this.Date = reader.ReadCString().TrimEnd(); // Strip off last 2 Characters, because it contains a return
             // It is possible that Date has a newline in it instead of a null.  If so, split it based on newline.  Otherwise read Author.

--- a/CgfConverter/CryEngineCore/Chunks/GeometryInfo.cs
+++ b/CgfConverter/CryEngineCore/Chunks/GeometryInfo.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace CgfConverter.CryEngineCore
+﻿namespace CgfConverter.CryEngineCore
 {
     /// <summary>
     /// Geometry info contains all the vertex, color, normal, UV, tangent, index, etc.  Basically if you have a Node chunk with a Mesh and Submesh, this will contain the summary of all
@@ -17,15 +15,15 @@ namespace CgfConverter.CryEngineCore
         public UV[] UVs { get; set; }            // for datastreamType of 2, length is NumElements.
         public IRGB[] RGBColors { get; set; }    // for dataStreamType of 3, length is NumElements.  Bytes per element of 3
         public IRGBA[] RGBAColors { get; set; }  // for dataStreamType of 4, length is NumElements.  Bytes per element of 4
-        public UInt32[] Indices { get; set; }    // for dataStreamType of 5, length is NumElements.
+        public uint[] Indices { get; set; }    // for dataStreamType of 5, length is NumElements.
         // For Tangents on down, this may be a 2 element array.  See line 846+ in cgf.xml
         public Tangent[,] Tangents { get; set; }  // for dataStreamType of 6, length is NumElements, 2.  
-        public Byte[,] ShCoeffs { get; set; }     // for dataStreamType of 7, length is NumElement,BytesPerElements.
-        public Byte[,] ShapeDeformation { get; set; } // for dataStreamType of 8, length is NumElements,BytesPerElement.
-        public Byte[,] BoneMap { get; set; }      // for dataStreamType of 9, length is NumElements,BytesPerElement, 2.
-        //public MeshBoneMapping[] BoneMap;      // for dataStreamType of 9, length is NumElements,BytesPerElement.
-        public Byte[,] FaceMap { get; set; }      // for dataStreamType of 10, length is NumElements,BytesPerElement.
-        public Byte[,] VertMats { get; set; }     // for dataStreamType of 11, length is NumElements,BytesPerElement.
+        public byte[,] ShCoeffs { get; set; }     // for dataStreamType of 7, length is NumElement,BytesPerElements.
+        public byte[,] ShapeDeformation { get; set; } // for dataStreamType of 8, length is NumElements,BytesPerElement.
+        public byte[,] BoneMap { get; set; }      // for dataStreamType of 9, length is NumElements,BytesPerElement, 2.
+        //public MeshBoneMapping[] BoneMap;      // for dataStreamType of 9, length is NumElements, BytesPerElement.
+        public byte[,] FaceMap { get; set; }      // for dataStreamType of 10, length is NumElements,BytesPerElement.
+        public byte[,] VertMats { get; set; }     // for dataStreamType of 11, length is NumElements,BytesPerElement.
 
 
     }

--- a/CgfConverter/CryEngineCore/Model.cs
+++ b/CgfConverter/CryEngineCore/Model.cs
@@ -232,7 +232,6 @@ namespace CgfConverter.CryEngineCore
                 // Ensure we read to end of structure
                 ChunkMap[chunkHeaderItem.ID].SkipBytes(reader);
 
-                // TODO: Change this to detect node with ~0 (0xFFFFFFFF) parent ID
                 // Assume first node read in Model[0] is root node.  This may be bad if they aren't in order!
                 if (chunkHeaderItem.ChunkType == ChunkTypeEnum.Node && RootNode == null)
                 {

--- a/CgfConverter/CryEngineCore/Model.cs
+++ b/CgfConverter/CryEngineCore/Model.cs
@@ -7,63 +7,43 @@ namespace CgfConverter.CryEngineCore
 {
     public class Model
     {
-        /// <summary>
-        /// The Root of the loaded object
-        /// </summary>
+        /// <summary> The Root of the loaded object </summary>
         public ChunkNode RootNode { get; internal set; }
 
-        /// <summary>
-        /// Collection of all loaded Chunks
-        /// </summary>
+        /// <summary> Collection of all loaded Chunks </summary>
         public List<ChunkHeader> ChunkHeaders { get; internal set; } = new List<ChunkHeader> { };
 
-        /// <summary>
-        /// Lookup Table for Chunks, indexed by ChunkID
-        /// </summary>
+        /// <summary> Lookup Table for Chunks, indexed by ChunkID </summary>
         public Dictionary<int, Chunk> ChunkMap { get; internal set; } = new Dictionary<int, Chunk> { };
 
-        /// <summary>
-        /// The name of the currently processed file
-        /// </summary>
+        /// <summary> The name of the currently processed file </summary>
         public string FileName { get; internal set; }
 
-        /// <summary>
-        /// The File Signature - CryTek for 3.5 and lower. CrCh for 3.6 and higher
-        /// </summary>
+        /// <summary> The File Signature - CryTek for 3.5 and lower. CrCh for 3.6 and higher. #ivo for some SC files. </summary>
         public string FileSignature { get; internal set; }
 
-        /// <summary>
-        /// The type of file (geometry or animation)
-        /// </summary>
+        /// <summary> The type of file (geometry or animation) </summary>
         public FileType FileType { get; internal set; }
 
-        /// <summary>
-        /// The version of the file
-        /// </summary>
         public FileVersion FileVersion { get; internal set; }
 
-        /// <summary>
-        /// Position of the Chunk Header table
-        /// </summary>
+        /// <summary> Position of the Chunk Header table </summary>
         public int ChunkTableOffset { get; internal set; }
 
         /// <summary>
-        /// Contains all the information about bones and skinning them.  This a reference to the Cryengine object, since multiple Models can exist for a single object).
+        /// Contains all the information about bones and skinning them.  This a reference to the Cryengine object, 
+        /// since multiple Models can exist for a single object).
         /// </summary>
         public SkinningInfo SkinningInfo { get; set; } = new SkinningInfo();
 
-        /// <summary>
-        /// The Bones in the model.  The CompiledBones chunk will have a unique RootBone.
-        /// </summary>
+        /// <summary> The Bones in the model.  The CompiledBones chunk will have a unique RootBone. </summary>
         public ChunkCompiledBones Bones { get; internal set; }
 
         public uint NumChunks { get; internal set; }
 
         private Dictionary<int, ChunkNode> nodeMap { get; set; }
 
-        /// <summary>
-        /// Node map for this model only.
-        /// </summary>
+        /// <summary> Node map for this model only. </summary>
         public Dictionary<int, ChunkNode> NodeMap      // This isn't right.  Nodes can have duplicate names.
         {
             get

--- a/CgfConverter/CryEngineCore/Model.cs
+++ b/CgfConverter/CryEngineCore/Model.cs
@@ -5,19 +5,8 @@ using System.Linq;
 
 namespace CgfConverter.CryEngineCore
 {
-
-    /// <summary>
-    /// CryEngine cgf/cga/skin file handler
-    /// 
-    /// Structure:
-    ///   HEADER        <- Provides information about the format of the file
-    ///   CHUNKHEADER[] <- Provides information about locations of CHUNKs
-    ///   CHUNK[]
-    /// </summary>
     public class Model
     {
-        #region Public Properties
-
         /// <summary>
         /// The Root of the loaded object
         /// </summary>
@@ -104,8 +93,6 @@ namespace CgfConverter.CryEngineCore
                 return nodeMap;
             }
         }
-
-        #endregion
 
         #region Private Fields
 
@@ -210,7 +197,6 @@ namespace CgfConverter.CryEngineCore
 
         private void ReadChunkHeaders(BinaryReader b)
         {
-            // need to seek to the start of the table here.  foffset points to the start of the table
             b.BaseStream.Seek(ChunkTableOffset, SeekOrigin.Begin);
 
             for (int i = 0; i < NumChunks; i++)

--- a/CgfConverter/CryEngineCore/Model.cs
+++ b/CgfConverter/CryEngineCore/Model.cs
@@ -46,12 +46,12 @@ namespace CgfConverter.CryEngineCore
         /// <summary>
         /// The type of file (geometry or animation)
         /// </summary>
-        public FileTypeEnum FileType { get; internal set; }
+        public FileType FileType { get; internal set; }
 
         /// <summary>
         /// The version of the file
         /// </summary>
-        public FileVersionEnum FileVersion { get; internal set; }
+        public FileVersion FileVersion { get; internal set; }
 
         /// <summary>
         /// Position of the Chunk Header table
@@ -85,7 +85,7 @@ namespace CgfConverter.CryEngineCore
                     ChunkNode rootNode = null;
                     RootNode = rootNode = (rootNode ?? RootNode);  // Each model will have it's own rootnode.
 
-                    foreach (ChunkNode node in ChunkMap.Values.Where(c => c.ChunkType == ChunkTypeEnum.Node).Select(c => c as ChunkNode))
+                    foreach (ChunkNode node in ChunkMap.Values.Where(c => c.ChunkType == ChunkType.Node).Select(c => c as ChunkNode))
                     {
                         // Preserve existing parents
                         if (nodeMap.ContainsKey(node.ID))
@@ -115,9 +115,9 @@ namespace CgfConverter.CryEngineCore
 
         #region Calculated Properties
 
-        public int NodeCount { get { return ChunkMap.Values.Where(c => c.ChunkType == ChunkTypeEnum.Node).Count(); } }
+        public int NodeCount { get { return ChunkMap.Values.Where(c => c.ChunkType == ChunkType.Node).Count(); } }
 
-        public int BoneCount { get { return ChunkMap.Values.Where(c => c.ChunkType == ChunkTypeEnum.CompiledBones).Count(); } }
+        public int BoneCount { get { return ChunkMap.Values.Where(c => c.ChunkType == ChunkType.CompiledBones).Count(); } }
 
         #endregion
 
@@ -164,7 +164,7 @@ namespace CgfConverter.CryEngineCore
 
             if (FileSignature == "CrCh")           // file signature v3.6+
             {
-                FileVersion = (FileVersionEnum)b.ReadUInt32();    // 0x746
+                FileVersion = (FileVersion)b.ReadUInt32();    // 0x746
                 NumChunks = b.ReadUInt32();       // number of Chunks in the chunk table
                 ChunkTableOffset = b.ReadInt32(); // location of the chunk table
 
@@ -172,7 +172,7 @@ namespace CgfConverter.CryEngineCore
             } 
             else if (FileSignature == "#ivo")
             {
-                FileVersion = (FileVersionEnum)b.ReadUInt32();  // 0x0900
+                FileVersion = (FileVersion)b.ReadUInt32();  // 0x0900
                 NumChunks = b.ReadUInt32();
                 ChunkTableOffset = b.ReadInt32();
                 CreateDummyRootNode();
@@ -184,8 +184,8 @@ namespace CgfConverter.CryEngineCore
 
             if (FileSignature == "CryTek")         // file signature v3.5-
             {
-                FileType = (FileTypeEnum)b.ReadUInt32();
-                FileVersion = (FileVersionEnum)b.ReadUInt32();    // 0x744 0x745
+                FileType = (FileType)b.ReadUInt32();
+                FileVersion = (FileVersion)b.ReadUInt32();    // 0x744 0x745
                 ChunkTableOffset = b.ReadInt32() + 4;
                 NumChunks = b.ReadUInt32();       // number of Chunks in the chunk table
 
@@ -204,7 +204,7 @@ namespace CgfConverter.CryEngineCore
             rootNode.__NumChildren = 0;     // Single object
             rootNode.MatID = 0;
             rootNode.Transform = Matrix44.CreateDefaultRootNodeMatrix();
-            rootNode.ChunkType = ChunkTypeEnum.Node;
+            rootNode.ChunkType = ChunkType.Node;
             RootNode = rootNode;
         }
 
@@ -233,15 +233,15 @@ namespace CgfConverter.CryEngineCore
                 ChunkMap[chunkHeaderItem.ID].SkipBytes(reader);
 
                 // Assume first node read in Model[0] is root node.  This may be bad if they aren't in order!
-                if (chunkHeaderItem.ChunkType == ChunkTypeEnum.Node && RootNode == null)
+                if (chunkHeaderItem.ChunkType == ChunkType.Node && RootNode == null)
                 {
                     RootNode = ChunkMap[chunkHeaderItem.ID] as ChunkNode;
                 }
 
                 // Add Bones to the model.  We are assuming there is only one CompiledBones chunk per file.
-                if (chunkHeaderItem.ChunkType == ChunkTypeEnum.CompiledBones || 
-                    chunkHeaderItem.ChunkType == ChunkTypeEnum.CompiledBonesSC ||
-                    chunkHeaderItem.ChunkType == ChunkTypeEnum.CompiledBonesIvo)
+                if (chunkHeaderItem.ChunkType == ChunkType.CompiledBones || 
+                    chunkHeaderItem.ChunkType == ChunkType.CompiledBonesSC ||
+                    chunkHeaderItem.ChunkType == ChunkType.CompiledBonesIvo)
                 {
                     Bones = ChunkMap[chunkHeaderItem.ID] as ChunkCompiledBones;
                     SkinningInfo.HasSkinningInfo = true;

--- a/CgfConverter/CryEngineCore/Model.cs
+++ b/CgfConverter/CryEngineCore/Model.cs
@@ -166,13 +166,15 @@ namespace CgfConverter.CryEngineCore
         {
             ChunkNode rootNode = new ChunkNode_823();
             rootNode.Name = FileName;
-            rootNode.ObjectNodeID = 1;      // No node IDs in #ivo files
+            rootNode.ObjectNodeID = 2;      // No node IDs in #ivo files
             rootNode.ParentNodeID = ~0;     // No parent
             rootNode.__NumChildren = 0;     // Single object
             rootNode.MatID = 0;
             rootNode.Transform = Matrix44.CreateDefaultRootNodeMatrix();
             rootNode.ChunkType = ChunkType.Node;
             RootNode = rootNode;
+            rootNode._model = this;
+            ChunkMap.Add(1, rootNode);
         }
 
         private void ReadChunkHeaders(BinaryReader b)

--- a/CgfConverter/Enums/Enums.cs
+++ b/CgfConverter/Enums/Enums.cs
@@ -80,7 +80,7 @@
         CompiledBonesIvo = 0xC201973C,
         CompiledPhysicalBonesIvo = 0x90C687DC,
         MeshIvo = 0x9293B9D8,
-        DatastreamIvo = 0xB875B2D9,
+        IvoSkin = 0xB875B2D9,
 
         BinaryXmlDataSC = 0xcccbf004,
     }
@@ -154,7 +154,7 @@
         AUTOCUBIC
     }  //complete
 
-    public enum DataStreamTypeEnum : uint
+    public enum DATASTREAMTYPE : uint
     {
         VERTICES,
         NORMALS,
@@ -175,6 +175,15 @@
         UNKNOWN5,
         UNKNOWN6
     }  //complete
+
+    public enum IVODATASTREAMTYPE : uint {
+        COLORS = 0x9CF3F615,
+        INDICES = 0xEECDC168,
+        TANGENTS = 0xB95E9A1B,
+        BONEMAP = 0x677C7B23,
+        VERTSUVS = 0x91329AE9
+    };
+
     public enum PhysicsPrimitiveType : uint
     {
         CUBE = 0X0,

--- a/CgfConverter/Enums/Enums.cs
+++ b/CgfConverter/Enums/Enums.cs
@@ -79,6 +79,8 @@
         MtlNameIvo = 0x8335674E,
         CompiledBonesIvo = 0xC201973C,
         CompiledPhysicalBonesIvo = 0x90C687DC,
+        MeshIvo = 0x9293B9D8,
+        DatastreamIvo = 0xB875B2D9,
 
         BinaryXmlDataSC = 0xcccbf004,
     }

--- a/CgfConverter/Enums/Enums.cs
+++ b/CgfConverter/Enums/Enums.cs
@@ -1,18 +1,19 @@
 ﻿namespace CgfConverter
 {
-    public enum FileVersionEnum : uint
+    public enum FileVersion : uint
     {
         CryTek_3_4 = 0x744,
         CryTek_3_5 = 0x745,
         CryTek_3_6 = 0x746,
     }
-    // Enums
-    public enum FileTypeEnum : uint
+    
+    public enum FileType : uint
     {
         GEOM = 0xFFFF0000,
         ANIM = 0xFFFF0001
     }  // complete
-    public enum MtlNameTypeEnum : uint
+
+    public enum MtlNameType : uint
     {
         // It looks like there is a 0x04 type now as well, for mech parts.  Not sure what that is.
         // Also a 0x0B type now as well.
@@ -23,7 +24,8 @@
         Unknown1 = 0x0B,        // Collision materials?  In MWO, these are the torsos, arms, legs from body/<mech>.mtl
         Unknown2 = 0x04
     }
-    public enum ChunkTypeEnum : uint    // complete
+
+    public enum ChunkType : uint    // complete
     {
         Any = 0x0,
         Mesh = 0xCCCC0000,
@@ -90,7 +92,7 @@
         ChkVersion
     }    //complete
 
-    public enum HelperTypeEnum : uint
+    public enum HelperType : uint
     {
         POINT,
         DUMMY,
@@ -154,7 +156,7 @@
         AUTOCUBIC
     }  //complete
 
-    public enum DATASTREAMTYPE : uint
+    public enum DatastreamType : uint
     {
         VERTICES,
         NORMALS,
@@ -176,7 +178,7 @@
         UNKNOWN6
     }  //complete
 
-    public enum IVODATASTREAMTYPE : uint {
+    public enum IvoDatastreamType : uint {
         COLORS = 0x9CF3F615,
         INDICES = 0xEECDC168,
         TANGENTS = 0xB95E9A1B,

--- a/CgfConverter/Enums/Enums.cs
+++ b/CgfConverter/Enums/Enums.cs
@@ -175,16 +175,13 @@
         UNKNOWN3,
         VERTSUVS,   // 0x0F
         UNKNOWN5,
-        UNKNOWN6
-    }  //complete
-
-    public enum IvoDatastreamType : uint {
-        COLORS = 0x9CF3F615,
-        INDICES = 0xEECDC168,
-        TANGENTS = 0xB95E9A1B,
-        BONEMAP = 0x677C7B23,
-        VERTSUVS = 0x91329AE9
-    };
+        UNKNOWN6,
+        IVOCOLORS = 0x9CF3F615,
+        IVOINDICES = 0xEECDC168,
+        IVOTANGENTS = 0xB95E9A1B,
+        IVOBONEMAP = 0x677C7B23,
+        IVOVERTSUVS = 0x91329AE9
+    }
 
     public enum PhysicsPrimitiveType : uint
     {

--- a/CgfConverter/Renderers/Collada/COLLADA.cs
+++ b/CgfConverter/Renderers/Collada/COLLADA.cs
@@ -207,7 +207,6 @@ namespace CgfConverter
                     tmpMaterial.ID = CryData.Materials[i].Name + "-material";          // this is the order the materials appear in the .mtl file.  Needed for geometries.
                     tmpMaterial.Instance_Effect.URL = "#" + CryData.Materials[i].Name + "-effect";
                 }
-                // The # in front of tmpMaterial.name is needed to reference the effect in Library_effects.
 
                 materials[i] = tmpMaterial;
             }
@@ -216,7 +215,7 @@ namespace CgfConverter
 
         public void WriteLibrary_Effects()
         {
-            // The Effects library.  This is actual material stuff, so... let's get into it!  First, let's make a library effects object
+            // The Effects library.  This is actual material stuff.
             Grendgine_Collada_Library_Effects libraryEffects = new Grendgine_Collada_Library_Effects();
             // Like materials.  We will need one effect for each material.
             int numEffects = CryData.Materials.Count;
@@ -370,18 +369,14 @@ namespace CgfConverter
 
                 #endregion
 
-
-
                 tmpEffect.Profile_COMMON = profiles.ToArray();
                 profile.New_Param = new Grendgine_Collada_New_Param[newparams.Count];
                 profile.New_Param = newparams.ToArray();
-
-
             }
+
             libraryEffects.Effect = effects;
             DaeObject.Library_Effects = libraryEffects;
             // libraryEffects contains a number of effects objects.  One effects object for each material.
-
         }
 
         /// <summary> Write the Library_Geometries element.  These won't be instantiated except through the visual scene or controllers. </summary>

--- a/CgfConverter/Renderers/Collada/COLLADA.cs
+++ b/CgfConverter/Renderers/Collada/COLLADA.cs
@@ -96,7 +96,7 @@ namespace CgfConverter
             };
             // Get the actual file creators from the Source Chunk
             contributors[1] = new Grendgine_Collada_Asset_Contributor();
-            foreach (ChunkSourceInfo tmpSource in CryData.Chunks.Where(a => a.ChunkType == ChunkTypeEnum.SourceInfo))
+            foreach (ChunkSourceInfo tmpSource in CryData.Chunks.Where(a => a.ChunkType == ChunkType.SourceInfo))
             {
                 contributors[1].Author = tmpSource.Author;
                 contributors[1].Source_Data = tmpSource.SourceFile;
@@ -395,7 +395,7 @@ namespace CgfConverter
 
             // For each of the nodes, we need to write the geometry.
             // Use a foreach statement to get all the node chunks.  This will get us the meshes, which will contain the vertex, UV and normal info.
-            foreach (ChunkNode nodeChunk in CryData.Chunks.Where(a => a.ChunkType == ChunkTypeEnum.Node))
+            foreach (ChunkNode nodeChunk in CryData.Chunks.Where(a => a.ChunkType == ChunkType.Node))
             {
                 // Create a geometry object.  Use the chunk ID for the geometry ID
                 // Will have to be careful with this, since with .cga/.cgam pairs will need to match by Name.
@@ -430,7 +430,7 @@ namespace CgfConverter
                     continue;
                 }
 
-                if (nodeChunk._model.ChunkMap[nodeChunk.ObjectNodeID].ChunkType == ChunkTypeEnum.Mesh)
+                if (nodeChunk._model.ChunkMap[nodeChunk.ObjectNodeID].ChunkType == ChunkType.Mesh)
                 {
                     // Get the mesh chunk and submesh chunk for this node.
                     ChunkMesh tmpMeshChunk = (ChunkMesh)nodeChunk._model.ChunkMap[nodeChunk.ObjectNodeID];
@@ -1044,9 +1044,9 @@ namespace CgfConverter
             List<Grendgine_Collada_Node> nodes = new List<Grendgine_Collada_Node>();
 
             // Check to see if there is a CompiledBones chunk.  If so, add a Node.
-            if (CryData.Chunks.Any(a => a.ChunkType == ChunkTypeEnum.CompiledBones || 
-                a.ChunkType == ChunkTypeEnum.CompiledBonesSC ||
-                a.ChunkType == ChunkTypeEnum.CompiledBonesIvo))
+            if (CryData.Chunks.Any(a => a.ChunkType == ChunkType.CompiledBones || 
+                a.ChunkType == ChunkType.CompiledBonesSC ||
+                a.ChunkType == ChunkType.CompiledBonesIvo))
             {
                 Grendgine_Collada_Node boneNode = new Grendgine_Collada_Node();
                 boneNode = CreateJointNode(CryData.Bones.RootBone);
@@ -1094,9 +1094,9 @@ namespace CgfConverter
             List<Grendgine_Collada_Node> nodes = new List<Grendgine_Collada_Node>();
 
             // Check to see if there is a CompiledBones chunk.  If so, add a Node.  
-            if (CryData.Chunks.Any(a => a.ChunkType == ChunkTypeEnum.CompiledBones || 
-                a.ChunkType == ChunkTypeEnum.CompiledBonesSC ||
-                a.ChunkType == ChunkTypeEnum.CompiledBonesIvo))
+            if (CryData.Chunks.Any(a => a.ChunkType == ChunkType.CompiledBones || 
+                a.ChunkType == ChunkType.CompiledBonesSC ||
+                a.ChunkType == ChunkType.CompiledBonesIvo))
             {
                 Grendgine_Collada_Node boneNode = new Grendgine_Collada_Node();
                 boneNode = CreateJointNode(CryData.Bones.RootBone);
@@ -1168,7 +1168,7 @@ namespace CgfConverter
                 int nodeID = nodeChunk.ID;
 
                 // make sure there is a geometry node in the geometry file
-                if (CryData.Models[0].ChunkMap[nodeChunk.ObjectNodeID].ChunkType == ChunkTypeEnum.Helper)
+                if (CryData.Models[0].ChunkMap[nodeChunk.ObjectNodeID].ChunkType == ChunkType.Helper)
                 {
                     tmpNode = CreateSimpleNode(nodeChunk);
                 }
@@ -1188,7 +1188,7 @@ namespace CgfConverter
             }
             else                    // Regular Cryengine file.
             {
-                if (nodeChunk._model.ChunkMap[nodeChunk.ObjectNodeID].ChunkType == ChunkTypeEnum.Mesh)
+                if (nodeChunk._model.ChunkMap[nodeChunk.ObjectNodeID].ChunkType == ChunkType.Mesh)
                 {
                     ChunkMesh tmpMeshChunk = (ChunkMesh)nodeChunk._model.ChunkMap[nodeChunk.ObjectNodeID];
                     if (tmpMeshChunk.MeshSubsets == 0 || tmpMeshChunk.NumVertices == 0)  // Can have a node with a mesh and meshsubset, but no vertices.  Write as simple node.

--- a/CgfConverter/Renderers/Collada/COLLADA.cs
+++ b/CgfConverter/Renderers/Collada/COLLADA.cs
@@ -284,7 +284,6 @@ namespace CgfConverter
                 foreach (var texture in CryData.Materials[i].Textures)
                 //for (int j=0; j < CryData.Materials[i].Textures.Length; j++)
                 {
-                    //Console.WriteLine("Processing material texture {0}", CleanName(texture.File));
                     if (texture.Map == CryEngineCore.Material.Texture.MapTypeEnum.Diffuse)
                     {
                         diffound = true;
@@ -295,7 +294,6 @@ namespace CgfConverter
                     }
                     if (texture.Map == CryEngineCore.Material.Texture.MapTypeEnum.Specular)
                     {
-                        //Console.WriteLine("Found spec map");
                         specfound = true;
                         phong.Specular.Texture = new Grendgine_Collada_Texture();
                         phong.Specular.Texture.Texture = CleanMtlFileName(texture.File) + "-sampler";
@@ -338,7 +336,6 @@ namespace CgfConverter
                 }
                 if (specfound == false)
                 {
-                    //Console.WriteLine("No spec found, using color");
                     phong.Specular.Color = new Grendgine_Collada_Color();
                     phong.Specular.Color.sID = "specular";
                     if (CryData.Materials[i].__Specular != null)

--- a/CgfConverter/Renderers/Wavefront/Wavefront.cs
+++ b/CgfConverter/Renderers/Wavefront/Wavefront.cs
@@ -97,10 +97,10 @@ namespace CgfConverter
                     {
                         #region case ChunkTypeEnum.Mesh:
 
-                        case ChunkTypeEnum.Mesh:
+                        case ChunkType.Mesh:
                             // Render Meshes
 
-                            if ((node.ParentNode != null) && (node.ParentNode.ChunkType != ChunkTypeEnum.Node))
+                            if ((node.ParentNode != null) && (node.ParentNode.ChunkType != ChunkType.Node))
                             {
                                 Utils.Log(LogLevelEnum.Debug, "Rendering {0} to parent {1}", node.Name, node.ParentNode.Name);
                             }
@@ -115,7 +115,7 @@ namespace CgfConverter
                         #endregion
                         #region case ChunkTypeEnum.Helper:
 
-                        case ChunkTypeEnum.Helper:
+                        case ChunkType.Helper:
                             // Ignore Helpers nodes
                             // TODO: Investigate if there's something we should do here
                             break;
@@ -133,7 +133,7 @@ namespace CgfConverter
                 }
 
                 // If this is a .chr file, just write out the hitbox info.  OBJ files can't do armatures.
-                foreach (CryEngineCore.ChunkCompiledPhysicalProxies tmpProxy in this.CryData.Chunks.Where(a => a.ChunkType == ChunkTypeEnum.CompiledPhysicalProxies))
+                foreach (CryEngineCore.ChunkCompiledPhysicalProxies tmpProxy in this.CryData.Chunks.Where(a => a.ChunkType == ChunkType.CompiledPhysicalProxies))
                 {
                     // TODO: align these properly
                     this.WriteObjHitBox(file, tmpProxy);

--- a/CgfConverter/Services/ArgsHandler.cs
+++ b/CgfConverter/Services/ArgsHandler.cs
@@ -309,10 +309,8 @@ namespace CgfConverter
                     #region default...
 
                     default:
-                        this.InputFiles.AddRange(GetFiles(inputArgs[i]));
-
+                        InputFiles.AddRange(GetFiles(inputArgs[i]));
                         Console.WriteLine("Input file set to {0}", inputArgs[i]);
-
                         break;
 
                         #endregion
@@ -320,15 +318,15 @@ namespace CgfConverter
             }
 
             // Ensure we have a file to process
-            if (this.InputFiles.Count == 0)
+            if (InputFiles.Count == 0)
             {
                 PrintUsage();
                 return 1;
             }
 
             // Default to Collada (.dae) format
-            if (!this.OutputBlender && !this.OutputCollada && !this.OutputWavefront && !this.OutputFBX)
-                this.OutputCollada = true;
+            if (!OutputBlender && !OutputCollada && !OutputWavefront && !OutputFBX)
+                OutputCollada = true;
 
             return 0;
         }

--- a/CgfConverter/Structs/Structs.cs
+++ b/CgfConverter/Structs/Structs.cs
@@ -1054,10 +1054,6 @@ namespace CgfConverter
             framemtx.ReadMatrix33(b);
             return;
         }
-        public void WritePhysicsGeometry()
-        {
-            Utils.Log(LogLevelEnum.Verbose, "WritePhysicsGeometry");
-        }
     }
 
     public class CompiledPhysicalBone
@@ -1074,22 +1070,17 @@ namespace CgfConverter
         public uint parentID;                       // ControllerID of parent
         public List<uint> childIDs;                 // Not part of read struct.  Contains the controllerIDs of the children to this bone.
 
-        public CompiledBone GetBonePartner()
-        {
-            return null;
-        }
-
         public void ReadCompiledPhysicalBone(BinaryReader b)
         {
             // Reads just a single 584 byte entry of a bone. At the end the seek position will be advanced, so keep that in mind.
-            BoneIndex = b.ReadUInt32();                 // unique id of bone (generated from bone name)
+            BoneIndex = b.ReadUInt32();                // unique id of bone (generated from bone name)
             ParentOffset = b.ReadUInt32();
             NumChildren = b.ReadUInt32();
             ControllerID = b.ReadUInt32();
             prop = b.ReadChars(32);                    // Not sure what this is used for.
             PhysicsGeometry.ReadPhysicsGeometry(b);
 
-            childIDs = new List<uint>();                    // Calculated
+            childIDs = new List<uint>();               // Calculated
         }
     }
 

--- a/CgfConverter/Structs/Structs.cs
+++ b/CgfConverter/Structs/Structs.cs
@@ -1212,18 +1212,6 @@ namespace CgfConverter
         public UInt16 I0 { get; set; }
         public UInt16 I1 { get; set; }
         public UInt16 I2 { get; set; }
-
-        //public static bool operator =(TFace face)
-        //{
-        //    if (face.i0 == i0 && face.i1 == i1 && face.i2 == i2)
-        //    {
-        //        return true;
-        //    }
-        //    else
-        //    {
-        //        return false;
-        //    }
-        //}
     }
 
     public class MeshCollisionInfo
@@ -1233,11 +1221,6 @@ namespace CgfConverter
         public Vector3 Position;
         public List<short> Indices;
         public int BoneID;
-
-        public MeshCollisionInfo()
-        {
-
-        }
     }
 
     public struct IntSkinVertex

--- a/CgfConverter/Structs/Structs.cs
+++ b/CgfConverter/Structs/Structs.cs
@@ -857,19 +857,6 @@ namespace CgfConverter
         }
     }   // May also be known as ColorB.
 
-    public struct FRGB
-    {
-        public double r; // Double Red
-        public double g; // Double green
-        public double b; // Double blue
-    }
-
-    public struct AABB
-    {
-        Vector3 min;
-        Vector3 max;
-    }
-
     public struct Tangent
     {
         // Tangents.  Divide each component by 32767 to get the actual value

--- a/CgfConverter/packages.config
+++ b/CgfConverter/packages.config
@@ -2,6 +2,5 @@
 <packages>
   <package id="MathNet.Numerics" version="4.12.0" targetFramework="net472" />
   <package id="Microsoft.CodeAnalysis.NetAnalyzers" version="5.0.1" targetFramework="net472" developmentDependency="true" />
-  <package id="Microsoft.NetCore.Analyzers" version="3.3.2" targetFramework="net472" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
 </packages>

--- a/CgfConverter/packages.config
+++ b/CgfConverter/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MathNet.Numerics" version="4.12.0" targetFramework="net472" />
-  <package id="Microsoft.CodeAnalysis.NetAnalyzers" version="5.0.1" targetFramework="net472" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="MathNet.Numerics" version="4.15.0" targetFramework="net472" />
+  <package id="Microsoft.CodeAnalysis.NetAnalyzers" version="5.0.3" targetFramework="net472" developmentDependency="true" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
 </packages>

--- a/CgfConverterTests/CgfConverterTests.csproj
+++ b/CgfConverterTests/CgfConverterTests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="..\packages\MSTest.TestAdapter.2.2.4\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.2.4\build\net45\MSTest.TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -41,10 +41,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.2.1.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.2.2.4\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.2.1.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.2.2.4\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -100,8 +100,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.2.4\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.2.4\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.2.4\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.2.4\build\net45\MSTest.TestAdapter.targets'))" />
   </Target>
-  <Import Project="..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\packages\MSTest.TestAdapter.2.2.4\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.2.4\build\net45\MSTest.TestAdapter.targets')" />
 </Project>

--- a/CgfConverterTests/IntegrationTests/CgfConverterIntegrationTests.cs
+++ b/CgfConverterTests/IntegrationTests/CgfConverterIntegrationTests.cs
@@ -197,7 +197,7 @@ namespace CgfConverterTests.IntegrationTests
             cryData.ProcessCryengineFiles();
 
             Assert.AreEqual((uint)41, cryData.Models[0].NumChunks);
-            Assert.AreEqual(ChunkTypeEnum.Node, cryData.Models[0].ChunkMap[47].ChunkType);
+            Assert.AreEqual(ChunkType.Node, cryData.Models[0].ChunkMap[47].ChunkType);
             var datastream = cryData.Models[0].ChunkMap[40] as ChunkDataStream_801;
             Assert.AreEqual((uint)12, datastream.BytesPerElement);
             Assert.AreEqual((uint)22252, datastream.NumElements);

--- a/CgfConverterTests/IntegrationTests/CrucibleTests/CrucibleTests.cs
+++ b/CgfConverterTests/IntegrationTests/CrucibleTests/CrucibleTests.cs
@@ -37,7 +37,7 @@ namespace CgfConverterTests.IntegrationTests.Crucible
             cryData.ProcessCryengineFiles();
 
             Assert.AreEqual((uint)11, cryData.Models[0].NumChunks);
-            Assert.AreEqual(ChunkTypeEnum.Node, cryData.Models[0].ChunkMap[22].ChunkType);
+            Assert.AreEqual(ChunkType.Node, cryData.Models[0].ChunkMap[22].ChunkType);
             var datastream = cryData.Models[0].ChunkMap[16] as ChunkDataStream_801;
             Assert.AreEqual((uint)8, datastream.BytesPerElement);
             Assert.AreEqual((uint)96, datastream.NumElements);

--- a/CgfConverterTests/IntegrationTests/SC/StarCitizenTests.cs
+++ b/CgfConverterTests/IntegrationTests/SC/StarCitizenTests.cs
@@ -86,7 +86,5 @@ namespace CgfConverterTests.IntegrationTests.SC
             colladaData.GenerateDaeObject();
             testUtils.ValidateColladaXml(colladaData);
         }
-
-
     }
 }

--- a/CgfConverterTests/IntegrationTests/SC/StarCitizenTests.cs
+++ b/CgfConverterTests/IntegrationTests/SC/StarCitizenTests.cs
@@ -86,5 +86,30 @@ namespace CgfConverterTests.IntegrationTests.SC
             colladaData.GenerateDaeObject();
             testUtils.ValidateColladaXml(colladaData);
         }
+
+        [TestMethod]
+        public void SC_BehrRifle_34()
+        {
+            var args = new string[] { 
+                $@"{userHome}\OneDrive\ResourceFiles\SC\brfl_fps_behr_p4ar_parts_3.4.skin", 
+                "-dds", "-dae", "-objectdir", @"..\..\ResourceFiles\" };
+            int result = testUtils.argsHandler.ProcessArgs(args);
+            Assert.AreEqual(0, result);
+            CryEngine cryData = new CryEngine(args[0], testUtils.argsHandler.DataDir.FullName);
+            cryData.ProcessCryengineFiles();
+
+            COLLADA colladaData = new COLLADA(testUtils.argsHandler, cryData);
+            colladaData.GenerateDaeObject();
+
+            var controllers = colladaData.DaeObject.Library_Controllers.Controller;
+            var geometries = colladaData.DaeObject.Library_Geometries.Geometry;
+            Assert.AreEqual(1, controllers.Length);
+            Assert.AreEqual(1, geometries.Length);
+
+            var meshes = geometries[0].Mesh;
+            Assert.AreEqual(4, meshes.Source);
+
+            testUtils.ValidateColladaXml(colladaData);
+        }
     }
 }

--- a/CgfConverterTests/IntegrationTests/SC/StarCitizenTests.cs
+++ b/CgfConverterTests/IntegrationTests/SC/StarCitizenTests.cs
@@ -84,6 +84,10 @@ namespace CgfConverterTests.IntegrationTests.SC
 
             COLLADA colladaData = new COLLADA(testUtils.argsHandler, cryData);
             colladaData.GenerateDaeObject();
+
+            var geometries = colladaData.DaeObject.Library_Geometries.Geometry;
+            Assert.AreEqual(3, geometries.Length);
+
             testUtils.ValidateColladaXml(colladaData);
         }
 
@@ -106,8 +110,12 @@ namespace CgfConverterTests.IntegrationTests.SC
             Assert.AreEqual(1, controllers.Length);
             Assert.AreEqual(1, geometries.Length);
 
-            var meshes = geometries[0].Mesh;
-            Assert.AreEqual(4, meshes.Source);
+            var mesh = geometries[0].Mesh;
+            Assert.AreEqual(4, mesh.Source.Length);
+            Assert.AreEqual("brfl_fps_behr_p4ar_parts-vertices", mesh.Vertices.ID);
+            Assert.AreEqual(9, mesh.Triangles.Length);
+            Assert.AreEqual(78, mesh.Triangles[0].Count);
+            Assert.AreEqual(134, mesh.Triangles[8].Count);
 
             testUtils.ValidateColladaXml(colladaData);
         }

--- a/CgfConverterTests/IntegrationTests/SC/StarCitizenTests.cs
+++ b/CgfConverterTests/IntegrationTests/SC/StarCitizenTests.cs
@@ -24,7 +24,7 @@ namespace CgfConverterTests.IntegrationTests.SC
         }
 
         [TestMethod]
-        public void BehrRifle_312IvoFile()
+        public void BehrRifle_312IvoChrFile()
         {
             var args = new string[] { $@"{userHome}\OneDrive\ResourceFiles\SC\3.12.0\brfl_fps_behr_p4ar.chr", "-dds", "-dae" };
             int result = testUtils.argsHandler.ProcessArgs(args);
@@ -37,6 +37,19 @@ namespace CgfConverterTests.IntegrationTests.SC
             var daeObject = colladaData.DaeObject;
 
             Assert.AreEqual(1, cryData.Materials.Count);
+        }
+
+        [TestMethod]
+        public void BehrRifle_312IvoSkinFile()
+        {
+            var args = new string[] { $@"{userHome}\OneDrive\ResourceFiles\SC\3.12.0\brfl_fps_behr_p4ar_parts.skin", "-dds", "-dae" };
+            int result = testUtils.argsHandler.ProcessArgs(args);
+            Assert.AreEqual(0, result);
+            CryEngine cryData = new CryEngine(args[0], testUtils.argsHandler.DataDir.FullName);
+            cryData.ProcessCryengineFiles();
+
+            var colladaData = new COLLADA(testUtils.argsHandler, cryData);
+            colladaData.GenerateDaeObject();
         }
 
         [TestMethod]

--- a/CgfConverterTests/IntegrationTests/SonicBoomTests/SonicBoomTests.cs
+++ b/CgfConverterTests/IntegrationTests/SonicBoomTests/SonicBoomTests.cs
@@ -35,7 +35,7 @@ namespace CgfConverterTests.IntegrationTests.SonicBoom
             cryData.ProcessCryengineFiles();
 
             Assert.AreEqual((uint)17, cryData.Models[0].NumChunks);
-            Assert.AreEqual(ChunkTypeEnum.Node, cryData.Models[0].ChunkMap[33].ChunkType);
+            Assert.AreEqual(ChunkType.Node, cryData.Models[0].ChunkMap[33].ChunkType);
             var datastream = cryData.Models[0].ChunkMap[23] as ChunkDataStream_80000800;
             Assert.AreEqual((uint)12, datastream.BytesPerElement);
             Assert.AreEqual((uint)629, datastream.NumElements);
@@ -60,7 +60,7 @@ namespace CgfConverterTests.IntegrationTests.SonicBoom
             cryData.ProcessCryengineFiles();
 
             Assert.AreEqual((uint)24, cryData.Models[0].NumChunks);
-            Assert.AreEqual(ChunkTypeEnum.Node, cryData.Models[0].ChunkMap[47].ChunkType);
+            Assert.AreEqual(ChunkType.Node, cryData.Models[0].ChunkMap[47].ChunkType);
             var datastream = cryData.Models[0].ChunkMap[40] as ChunkDataStream_80000800;
             Assert.AreEqual((uint)12, datastream.BytesPerElement);
             Assert.AreEqual((uint)46244, datastream.NumElements);
@@ -85,7 +85,7 @@ namespace CgfConverterTests.IntegrationTests.SonicBoom
             cryData.ProcessCryengineFiles();
 
             Assert.AreEqual((uint)30, cryData.Models[0].NumChunks);
-            Assert.AreEqual(ChunkTypeEnum.Node, cryData.Models[0].ChunkMap[59].ChunkType);
+            Assert.AreEqual(ChunkType.Node, cryData.Models[0].ChunkMap[59].ChunkType);
             var datastream = cryData.Models[0].ChunkMap[52] as ChunkDataStream_80000800;
             Assert.AreEqual((uint)12, datastream.BytesPerElement);
             Assert.AreEqual((uint)60794, datastream.NumElements);

--- a/CgfConverterTests/packages.config
+++ b/CgfConverterTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MSTest.TestAdapter" version="2.1.2" targetFramework="net472" />
-  <package id="MSTest.TestFramework" version="2.1.2" targetFramework="net472" />
+  <package id="MSTest.TestAdapter" version="2.2.4" targetFramework="net472" />
+  <package id="MSTest.TestFramework" version="2.2.4" targetFramework="net472" />
 </packages>

--- a/cgf-converter/App.config
+++ b/cgf-converter/App.config
@@ -1,6 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/cgf-converter/FodyWeavers.xsd
+++ b/cgf-converter/FodyWeavers.xsd
@@ -17,6 +17,16 @@
                   <xs:documentation>A list of assembly names to include from the default action of "embed all Copy Local references", delimited with line breaks.</xs:documentation>
                 </xs:annotation>
               </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="ExcludeRuntimeAssemblies" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of runtime assembly names to exclude from the default action of "embed all Copy Local references", delimited with line breaks</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="IncludeRuntimeAssemblies" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of runtime assembly names to include from the default action of "embed all Copy Local references", delimited with line breaks.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
               <xs:element minOccurs="0" maxOccurs="1" name="Unmanaged32Assemblies" type="xs:string">
                 <xs:annotation>
                   <xs:documentation>A list of unmanaged 32 bit assembly names to include, delimited with line breaks.</xs:documentation>
@@ -41,6 +51,16 @@
             <xs:attribute name="IncludeDebugSymbols" type="xs:boolean">
               <xs:annotation>
                 <xs:documentation>Controls if .pdbs for reference assemblies are also embedded.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IncludeRuntimeReferences" type="xs:boolean">
+              <xs:annotation>
+                <xs:documentation>Controls if runtime assemblies are also embedded.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UseRuntimeReferencePaths" type="xs:boolean">
+              <xs:annotation>
+                <xs:documentation>Controls whether the runtime assemblies are embedded with their full path or only with their assembly name.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
             <xs:attribute name="DisableCompression" type="xs:boolean">
@@ -71,6 +91,16 @@
             <xs:attribute name="IncludeAssemblies" type="xs:string">
               <xs:annotation>
                 <xs:documentation>A list of assembly names to include from the default action of "embed all Copy Local references", delimited with |.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="ExcludeRuntimeAssemblies" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A list of runtime assembly names to exclude from the default action of "embed all Copy Local references", delimited with |</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IncludeRuntimeAssemblies" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A list of runtime assembly names to include from the default action of "embed all Copy Local references", delimited with |.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
             <xs:attribute name="Unmanaged32Assemblies" type="xs:string">

--- a/cgf-converter/cgf-converter.csproj
+++ b/cgf-converter/cgf-converter.csproj
@@ -124,15 +124,18 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
+    <Reference Include="System.Console, Version=4.0.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Console.4.3.1\lib\net46\System.Console.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=5.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.5.0.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Diagnostics.Tracing, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Diagnostics.Tracing.4.3.0\lib\net462\System.Diagnostics.Tracing.dll</HintPath>
@@ -180,8 +183,11 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Net.Http.4.3.0\lib\net46\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.4.3.4\lib\net46\System.Net.Http.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
@@ -191,18 +197,24 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
     <Reference Include="System.Reflection, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reflection.4.3.0\lib\net462\System.Reflection.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Runtime, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
+    <Reference Include="System.Runtime, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.4.3.1\lib\net462\System.Runtime.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Runtime.Extensions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.Extensions.4.3.0\lib\net462\System.Runtime.Extensions.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.Extensions, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.Extensions.4.3.1\lib\net462\System.Runtime.Extensions.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
@@ -218,7 +230,7 @@
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.1\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
@@ -232,13 +244,13 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Text.RegularExpressions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.RegularExpressions.4.3.0\lib\net463\System.Text.RegularExpressions.dll</HintPath>
+      <HintPath>..\packages\System.Text.RegularExpressions.4.3.1\lib\net463\System.Text.RegularExpressions.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
@@ -248,7 +260,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+      <HintPath>..\packages\System.Xml.ReaderWriter.4.3.1\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
@@ -312,8 +324,10 @@
     <Error Condition="!Exists('..\packages\Fody.6.5.1\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.6.5.1\build\Fody.targets'))" />
     <Error Condition="!Exists('..\packages\Costura.Fody.5.3.0\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.5.3.0\build\Costura.Fody.props'))" />
     <Error Condition="!Exists('..\packages\Costura.Fody.5.3.0\build\Costura.Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.5.3.0\build\Costura.Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets'))" />
   </Target>
   <Import Project="..\packages\Costura.Fody.5.3.0\build\Costura.Fody.targets" Condition="Exists('..\packages\Costura.Fody.5.3.0\build\Costura.Fody.targets')" />
+  <Import Project="..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets" Condition="Exists('..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/cgf-converter/cgf-converter.csproj
+++ b/cgf-converter/cgf-converter.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props" Condition="Exists('..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props')" />
+  <Import Project="..\packages\Costura.Fody.5.3.0\build\Costura.Fody.props" Condition="Exists('..\packages\Costura.Fody.5.3.0\build\Costura.Fody.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -101,27 +101,157 @@
     <ApplicationIcon>logo-50px-prod.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Costura, Version=4.1.0.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Costura.Fody.4.1.0\lib\net40\Costura.dll</HintPath>
+    <Reference Include="Costura, Version=5.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Costura.Fody.5.3.0\lib\netstandard1.0\Costura.dll</HintPath>
     </Reference>
     <Reference Include="FbxSharp, Version=0.9.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\FbxSharp.0.9\lib\net40\FbxSharp.dll</HintPath>
     </Reference>
-    <Reference Include="MathNet.Numerics, Version=4.12.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MathNet.Numerics.4.12.0\lib\net461\MathNet.Numerics.dll</HintPath>
+    <Reference Include="MathNet.Numerics, Version=4.15.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MathNet.Numerics.4.15.0\lib\net461\MathNet.Numerics.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.AppContext, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.AppContext.4.3.0\lib\net463\System.AppContext.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Diagnostics.Tracing, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.Tracing.4.3.0\lib\net462\System.Diagnostics.Tracing.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Globalization.Calendars, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Globalization.Calendars.4.3.0\lib\net46\System.Globalization.Calendars.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.IO.Compression.ZipFile, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Compression.ZipFile.4.3.0\lib\net46\System.IO.Compression.ZipFile.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.FileSystem, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Linq, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Linq.4.3.0\lib\net463\System.Linq.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Linq.Expressions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Linq.Expressions.4.3.0\lib\net463\System.Linq.Expressions.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.4.3.0\lib\net46\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Sockets, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Sockets.4.3.0\lib\net46\System.Net.Sockets.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Reflection, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.4.3.0\lib\net462\System.Reflection.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.Extensions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.Extensions.4.3.0\lib\net462\System.Runtime.Extensions.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.4.3.0\lib\net463\System.Runtime.InteropServices.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Text.RegularExpressions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.RegularExpressions.4.3.0\lib\net463\System.Text.RegularExpressions.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="cgf-converter.cs" />
@@ -174,14 +304,16 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Fody.6.5.1\build\Fody.targets" Condition="Exists('..\packages\Fody.6.5.1\build\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props'))" />
-    <Error Condition="!Exists('..\packages\Fody.6.3.0\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.6.3.0\build\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\Fody.6.5.1\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.6.5.1\build\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\Costura.Fody.5.3.0\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.5.3.0\build\Costura.Fody.props'))" />
+    <Error Condition="!Exists('..\packages\Costura.Fody.5.3.0\build\Costura.Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.5.3.0\build\Costura.Fody.targets'))" />
   </Target>
-  <Import Project="..\packages\Fody.6.3.0\build\Fody.targets" Condition="Exists('..\packages\Fody.6.3.0\build\Fody.targets')" />
+  <Import Project="..\packages\Costura.Fody.5.3.0\build\Costura.Fody.targets" Condition="Exists('..\packages\Costura.Fody.5.3.0\build\Costura.Fody.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/cgf-converter/packages.config
+++ b/cgf-converter/packages.config
@@ -4,16 +4,17 @@
   <package id="FbxSharp" version="0.9" targetFramework="net45" />
   <package id="Fody" version="6.5.1" targetFramework="net472" developmentDependency="true" />
   <package id="MathNet.Numerics" version="4.15.0" targetFramework="net472" />
-  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net472" />
+  <package id="Microsoft.NETCore.Platforms" version="5.0.2" targetFramework="net472" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net472" />
-  <package id="NETStandard.Library" version="1.6.1" targetFramework="net472" />
+  <package id="NETStandard.Library" version="2.0.3" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Collections" version="4.3.0" targetFramework="net472" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net472" />
-  <package id="System.Console" version="4.3.0" targetFramework="net472" />
+  <package id="System.Console" version="4.3.1" targetFramework="net472" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net472" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net472" />
+  <package id="System.Diagnostics.DiagnosticSource" version="5.0.1" targetFramework="net472" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net472" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net472" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net472" />
@@ -25,30 +26,33 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net472" />
   <package id="System.Linq" version="4.3.0" targetFramework="net472" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net472" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net472" />
-  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net472" />
+  <package id="System.Net.Primitives" version="4.3.1" targetFramework="net472" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net472" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net472" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net472" />
   <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net472" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net472" />
-  <package id="System.Runtime" version="4.3.0" targetFramework="net472" />
-  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime" version="4.3.1" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net472" />
+  <package id="System.Runtime.Extensions" version="4.3.1" targetFramework="net472" />
   <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net472" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net472" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net472" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net472" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net472" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net472" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net472" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net472" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net472" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net472" />
-  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net472" />
+  <package id="System.Text.RegularExpressions" version="4.3.1" targetFramework="net472" />
   <package id="System.Threading" version="4.3.0" targetFramework="net472" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net472" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net472" />
-  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net472" />
+  <package id="System.Xml.ReaderWriter" version="4.3.1" targetFramework="net472" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net472" />
 </packages>

--- a/cgf-converter/packages.config
+++ b/cgf-converter/packages.config
@@ -1,8 +1,54 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Costura.Fody" version="4.1.0" targetFramework="net461" developmentDependency="true" />
+  <package id="Costura.Fody" version="5.3.0" targetFramework="net472" developmentDependency="true" />
   <package id="FbxSharp" version="0.9" targetFramework="net45" />
-  <package id="Fody" version="6.3.0" targetFramework="net472" developmentDependency="true" />
-  <package id="MathNet.Numerics" version="4.12.0" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="Fody" version="6.5.1" targetFramework="net472" developmentDependency="true" />
+  <package id="MathNet.Numerics" version="4.15.0" targetFramework="net472" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net472" />
+  <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net472" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="net472" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net472" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net472" />
+  <package id="System.Console" version="4.3.0" targetFramework="net472" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net472" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net472" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net472" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net472" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net472" />
+  <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="net472" />
+  <package id="System.IO" version="4.3.0" targetFramework="net472" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net472" />
+  <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net472" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net472" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net472" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net472" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net472" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net472" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net472" />
+  <package id="System.Net.Sockets" version="4.3.0" targetFramework="net472" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net472" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net472" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net472" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net472" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net472" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net472" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net472" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net472" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net472" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net472" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net472" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net472" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Converter handles #ivo armatures, but not skins.  This update will allow the conversion of .skin/.skinm file geometry in addition to the armature.
- Convert #ivo file geometry
- General cleanup of project.