### PR TITLE
Issue 54 better mtls

### DIFF
--- a/CgfConverter/CryEngine/CryEngine.cs
+++ b/CgfConverter/CryEngine/CryEngine.cs
@@ -257,10 +257,6 @@ namespace CgfConverter
                     default:
                         break;
                 }
-                //if (mtlChunk.MatType != MtlNameType.Library)
-                //{
-                Materials.Add(Material.CreateDefaultMaterial(mtlChunk.Name));
-                //}
             }
         }
 

--- a/CgfConverter/CryEngine/CryEngine.cs
+++ b/CgfConverter/CryEngine/CryEngine.cs
@@ -231,10 +231,10 @@ namespace CgfConverter
 
             foreach (ChunkMtlName mtlChunk in allMaterialChunks)
             {
-                if (mtlChunk.MatType != MtlNameType.Library)
-                {
-                    Materials.Add(Material.CreateDefaultMaterial(mtlChunk.Name));
-                }
+                //if (mtlChunk.MatType != MtlNameType.Library)
+                //{
+                Materials.Add(Material.CreateDefaultMaterial(mtlChunk.Name));
+                //}
             }
         }
 

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMtlName.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMtlName.cs
@@ -7,7 +7,7 @@
         /// <summary> Name of the Material </summary>
         public string Name { get; set; }
         public MtlNamePhysicsType[] PhysicsType { get; internal set; }
-        /// <summary> Number of Materials in this name (Max: 66) </summary>
+        /// <summary> Number of Materials in this MtlName (Max: 66) </summary>
         public uint NumChildren { get; internal set; }
         public uint[] ChildIDs { get; internal set; }
 

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMtlName.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMtlName.cs
@@ -10,6 +10,7 @@
         /// <summary> Number of Materials in this MtlName (Max: 66) </summary>
         public uint NumChildren { get; internal set; }
         public uint[] ChildIDs { get; internal set; }
+        public uint NFlags2 { get; internal set; }
 
         public override string ToString()
         {

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMtlName_744.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMtlName_744.cs
@@ -14,6 +14,7 @@ namespace CgfConverter.CryEngineCore
             NumChildren = b.ReadUInt32();
             PhysicsType = new MtlNamePhysicsType[NumChildren];
             MatType = NumChildren == 0 ? MtlNameType.Single : MtlNameType.Library;
+            NFlags2 = 0;
 
             for (int i = 0; i < NumChildren; i++)
             {

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMtlName_800.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMtlName_800.cs
@@ -11,7 +11,7 @@ namespace CgfConverter.CryEngineCore
 
             MatType = (MtlNameType)b.ReadUInt32();
             // if 0x01, then material lib.  If 0x12, mat name.  This is actually a bitstruct.
-            SkipBytes(b, 4);               // NFlags2
+            NFlags2 = b.ReadUInt32();               // NFlags2
             Name = b.ReadFString(128);
             PhysicsType = new MtlNamePhysicsType[] { (MtlNamePhysicsType)b.ReadUInt32() };
             NumChildren = b.ReadUInt32();

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMtlName_80000800.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMtlName_80000800.cs
@@ -11,7 +11,7 @@ namespace CgfConverter.CryEngineCore
 
             MatType = (MtlNameType)Utils.SwapUIntEndian(b.ReadUInt32());
             // if 0x01, then material lib.  If 0x12, mat name.  This is actually a bitstruct.
-            SkipBytes(b, 4);               // NFlags2
+            NFlags2 = b.ReadUInt32();               // NFlags2
             Name = b.ReadFString(128);
             PhysicsType = new MtlNamePhysicsType[] { (MtlNamePhysicsType)Utils.SwapUIntEndian(b.ReadUInt32()) };
 

--- a/CgfConverter/CryEngineCore/Material.cs
+++ b/CgfConverter/CryEngineCore/Material.cs
@@ -21,11 +21,7 @@ namespace CgfConverter.CryEngineCore
             public double Green;
             public double Blue;
 
-            /// <summary>
-            /// Deserialize a string into a Color object
-            /// </summary>
-            /// <param name="value"></param>
-            /// <returns></returns>
+            /// <summary>Deserialize a string into a Color object</summary>
             public static Color Deserialize(string value)
             {
                 if (string.IsNullOrWhiteSpace(value))
@@ -50,11 +46,7 @@ namespace CgfConverter.CryEngineCore
                 return buffer;
             }
 
-            /// <summary>
-            /// Serialize a Color object into a comma separated string list
-            /// </summary>
-            /// <param name="input"></param>
-            /// <returns></returns>
+            /// <summary>Serialize a Color object into a comma separated string list</summary>
             public static string Serialize(Color input)
             {
                 return (input == null) ? null : string.Format("{0},{1},{2}", input.Red, input.Green, input.Blue);
@@ -66,9 +58,7 @@ namespace CgfConverter.CryEngineCore
             }
         }
 
-        /// <summary>
-        /// The texture object
-        /// </summary>
+        /// <summary>The texture object</summary>
         [XmlRoot(ElementName = "Texture")]
         public class Texture
         {
@@ -113,35 +103,25 @@ namespace CgfConverter.CryEngineCore
                 }
             }
 
