### PR TITLE
Texture Handling

### DIFF
--- a/CgfConverter/Renderers/Wavefront/Wavefront.Material.cs
+++ b/CgfConverter/Renderers/Wavefront/Wavefront.Material.cs
@@ -1,5 +1,7 @@
 ﻿using System.IO;
 using System.Reflection;
+using System.Text;
+using static Extensions.FileHandlingExtensions;
 
 namespace CgfConverter
 {
@@ -65,10 +67,7 @@ namespace CgfConverter
 
                     foreach (CryEngineCore.Material.Texture texture in material.Textures)
                     {
-                        string textureFile = texture.File;
-
-                        if (this.Args.DataDir != null)
-                            textureFile = Path.Combine(this.Args.DataDir.FullName, textureFile);
+                        StringBuilder textureFile = new StringBuilder(ResolveTexFile(texture.File, Args.DataDir));
 
                         // TODO: More filehandling here
 
@@ -76,43 +75,37 @@ namespace CgfConverter
                             textureFile = textureFile.Replace(".dds", ".png");
                         else if (this.Args.TiffTextures)
                             textureFile = textureFile.Replace(".dds", ".tif");
-                        else
-                            // Is this right? exported `tif` files might actually be `tif`s, maybe
-                            // normalize by checking if the file exists first?
-                            textureFile = textureFile.Replace(".tif", ".dds");
-
-                        textureFile = textureFile.Replace(@"/", @"\");
 
                         switch (texture.Map)
                         {
                             case CryEngineCore.Material.Texture.MapTypeEnum.Diffuse:
-                                file.WriteLine("map_Kd {0}", textureFile);
+                                file.WriteLine("map_Kd {0}", textureFile.ToString());
                                 break;
 
                             case CryEngineCore.Material.Texture.MapTypeEnum.Specular:
-                                file.WriteLine("map_Ks {0}", textureFile);
-                                file.WriteLine("map_Ns {0}", textureFile);
+                                file.WriteLine("map_Ks {0}", textureFile.ToString());
+                                file.WriteLine("map_Ns {0}", textureFile.ToString());
                                 break;
 
                             case CryEngineCore.Material.Texture.MapTypeEnum.Bumpmap:
                             case CryEngineCore.Material.Texture.MapTypeEnum.Detail:
                                 // <Texture Map="Detail" File="textures/unified_detail/metal/metal_scratches_a_detail.tif" />
-                                file.WriteLine("map_bump {0}", textureFile);
+                                file.WriteLine("map_bump {0}", textureFile.ToString());
                                 break;
 
                             case CryEngineCore.Material.Texture.MapTypeEnum.Heightmap:
                                 // <Texture Map="Heightmap" File="objects/spaceships/ships/aegs/gladius/textures/aegs_switches_buttons_disp.tif"/>
-                                file.WriteLine("disp {0}", textureFile);
+                                file.WriteLine("disp {0}", textureFile.ToString());
                                 break;
 
                             case CryEngineCore.Material.Texture.MapTypeEnum.Decal:
                                 // <Texture Map="Decal" File="objects/spaceships/ships/aegs/textures/interior/metal/aegs_int_metal_alum_bare_diff.tif"/>
-                                file.WriteLine("decal {0}", textureFile);
+                                file.WriteLine("decal {0}", textureFile.ToString());
                                 break;
 
                             case CryEngineCore.Material.Texture.MapTypeEnum.SubSurface:
                                 // <Texture Map="SubSurface" File="objects/spaceships/ships/aegs/textures/interior/atlas/aegs_int_atlas_retaliator_spec.tif"/>
-                                file.WriteLine("map_Ns {0}", textureFile);
+                                file.WriteLine("map_Ns {0}", textureFile.ToString());
                                 break;
 
                             case CryEngineCore.Material.Texture.MapTypeEnum.Custom:
@@ -126,7 +119,7 @@ namespace CgfConverter
 
                             case CryEngineCore.Material.Texture.MapTypeEnum.Opacity:
                                 // <Texture Map="Opacity" File="objects/spaceships/ships/aegs/textures/interior/blend/interior_blnd_a_diff.tif"/>
-                                file.WriteLine("map_d {0}", textureFile);
+                                file.WriteLine("map_d {0}", textureFile.ToString());
                                 break;
 
                             case CryEngineCore.Material.Texture.MapTypeEnum.Environment:

--- a/CgfConverter/Renderers/Wavefront/Wavefront.Material.cs
+++ b/CgfConverter/Renderers/Wavefront/Wavefront.Material.cs
@@ -72,10 +72,14 @@ namespace CgfConverter
 
                         // TODO: More filehandling here
 
-                        if (!this.Args.TiffTextures)
-                            textureFile = textureFile.Replace(".tif", ".dds");
-                        else
+                        if (this.Args.PngTextures)
+                            textureFile = textureFile.Replace(".dds", ".png");
+                        else if (this.Args.TiffTextures)
                             textureFile = textureFile.Replace(".dds", ".tif");
+                        else
+                            // Is this right? exported `tif` files might actually be `tif`s, maybe
+                            // normalize by checking if the file exists first?
+                            textureFile = textureFile.Replace(".tif", ".dds");
 
                         textureFile = textureFile.Replace(@"/", @"\");
 

--- a/CgfConverter/Renderers/Wavefront/Wavefront.cs
+++ b/CgfConverter/Renderers/Wavefront/Wavefront.cs
@@ -46,7 +46,7 @@ namespace CgfConverter
             if (this.Args.GroupMeshes)
                 this.GroupOverride = Path.GetFileNameWithoutExtension(this.OutputFile_Model.Name);
 
-            Console.WriteLine(@"Output file is {0}\...\{1}", outputDir, this.OutputFile_Model.Name);
+            Utils.Log(LogLevelEnum.Info, @"Output file is {0}\...\{1}", outputDir, this.OutputFile_Model.Name);
 
             if (!OutputFile_Model.Directory.Exists)
                 OutputFile_Model.Directory.Create();

--- a/CgfConverter/Services/ArgsHandler.cs
+++ b/CgfConverter/Services/ArgsHandler.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 
 namespace CgfConverter
 {
@@ -24,13 +25,12 @@ namespace CgfConverter
         /// Directory to render to
         /// </summary>
         public string OutputDir { get; internal set; }
-
         /// <summary>
-        /// Allows naming conflicts for mtl file
+        /// Sets the output log level
         /// </summary>
         public LogLevelEnum LogLevel { get; set; } = LogLevelEnum.Critical;
         /// <summary>
-        /// Sets the output log level
+        /// Allows naming conflicts for mtl file
         /// </summary>
         public bool AllowConflicts { get; internal set; }
         /// <summary>
@@ -356,7 +356,7 @@ namespace CgfConverter
             Console.WriteLine();
             Console.WriteLine("cgf-converter [-usage] | <.cgf file> [-outputfile <output file>] [-obj] [-blend] [-dae] [-tif/-png] [-group] [-smooth] [-loglevel <LogLevel>] [-throw] [-dump] [-objectdir <ObjectDir>]");
             Console.WriteLine();
-            Console.WriteLine("CryEngine Converter v1.3.0");
+            Console.WriteLine($"CryEngine Converter v{Assembly.GetExecutingAssembly().GetName().Version}");
             Console.WriteLine();
             Console.WriteLine("-usage:           Prints out the usage statement");
             Console.WriteLine();

--- a/CgfConverter/Services/MaterialLibraryCreator.cs
+++ b/CgfConverter/Services/MaterialLibraryCreator.cs
@@ -14,7 +14,7 @@ namespace CgfConverter.Services
                 BaseDirectory = Environment.CurrentDirectory,
             };
 
-            Console.WriteLine("Base Directory is " + Environment.CurrentDirectory);
+            Utils.Log(LogLevelEnum.Info, "Base Directory is " + Environment.CurrentDirectory);
             string[] materialFiles = Directory.GetFiles(Environment.CurrentDirectory, "*.mtl", SearchOption.AllDirectories);
 
             //FileInfo materialFile = new FileInfo(materialFileName);
@@ -22,7 +22,7 @@ namespace CgfConverter.Services
             {
                 foreach (string file in materialFiles)
                 {
-                    Console.WriteLine("Processing " + file);
+                    Utils.Log(LogLevelEnum.Info, "Processing " + file);
                     //Material material = Material.FromFile(new FileInfo(file));
                     CgfConverter.CryEngineCore.Material materials = CgfConverter.CryEngineCore.Material.FromFile(new FileInfo(file));
                     // All the materials in this file are in the materials variable.  For each material in here, create a materiallibraryitem.
@@ -59,7 +59,7 @@ namespace CgfConverter.Services
             }
             catch (Exception ex)
             {
-                Console.WriteLine("*** Exception converting XML: ", ex.Message);
+                Utils.Log(LogLevelEnum.Critical, "*** Exception converting XML: ", ex.Message);
             }
             WriteMaterialLibrary(matLibrary);
             Console.WriteLine("Press any key to close.");

--- a/CgfConverter/Utils/FileHandlingExtensions.cs
+++ b/CgfConverter/Utils/FileHandlingExtensions.cs
@@ -1,0 +1,48 @@
+using System.IO;
+using System.Text;
+using CgfConverter;
+
+namespace Extensions
+{
+    public static class FileHandlingExtensions
+    {
+        /// <summary>Material texture file extensions used to search resolve texture paths to files on disk</summary>
+        private static readonly string[] TextureExtensions = {".dds", ".png", ".tif"};
+        
+        /// <summary>Attempts to resole a material path to the correct file extension, and normalizes the path separators</summary>
+        public static string ResolveTexFile(string mtl, DirectoryInfo dataDir)
+        {
+            StringBuilder mtlfile = new StringBuilder();
+            string cleanName = CleanTexFileName(mtl);
+            if (dataDir.ToString() == ".")
+                mtlfile.Append(CleanTexFileName(mtl)); // Resolve in current directory
+            else
+                mtlfile.Append($"{dataDir.FullName}/{Path.GetDirectoryName(mtl)}/{cleanName}");
+
+            mtlfile.Replace("\\", "/");
+
+            foreach (string ext in TextureExtensions)
+            {
+                if (File.Exists($"{mtlfile}{ext}"))
+                    return $"{mtlfile}{ext}".Replace("\\", "/");
+            }
+            
+            // check in textures sub-directory if we didn't find it
+            mtlfile.Replace(cleanName, $"textures/{cleanName}");
+            foreach (string ext in TextureExtensions)
+            {
+                if (File.Exists($"{mtlfile}{ext}"))
+                    return $"{mtlfile}{ext}".Replace("\\", "/");
+            }
+
+            Utils.Log(LogLevelEnum.Debug, "Could not find extension for material texture \"{0}\". Defaulting to .dds", mtlfile);
+            return $"{mtlfile}.dds".Replace("\\", "/");;
+        }
+
+        /// <summary>Takes the texture file name and returns just the file name with no extension</summary>
+        public static string CleanTexFileName(string cleanMe)
+        {
+            return Path.GetFileNameWithoutExtension(cleanMe);
+        }
+    }
+}

--- a/cgf-converter/cgf-converter.cs
+++ b/cgf-converter/cgf-converter.cs
@@ -3,8 +3,10 @@ using System.Threading;
 using System.Globalization;
 using CgfConverter;
 
+
 namespace CgfConverterConsole
 {
+
     public class Program
     {
         public static int Main(string[] args)
@@ -13,14 +15,6 @@ namespace CgfConverterConsole
             Utils.DebugLevel = LogLevelEnum.Debug;
 
             string oldTitle = Console.Title;
-
-#if DEV_DOLKENSP
-            Utils.LogLevel = LogLevelEnum.None;      // Display NO error logs
-            Utils.DebugLevel = LogLevelEnum.Debug;
-
-            args = new String[] { @"C:\Users\PeterDolkens\Downloads\SOC'n'destroy\socpak\pisces_int.soc", "-objectdir", @"C:\Users\PeterDolkens\Downloads\SOC'n'destroy\socpak", "-obj", "-outdir", @"C:\Users\PeterDolkens\Downloads\SOC'n'destroy\socpak\out" };
-
-#endif
 
 #if DEV_MARKEMP
             Utils.LogLevel = LogLevelEnum.Verbose; // Display ALL error logs in the console
@@ -122,10 +116,8 @@ namespace CgfConverterConsole
 
             Console.Title = oldTitle;
 
-#if (DEV_DOLKENSP || DEV_MARKEMP)
-            Console.WriteLine("Done...");
-            Console.ReadKey();
-#endif
+            Utils.Log(LogLevelEnum.Debug, "Done...");
+            
             return 0;
         }
     }

--- a/cgf-converter/cgf-converter.cs
+++ b/cgf-converter/cgf-converter.cs
@@ -3,10 +3,8 @@ using System.Threading;
 using System.Globalization;
 using CgfConverter;
 
-
 namespace CgfConverterConsole
 {
-
     public class Program
     {
         public static int Main(string[] args)


### PR DESCRIPTION
Rebased to make life easier. This replaces and obsoletes #68 and #67

Fixed path separator normalization for collada texture outputs. This will probably address #54. Absolute paths were be generated like so: `/I:\sc\full\Data/objects/spaceships/ships/aegs/textures/interior/atlas/retaliator_cockpit_atlas_diff_diff.dds` (notice the conflicting path separators) which would cause import issues with some tools (see Blender)

    Refactored material texture handling and discovery for collada output. Should be more robust.
    Added a -png option to use .png textures instead of .dds
    Added -loglevel parameter to control output levels and updated outputs to use Utils.Log
    Added a version number to the usage output

The last two are opinionated changes, feel free to reject and I'll go undo them.