### PR TITLE
Fix for issue #72, infinite hang while exporting IVO files.

### DIFF
--- a/CgfConverter/CryEngineCore/Chunks/ChunkIvoSkin_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkIvoSkin_900.cs
@@ -140,6 +140,9 @@ namespace CgfConverter.CryEngineCore.Chunks
                         bonemap.ID = 8;
                         model.ChunkMap.Add(bonemap.ID, bonemap);
                         break;
+                    default:
+                        b.BaseStream.Position = b.BaseStream.Position + 4;
+                        break;
                 }
             }
         }


### PR DESCRIPTION
Simple fix; forgot to advance the bytestream if there was no matching case.