-            /// <summary>
-            /// Diffuse, Specular, Bumpmap, Environment, HeightMamp or Custom
-            /// </summary>
+            /// <summary>Diffuse, Specular, Bumpmap, Environment, HeightMamp or Custom</summary>
             [XmlIgnore]
             public MapTypeEnum Map { get; set; }
 
-            /// <summary>
-            /// Location of the texture
-            /// </summary>
+            /// <summary>Location of the texture</summary>
             [XmlAttribute(AttributeName = "File")]
             public string File { get; set; }
 
-            /// <summary>
-            /// The type of the texture
-            /// </summary>
+            /// <summary>The type of the texture</summary>
             [XmlAttribute(AttributeName = "TexType")]
             [DefaultValue(TypeEnum.Default)]
             public TypeEnum TexType;
 
-            /// <summary>
-            /// The modifier to apply to the texture
-            /// </summary>
+            /// <summary>The modifier to apply to the texture</summary>
             [XmlElement(ElementName = "TexMod")]
             public TextureModifier Modifier;
         }
 
-        /// <summary>
-        /// The texture modifier
-        /// </summary>
+        /// <summary>The texture modifier</summary>
         [XmlRoot(ElementName = "TexMod")]
         public class TextureModifier
         {
@@ -178,7 +158,6 @@ namespace CgfConverter.CryEngineCore
         /// <summary>
         /// After the textures
         /// General things that apply to the material
-        /// Not really needed
         /// </summary>
         [XmlRoot(ElementName = "PublicParams")]
         internal class PublicParameters
@@ -296,9 +275,7 @@ namespace CgfConverter.CryEngineCore
         [XmlIgnore]
         internal Color Emissive { get; set; }
 
-        /// <summary>
-        /// Value between 0 and 1 that controls opacity
-        /// </summary>
+        /// <summary>Value between 0 and 1 that controls opacity</summary>
         [XmlAttribute(AttributeName = "Opacity")]
         [DefaultValue(1)]
         public double Opacity { get; set; }

--- a/CgfConverter/Enums/Enums.cs
+++ b/CgfConverter/Enums/Enums.cs
@@ -119,6 +119,7 @@
         OBSTRUCT = 0x00000002,
         DEFAULTPROXY = 0x000000FF,  // this needs to be checked.  cgf.xml says 256; not sure if hex or dec
         UNKNOWN = 0x00001100,       // collision mesh?
+        UNKNOWN2 = 0x00001000
     }
 
     public enum LightType : uint         //complete

--- a/CgfConverterIntegrationTests/IntegrationTests/CgfConverterIntegrationTests.cs
+++ b/CgfConverterIntegrationTests/IntegrationTests/CgfConverterIntegrationTests.cs
@@ -28,6 +28,7 @@ namespace CgfConverterTests.IntegrationTests
             testUtils.GetSchemaSet();
         }
 
+
         [TestMethod]
         public void SimpleCubeSchemaValidation()
         {
@@ -40,6 +41,23 @@ namespace CgfConverterTests.IntegrationTests
         {
             testUtils.ValidateXml($@"{userHome}\OneDrive\ResourceFiles\simple_cube_bad.dae");
             Assert.AreEqual(1, testUtils.errors.Count);
+        }
+
+
+        [TestMethod]
+        public void brfl_rifle_NoMtlFilev802_CreatesDummyInstanceMaterial()
+        {
+            var args = new string[] { $@"{userHome}\OneDrive\ResourceFiles\brfl_fps_behr_p4ar_body.cgf", "-dds", "-dae" };
+            int result = testUtils.argsHandler.ProcessArgs(args);
+            Assert.AreEqual(0, result);
+            CryEngine cryData = new CryEngine(args[0], testUtils.argsHandler.DataDir.FullName);
+            cryData.ProcessCryengineFiles();
+
+            COLLADA colladaData = new COLLADA(testUtils.argsHandler, cryData);
+            colladaData.GenerateDaeObject();
+
+            int actualMaterialsCount = colladaData.DaeObject.Library_Materials.Material.Count();
+            Assert.AreEqual(17, actualMaterialsCount);
         }
 
         [TestMethod]

--- a/CgfConverterIntegrationTests/IntegrationTests/CgfConverterIntegrationTests.cs
+++ b/CgfConverterIntegrationTests/IntegrationTests/CgfConverterIntegrationTests.cs
@@ -145,7 +145,7 @@ namespace CgfConverterTests.IntegrationTests
             colladaData.GenerateDaeObject();
 
             int actualMaterialsCount = colladaData.DaeObject.Library_Materials.Material.Count();
-            Assert.AreEqual(0, actualMaterialsCount);
+            Assert.AreEqual(15, actualMaterialsCount);
 
             testUtils.ValidateColladaXml(colladaData);
         }
