### PR TITLE
Add additional flags to filter physics and material proxies

### DIFF
--- a/CgfConverter/Renderers/BaseRenderer.cs
+++ b/CgfConverter/Renderers/BaseRenderer.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace CgfConverter
 {
@@ -47,6 +48,33 @@ namespace CgfConverter
             }
 
             return outputFile;
+        }
+
+        public bool IsNodeNameExcluded(String nodeName)
+        {
+            foreach (var excname in Args.ExcludeNodeNames)
+            {
+                if (nodeName.ToLower().StartsWith(excname.ToLower()))
+                {
+                    Utils.Log(LogLevelEnum.Debug, $"Node matched excludename '{excname}'");
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool IsMeshMaterialExcluded(String materialName)
+        {
+            foreach (var excname in Args.ExcludeMaterialNames)
+            {
+                if (materialName.ToLower().StartsWith(excname.ToLower()))
+                {
+                    Utils.Log(LogLevelEnum.Debug, $"Material name matched excludemat '{excname}'");
+                    return true;
+                }
+            }
+            return false;
         }
     }
 }

--- a/CgfConverter/Renderers/Collada/COLLADA.cs
+++ b/CgfConverter/Renderers/Collada/COLLADA.cs
@@ -577,6 +577,22 @@ namespace CgfConverter
                             floatArrayNormals.Digits = 6;
                             floatArrayNormals.Magnitude = 38;
                             floatArrayNormals.Count = (int)tmpVertsUVs.NumElements * 3;
+                            floatArrayColors.ID = colorSource.ID + "-array";
+                            floatArrayColors.Digits = 6;
+                            floatArrayColors.Magnitude = 38;
+                            if (tmpVertsUVs.Colors != null)
+                            {
+                                floatArrayColors.Count = (int)tmpVertsUVs.Colors.Count() * 4;
+                                for (uint j = 0; j < tmpVertsUVs.Colors.Count(); j++)  // Create Colors string
+                                {
+                                    colorString.AppendFormat(culture, "{0:F6} {1:F6} {2:F6} {3:F6} ",
+                                        tmpVertsUVs.Colors[j].r / 255.0,
+                                        tmpVertsUVs.Colors[j].g / 255.0,
+                                        tmpVertsUVs.Colors[j].b / 255.0,
+                                        tmpVertsUVs.Colors[j].a / 255.0);
+                                }
+                            }
+
                             // Create Vertices and normals string
                             for (uint j = 0; j < tmpMeshChunk.NumVertices; j++)
                             {

--- a/CgfConverter/Renderers/Collada/COLLADA.cs
+++ b/CgfConverter/Renderers/Collada/COLLADA.cs
@@ -430,24 +430,9 @@ namespace CgfConverter
                 ChunkDataStream tmpColors = null;
                 ChunkDataStream tmpTangents = null;
 
-                // Don't render shields if skip flag enabled
-                if (Args.SkipShieldNodes && nodeChunk.Name.ToLower().StartsWith("$shield"))
+                if (IsNodeNameExcluded(nodeChunk.Name))
                 {
-                    Utils.Log(LogLevelEnum.Debug, "Skipped shields node {0}", nodeChunk.Name);
-                    continue;
-                }
-
-                // Don't render proxies if skip flag enabled
-                if (Args.SkipProxyNodes && nodeChunk.Name.ToLower().StartsWith("proxy"))
-                {
-                    Utils.Log(LogLevelEnum.Debug, "Skipped proxy node {0}", nodeChunk.Name);
-                    continue;
-                }
-                
-                // Don't render SC physicss proxies if skip flag enabled
-                if (Args.SkipPhysicsProxyNodes && nodeChunk.Name.ToLower().StartsWith("$physics_proxy"))
-                {
-                    Utils.Log(LogLevelEnum.Debug, "Skipped physics proxy node {0}", nodeChunk.Name);
+                    Utils.Log(LogLevelEnum.Debug, $"Excluding node {nodeChunk.Name}");
                     continue;
                 }
 
@@ -690,18 +675,6 @@ namespace CgfConverter
                                 Count = tmpMeshSubsets.MeshSubsets[j].NumIndices / 3
                             };
                             
-                            if (Args.SkipProxyMaterials)
-                            {
-                                if (CryData.Materials.Count > 0 && tmpMeshSubsets.MeshSubsets[j].MatID < CryData.Materials.Count)
-                                {
-                                    if (CryData.Materials[(int) tmpMeshSubsets.MeshSubsets[j].MatID].Name.ToLower() == "proxy")
-                                    {
-                                        Utils.Log(LogLevelEnum.Debug, $"Skipped proxy mesh {tmpGeo.Name}.triangles[{j}]");
-                                        continue;
-                                    }
-                                }
-                            }
-                            
                             if (CryData.Materials.Count != 0)
                             {
                                 if (tmpMeshSubsets.MeshSubsets[j].MatID > CryData.Materials.Count - 1)
@@ -711,6 +684,12 @@ namespace CgfConverter
                                     tmpMeshSubsets.MeshSubsets[j].MatID = 0;  
                                 }
                                 string MatName = CryData.Materials[tmpMeshSubsets.MeshSubsets[j].MatID].Name;
+                                if (IsMeshMaterialExcluded(MatName))
+                                {
+                                    Utils.Log(LogLevelEnum.Debug, $"Excluding mesh {tmpGeo.Name}.triangles[{j}] with material {MatName}");
+                                    continue;
+                                }
+                                
                                 if (Args.PrefixMaterialNames)
                                     MatName = CryData.Materials[tmpMeshSubsets.MeshSubsets[j].MatID].SourceFileName + "_" + MatName;
 
@@ -1385,8 +1364,9 @@ namespace CgfConverter
                 List<Grendgine_Collada_Node> childNodes = new List<Grendgine_Collada_Node>();
                 foreach (ChunkNode childNodeChunk in nodeChunk.AllChildNodes.ToList())
                 {
-                    if (Args.SkipPhysicsProxyNodes && childNodeChunk.Name.ToLower().StartsWith("$physics_proxy"))
+                    if (IsNodeNameExcluded(childNodeChunk.Name))
                     {
+                        Utils.Log(LogLevelEnum.Debug, $"Excluding child node {childNodeChunk.Name}");
                         continue;
                     }
 

--- a/CgfConverter/Renderers/Collada/COLLADA.cs
+++ b/CgfConverter/Renderers/Collada/COLLADA.cs
@@ -399,16 +399,23 @@ namespace CgfConverter
                 ChunkDataStream tmpTangents = null;
 
                 // Don't render shields if skip flag enabled
-                if (Args.SkipShieldNodes && nodeChunk.Name.StartsWith("$shield"))
+                if (Args.SkipShieldNodes && nodeChunk.Name.ToLower().StartsWith("$shield"))
                 {
                     Utils.Log(LogLevelEnum.Debug, "Skipped shields node {0}", nodeChunk.Name);
                     continue;
                 }
 
                 // Don't render proxies if skip flag enabled
-                if (Args.SkipProxyNodes && nodeChunk.Name.StartsWith("proxy"))
+                if (Args.SkipProxyNodes && nodeChunk.Name.ToLower().StartsWith("proxy"))
                 {
                     Utils.Log(LogLevelEnum.Debug, "Skipped proxy node {0}", nodeChunk.Name);
+                    continue;
+                }
+                
+                // Don't render SC physicss proxies if skip flag enabled
+                if (Args.SkipPhysicsProxyNodes && nodeChunk.Name.ToLower().StartsWith("$physics_proxy"))
+                {
+                    Utils.Log(LogLevelEnum.Debug, "Skipped physics proxy node {0}", nodeChunk.Name);
                     continue;
                 }
 
@@ -642,6 +649,13 @@ namespace CgfConverter
                         for (uint j = 0; j < tmpMeshSubsets.NumMeshSubset; j++) // Need to make a new Triangles entry for each submesh.
                         {
                             triangles[j] = new Grendgine_Collada_Triangles();
+
+                            if (Args.SkipProxyMaterials && CryData.Materials[(int) tmpMeshSubsets.MeshSubsets[j].MatID].Name.ToLower() == "proxy")
+                            {
+                                Utils.Log(LogLevelEnum.Debug, $"Skipped proxy mesh {tmpGeo.Name}.triangles[{j}]");
+                                continue;
+                            }
+                            
                             triangles[j].Count = (int)tmpMeshSubsets.MeshSubsets[j].NumIndices / 3;
 
                             if (CryData.Materials.Count != 0)
@@ -1261,6 +1275,11 @@ namespace CgfConverter
                 List<Grendgine_Collada_Node> childNodes = new List<Grendgine_Collada_Node>();
                 foreach (ChunkNode childNodeChunk in nodeChunk.AllChildNodes.ToList())
                 {
+                    if (Args.SkipPhysicsProxyNodes && childNodeChunk.Name.ToLower().StartsWith("$physics_proxy"))
+                    {
+                        continue;
+                    }
+
                     Grendgine_Collada_Node childNode = CreateNode(childNodeChunk); ;
                     childNodes.Add(childNode);
                 }

--- a/CgfConverter/Renderers/Collada/COLLADA.cs
+++ b/CgfConverter/Renderers/Collada/COLLADA.cs
@@ -648,12 +648,19 @@ namespace CgfConverter
 
                         for (uint j = 0; j < tmpMeshSubsets.NumMeshSubset; j++) // Need to make a new Triangles entry for each submesh.
                         {
+                            
                             triangles[j] = new Grendgine_Collada_Triangles();
-
-                            if (Args.SkipProxyMaterials && CryData.Materials[(int) tmpMeshSubsets.MeshSubsets[j].MatID].Name.ToLower() == "proxy")
+                            
+                            if (Args.SkipProxyMaterials)
                             {
-                                Utils.Log(LogLevelEnum.Debug, $"Skipped proxy mesh {tmpGeo.Name}.triangles[{j}]");
-                                continue;
+                                if (CryData.Materials.Count > 0 && tmpMeshSubsets.MeshSubsets[j].MatID < CryData.Materials.Count)
+                                {
+                                    if (CryData.Materials[(int) tmpMeshSubsets.MeshSubsets[j].MatID].Name.ToLower() == "proxy")
+                                    {
+                                        Utils.Log(LogLevelEnum.Debug, $"Skipped proxy mesh {tmpGeo.Name}.triangles[{j}]");
+                                        continue;
+                                    }
+                                }
                             }
                             
                             triangles[j].Count = (int)tmpMeshSubsets.MeshSubsets[j].NumIndices / 3;

--- a/CgfConverter/Renderers/Wavefront/Wavefront.cs
+++ b/CgfConverter/Renderers/Wavefront/Wavefront.cs
@@ -76,16 +76,23 @@ namespace CgfConverter
                 foreach (CryEngineCore.ChunkNode node in this.CryData.NodeMap.Values)
                 {
                     // Don't render shields
-                    if (this.Args.SkipShieldNodes && node.Name.StartsWith("$shield"))
+                    if (this.Args.SkipShieldNodes && node.Name.ToLower().StartsWith("$shield"))
                     {
                         Utils.Log(LogLevelEnum.Debug, "Skipped shields node {0}", node.Name);
                         continue;
                     }
 
                     // Don't render shields
-                    if (this.Args.SkipProxyNodes && node.Name.StartsWith("proxy"))
+                    if (this.Args.SkipProxyNodes && node.Name.ToLower().StartsWith("proxy"))
                     {
                         Utils.Log(LogLevelEnum.Debug, "Skipped proxy node {0}", node.Name);
+                        continue;
+                    }
+
+                    // Don't render physics proxies
+                    if (this.Args.SkipProxyNodes && node.Name.ToLower().StartsWith("$physics_proxy"))
+                    {
+                        Utils.Log(LogLevelEnum.Debug, "Skipped physics proxy node {0}", node.Name);
                         continue;
                     }
 

--- a/CgfConverter/Renderers/Wavefront/Wavefront.cs
+++ b/CgfConverter/Renderers/Wavefront/Wavefront.cs
@@ -75,24 +75,9 @@ namespace CgfConverter
 
                 foreach (CryEngineCore.ChunkNode node in this.CryData.NodeMap.Values)
                 {
-                    // Don't render shields
-                    if (this.Args.SkipShieldNodes && node.Name.ToLower().StartsWith("$shield"))
+                    if (IsNodeNameExcluded(node.Name))
                     {
-                        Utils.Log(LogLevelEnum.Debug, "Skipped shields node {0}", node.Name);
-                        continue;
-                    }
-
-                    // Don't render shields
-                    if (this.Args.SkipProxyNodes && node.Name.ToLower().StartsWith("proxy"))
-                    {
-                        Utils.Log(LogLevelEnum.Debug, "Skipped proxy node {0}", node.Name);
-                        continue;
-                    }
-
-                    // Don't render physics proxies
-                    if (this.Args.SkipProxyNodes && node.Name.ToLower().StartsWith("$physics_proxy"))
-                    {
-                        Utils.Log(LogLevelEnum.Debug, "Skipped physics proxy node {0}", node.Name);
+                        Utils.Log(LogLevelEnum.Debug, $"Excluding node {node.Name}");
                         continue;
                     }
 

--- a/CgfConverter/Services/ArgsHandler.cs
+++ b/CgfConverter/Services/ArgsHandler.cs
@@ -379,14 +379,14 @@ namespace CgfConverter
             Console.WriteLine();
             Console.WriteLine("-smooth:          Smooth Faces.");
             Console.WriteLine("-group:           Group meshes into single model.");
-            Console.WriteLine("-prefixmatnames:  Prefixes material names with the filename of the source mtl file.");
-            Console.WriteLine("-excludenode <nodename>:");
+            Console.WriteLine("-en/-excludenode <nodename>:");
             Console.WriteLine("                  Exclude nodes starting with <nodename> from rendering. Can be listed multiple times.");
-            Console.WriteLine("-excludemat <material_name>:");
+            Console.WriteLine("-em/-excludemat <material_name>:");
             Console.WriteLine("                  Exclude meshes with the material <material_name> from rendering. Can be listed multiple times.");
             Console.WriteLine("-noconflict:      Use non-conflicting naming scheme (<cgf File>_out.obj)");
             Console.WriteLine("-allowconflict:   Allows conflicts in .mtl file name. (obj exports only, as not an issue in dae.)");
             Console.WriteLine();
+            Console.WriteLine("-prefixmatnames:  Prefixes material names with the filename of the source mtl file.");
             Console.WriteLine("-notex:           Do not include textures in outputs");
             Console.WriteLine("-tif:             Change the materials to look for .tif files instead of .dds.");
             Console.WriteLine("-png:             Change the materials to look for .png files instead of .dds.");

--- a/CgfConverter/Services/ArgsHandler.cs
+++ b/CgfConverter/Services/ArgsHandler.cs
@@ -45,10 +45,14 @@ namespace CgfConverter
         public bool TgaTextures { get; internal set; }
         /// <summary>Flag used to indicate that textures should not be included in the output file</summary>
         public bool NoTextures { get; internal set; }
-        /// <summary>Flag used to skip the rendering of nodes containing $shield</summary>
+        /// <summary>Flag used to skip the rendering of nodes starting with $shield</summary>
         public bool SkipShieldNodes { get; internal set; }
-        /// <summary>Flag used to skip the rendering of nodes containing $proxy</summary>
+        /// <summary>Flag used to skip the rendering of nodes starting with proxy</summary>
         public bool SkipProxyNodes { get; internal set; }
+        /// <summary>Flag used to skip the rendering of nodes with the proxy-material</summary>
+        public bool SkipProxyMaterials { get; internal set; }
+        /// <summary>Flag used to skip the rendering of nodes starting with $physics_proxy</summary>
+        public bool SkipPhysicsProxyNodes { get; internal set; }
         /// <summary>Flag used to pass exceptions to installed debuggers</summary>
         public bool Throw { get; internal set; }
         public bool DumpChunkInfo { get; internal set; }
@@ -214,11 +218,32 @@ namespace CgfConverter
                     #region case "-skipproxy"...
 
                     case "-skipproxy":
+                    case "-skipproxies":
 
                         SkipProxyNodes = true;
 
                         break;
 
+                    #endregion
+                    #region case "-skipproxymats"...
+
+                    case "-skipproxymat":
+                    case "-skipproxymats":
+
+                        SkipProxyMaterials = true;
+
+                        break;
+
+                    #endregion
+                    #region case "-skipphysproxy"...
+                    
+                    case "-skipphysproxy":
+                    case "-skipphysproxies":
+                        
+                        SkipPhysicsProxyNodes = true;
+                        
+                        break;
+                    
                     #endregion
                     #region case "-group"...
 
@@ -312,6 +337,14 @@ namespace CgfConverter
                 Utils.Log(LogLevelEnum.Info, "Allow conflicts for mtl files enabled");
             if (NoConflicts)
                 Utils.Log(LogLevelEnum.Info, "Prevent conflicts for mtl files enabled");
+            if (SkipShieldNodes)
+                Utils.Log(LogLevelEnum.Info, "Skipping shield nodes");
+            if (SkipProxyNodes)
+                Utils.Log(LogLevelEnum.Info, "Skipping proxy nodes");
+            if (SkipProxyMaterials)
+                Utils.Log(LogLevelEnum.Info, "Skipping meshes with the proxy material");
+            if (SkipPhysicsProxyNodes)
+                Utils.Log(LogLevelEnum.Info, "Skipping physics proxy nodes");
             if (DumpChunkInfo)
                 Utils.Log(LogLevelEnum.Info, "Output chunk info for missing or invalid chunks.");
             if (Throw)
@@ -338,7 +371,7 @@ namespace CgfConverter
         public static void PrintUsage()
         {
             Console.WriteLine();
-            Console.WriteLine("cgf-converter [-usage] | <.cgf file> [-outputfile <output file>] [-obj] [-blend] [-dae] [-tif/-png] [-group] [-smooth] [-loglevel <LogLevel>] [-throw] [-dump] [-objectdir <ObjectDir>]");
+            Console.WriteLine("cgf-converter [-usage] | <.cgf file> [-outputfile <output file>] [-obj] [-blend] [-dae] [-notex/-png/-tif/-tga] [-group] [-skipshield] [-skipproxy] [-skipproxymat] [-skipphyproxy] [-smooth] [-loglevel <LogLevel>] [-throw] [-dump] [-objectdir <ObjectDir>]");
             Console.WriteLine();
             Console.WriteLine($"CryEngine Converter v{Assembly.GetExecutingAssembly().GetName().Version}");
             Console.WriteLine();
@@ -354,6 +387,11 @@ namespace CgfConverter
             Console.WriteLine("-blend:           Export Blender format files (Not Implemented).");
             Console.WriteLine("-fbx:             Export FBX format files (Not Implemented).");
             Console.WriteLine("-smooth:          Smooth Faces.");
+            Console.WriteLine("-group:           Group meshes into single model.");
+            Console.WriteLine("-skipshield:      Skip the rendering of nodes starting with $shield.");
+            Console.WriteLine("-skipproxy:       Skip the rendering of nodes starting with proxy.");
+            Console.WriteLine("-skipproxymat:    Skip the rendering of meshes with the proxy material.");
+            Console.WriteLine("-skipphysproxy:   Skip the rendering of nodes starting with $pyhsics_proxy.");
             Console.WriteLine("-group:           Group meshes into single model.");
             Console.WriteLine();
             Console.WriteLine("-notex:           Do not include textures in outputs");

--- a/CgfConverter/Services/ArgsHandler.cs
+++ b/CgfConverter/Services/ArgsHandler.cs
@@ -362,7 +362,7 @@ namespace CgfConverter
         public static void PrintUsage()
         {
             Console.WriteLine();
-            Console.WriteLine("cgf-converter [-usage] | <.cgf file> [-outputfile <output file>] [-obj] [-blend] [-dae] [-notex/-png/-tif/-tga] [-group] [-skipshield] [-skipproxy] [-skipproxymat] [-skipphyproxy] [-smooth] [-loglevel <LogLevel>] [-throw] [-dump] [-objectdir <ObjectDir>]");
+            Console.WriteLine("cgf-converter [-usage] | <.cgf file> [-outputfile <output file>] [-dae] [-obj] [-notex/-png/-tif/-tga] [-group] [-excludenode <nodename>] [-excludemat <matname>] [-loglevel <LogLevel>] [-throw] [-dump] [-objectdir <ObjectDir>]");
             Console.WriteLine();
             Console.WriteLine($"CryEngine Converter v{Assembly.GetExecutingAssembly().GetName().Version}");
             Console.WriteLine();
@@ -370,13 +370,13 @@ namespace CgfConverter
             Console.WriteLine();
             Console.WriteLine("<.cgf file>:      The name of the .cgf, .cga or .skin file to process.");
             Console.WriteLine("-outputfile:      The name of the file to write the output.  Default is [root].dae");
-            Console.WriteLine("-noconflict:      Use non-conflicting naming scheme (<cgf File>_out.obj)");
-            Console.WriteLine("-allowconflict:   Allows conflicts in .mtl file name. (obj exports only, as not an issue in dae.)");
             Console.WriteLine("-objectdir:       The name where the base Objects directory is located.  Used to read mtl file.");
             Console.WriteLine("                  Defaults to current directory.");
             Console.WriteLine("-dae:             Export Collada format files (Default).");
+            Console.WriteLine("-obj:             Export Wavefront format files (Not supported).");
             Console.WriteLine("-blend:           Export Blender format files (Not Implemented).");
             Console.WriteLine("-fbx:             Export FBX format files (Not Implemented).");
+            Console.WriteLine();
             Console.WriteLine("-smooth:          Smooth Faces.");
             Console.WriteLine("-group:           Group meshes into single model.");
             Console.WriteLine("-prefixmatnames:  Prefixes material names with the filename of the source mtl file.");
@@ -384,6 +384,8 @@ namespace CgfConverter
             Console.WriteLine("                  Exclude nodes starting with <nodename> from rendering. Can be listed multiple times.");
             Console.WriteLine("-excludemat <material_name>:");
             Console.WriteLine("                  Exclude meshes with the material <material_name> from rendering. Can be listed multiple times.");
+            Console.WriteLine("-noconflict:      Use non-conflicting naming scheme (<cgf File>_out.obj)");
+            Console.WriteLine("-allowconflict:   Allows conflicts in .mtl file name. (obj exports only, as not an issue in dae.)");
             Console.WriteLine();
             Console.WriteLine("-notex:           Do not include textures in outputs");
             Console.WriteLine("-tif:             Change the materials to look for .tif files instead of .dds.");


### PR DESCRIPTION
Post-processing large models to remove `$physics_proxy` objects and meshes with the `proxy` material adds a considerable amount of time in Blender. Solution? Add a flag to not generate them in the first place!

I'm considering this a WIP as I'd like feedback on if the other `-skip` flags were not included in the usage information for a good reason, and also the best place to implement `-skipproxymat` for wavefronts (currently not implemented).

