### PR TITLE
Texture handling

### DIFF
--- a/CgfConverter/Renderers/Wavefront/Wavefront.Material.cs
+++ b/CgfConverter/Renderers/Wavefront/Wavefront.Material.cs
@@ -72,10 +72,14 @@ namespace CgfConverter
 
                         // TODO: More filehandling here
 
-                        if (!this.Args.TiffTextures)
-                            textureFile = textureFile.Replace(".tif", ".dds");
-                        else
+                        if (this.Args.PngTextures)
+                            textureFile = textureFile.Replace(".dds", ".png");
+                        else if (this.Args.TiffTextures)
                             textureFile = textureFile.Replace(".dds", ".tif");
+                        else
+                            // Is this right? exported `tif` files might actually be `tif`s, maybe
+                            // normalize by checking if the file exists first?
+                            textureFile = textureFile.Replace(".tif", ".dds");
 
                         textureFile = textureFile.Replace(@"/", @"\");
 

--- a/CgfConverter/Renderers/Wavefront/Wavefront.cs
+++ b/CgfConverter/Renderers/Wavefront/Wavefront.cs
@@ -46,7 +46,7 @@ namespace CgfConverter
             if (this.Args.GroupMeshes)
                 this.GroupOverride = Path.GetFileNameWithoutExtension(this.OutputFile_Model.Name);
 
-            Console.WriteLine(@"Output file is {0}\...\{1}", outputDir, this.OutputFile_Model.Name);
+            Utils.Log(LogLevelEnum.Info, @"Output file is {0}\...\{1}", outputDir, this.OutputFile_Model.Name);
 
             if (!OutputFile_Model.Directory.Exists)
                 OutputFile_Model.Directory.Create();

--- a/CgfConverter/Services/MaterialLibraryCreator.cs
+++ b/CgfConverter/Services/MaterialLibraryCreator.cs
@@ -14,7 +14,7 @@ namespace CgfConverter.Services
                 BaseDirectory = Environment.CurrentDirectory,
             };
 
-            Console.WriteLine("Base Directory is " + Environment.CurrentDirectory);
+            Utils.Log(LogLevelEnum.Info, "Base Directory is " + Environment.CurrentDirectory);
             string[] materialFiles = Directory.GetFiles(Environment.CurrentDirectory, "*.mtl", SearchOption.AllDirectories);
 
             //FileInfo materialFile = new FileInfo(materialFileName);
@@ -22,7 +22,7 @@ namespace CgfConverter.Services
             {
                 foreach (string file in materialFiles)
                 {
-                    Console.WriteLine("Processing " + file);
+                    Utils.Log(LogLevelEnum.Info, "Processing " + file);
                     //Material material = Material.FromFile(new FileInfo(file));
                     CgfConverter.CryEngineCore.Material materials = CgfConverter.CryEngineCore.Material.FromFile(new FileInfo(file));
                     // All the materials in this file are in the materials variable.  For each material in here, create a materiallibraryitem.
@@ -59,7 +59,7 @@ namespace CgfConverter.Services
             }
             catch (Exception ex)
             {
-                Console.WriteLine("*** Exception converting XML: ", ex.Message);
+                Utils.Log(LogLevelEnum.Critical, "*** Exception converting XML: ", ex.Message);
             }
             WriteMaterialLibrary(matLibrary);
             Console.WriteLine("Press any key to close.");

--- a/cgf-converter/cgf-converter.cs
+++ b/cgf-converter/cgf-converter.cs
@@ -3,8 +3,10 @@ using System.Threading;
 using System.Globalization;
 using CgfConverter;
 
+
 namespace CgfConverterConsole
 {
+
     public class Program
     {
         public static int Main(string[] args)
@@ -13,14 +15,6 @@ namespace CgfConverterConsole
             Utils.DebugLevel = LogLevelEnum.Debug;
 
             string oldTitle = Console.Title;
-
-#if DEV_DOLKENSP
-            Utils.LogLevel = LogLevelEnum.None;      // Display NO error logs
-            Utils.DebugLevel = LogLevelEnum.Debug;
-
-            args = new String[] { @"C:\Users\PeterDolkens\Downloads\SOC'n'destroy\socpak\pisces_int.soc", "-objectdir", @"C:\Users\PeterDolkens\Downloads\SOC'n'destroy\socpak", "-obj", "-outdir", @"C:\Users\PeterDolkens\Downloads\SOC'n'destroy\socpak\out" };
-
-#endif
 
 #if DEV_MARKEMP
             Utils.LogLevel = LogLevelEnum.Verbose; // Display ALL error logs in the console
@@ -122,10 +116,8 @@ namespace CgfConverterConsole
 
             Console.Title = oldTitle;
 
-#if (DEV_DOLKENSP || DEV_MARKEMP)
-            Console.WriteLine("Done...");
-            Console.ReadKey();
-#endif
+            Utils.Log(LogLevelEnum.Debug, "Done...");
+            
             return 0;
         }
     }


### PR DESCRIPTION
Fixed path separator normalization for collada texture outputs. This will probably address #54. Absolute paths were be generated like so: `/I:\sc\full\Data/objects/spaceships/ships/aegs/textures/interior/atlas/retaliator_cockpit_atlas_diff_diff.dds` (notice the conflicting path separators) which would cause import issues with some tools (see Blender)

- Refactored material texture handling and discovery for collada output. Should be more robust.
- Added a `-png` option to use `.png` textures instead of `.dds`
- Added `-loglevel` parameter to control output levels and updated outputs to use `Utils.Log`
- Added a version number to the usage output

The last two are opinionated changes, feel free to reject and I'll go undo them. 