@@ -163,7 +163,7 @@ namespace CgfConverterTests.IntegrationTests
             colladaData.GenerateDaeObject();
 
             int actualMaterialsCount = colladaData.DaeObject.Library_Materials.Material.Count();
-            Assert.AreEqual(0, actualMaterialsCount);
+            Assert.AreEqual(2, actualMaterialsCount);
 
             testUtils.ValidateColladaXml(colladaData);
         }
@@ -181,7 +181,7 @@ namespace CgfConverterTests.IntegrationTests
             colladaData.GenerateDaeObject();
 
             int actualMaterialsCount = colladaData.DaeObject.Library_Materials.Material.Count();
-            Assert.AreEqual(0, actualMaterialsCount);
+            Assert.AreEqual(3, actualMaterialsCount);
 
             testUtils.ValidateColladaXml(colladaData);
         }
@@ -199,7 +199,7 @@ namespace CgfConverterTests.IntegrationTests
             colladaData.GenerateDaeObject();
 
             int actualMaterialsCount = colladaData.DaeObject.Library_Materials.Material.Count();
-            Assert.AreEqual(0, actualMaterialsCount);
+            Assert.AreEqual(5, actualMaterialsCount);
 
             testUtils.ValidateColladaXml(colladaData);
         }
@@ -226,9 +226,7 @@ namespace CgfConverterTests.IntegrationTests
             colladaData.GenerateDaeObject();
 
             int actualMaterialsCount = colladaData.DaeObject.Library_Materials.Material.Count();
-            Assert.AreEqual(0, actualMaterialsCount);
-
-            //Assert.AreEqual();
+            Assert.AreEqual(2, actualMaterialsCount);
 
             testUtils.ValidateColladaXml(colladaData);
         }
@@ -246,7 +244,7 @@ namespace CgfConverterTests.IntegrationTests
             colladaData.GenerateDaeObject();
 
             int actualMaterialsCount = colladaData.DaeObject.Library_Materials.Material.Count();
-            Assert.AreEqual(0, actualMaterialsCount);
+            Assert.AreEqual(1, actualMaterialsCount);
 
             testUtils.ValidateColladaXml(colladaData);
         }

--- a/CgfConverterIntegrationTests/IntegrationTests/CrucibleTests/CrucibleTests.cs
+++ b/CgfConverterIntegrationTests/IntegrationTests/CrucibleTests/CrucibleTests.cs
@@ -48,7 +48,7 @@ namespace CgfConverterTests.IntegrationTests.Crucible
             COLLADA colladaData = new COLLADA(testUtils.argsHandler, cryData);
             colladaData.GenerateDaeObject();
             int actualMaterialsCount = colladaData.DaeObject.Library_Materials.Material.Count();
-            Assert.AreEqual(1, actualMaterialsCount);
+            Assert.AreEqual(0, actualMaterialsCount);
             testUtils.ValidateColladaXml(colladaData);
         }
     }

--- a/CgfConverterIntegrationTests/IntegrationTests/Hunt/HuntIntegrationTests.cs
+++ b/CgfConverterIntegrationTests/IntegrationTests/Hunt/HuntIntegrationTests.cs
@@ -39,7 +39,7 @@ namespace CgfConverterTests.IntegrationTests.Hunt
             colladaData.GenerateDaeObject();
 
             int actualMaterialsCount = colladaData.DaeObject.Library_Materials.Material.Count();
-            Assert.AreEqual(0, actualMaterialsCount);  // Need to figure out material chunks
+            Assert.AreEqual(5, actualMaterialsCount);  // Need to figure out material chunks
 
             // Visual Scene Check
             Assert.AreEqual("Scene", daeObject.Scene.Visual_Scene.Name);
@@ -102,7 +102,7 @@ namespace CgfConverterTests.IntegrationTests.Hunt
             colladaData.GenerateDaeObject();
 
             int actualMaterialsCount = colladaData.DaeObject.Library_Materials.Material.Count();
-            Assert.AreEqual(0, actualMaterialsCount);   // Need to figure out material chunks
+            Assert.AreEqual(5, actualMaterialsCount);   // Need to figure out material chunks
 
             // Visual Scene Check
             Assert.AreEqual("Scene", daeObject.Scene.Visual_Scene.Name);


### PR DESCRIPTION
When a model has a material name chunk with ver 0x802 and the material file could not be found, the Collada exporter would create empty <instance_material /> elements.  This wasn't valid XML and would fail to import in Blender.

Now when the material isn't found, it creates dummy materials for each child element.  

NOTE:  The material mapping to the geometry doesn't look right.