### PR TITLE
Fix for missing Vertex Colors in DataStream_800 Star Citizen files, & Optional Material Name Prefix

### DIFF
--- a/CgfConverter/CryEngine/CryEngine.cs
+++ b/CgfConverter/CryEngine/CryEngine.cs
@@ -284,7 +284,10 @@ namespace CgfConverter
 
                 if (material.SubMaterials != null)
                     foreach (var subMaterial in material.SubMaterials.SelectMany(m => FlattenMaterials(m)))
+                    {
+                        subMaterial.SourceFileName = material.SourceFileName;
                         yield return subMaterial;
+                    }
             }
         }
 

--- a/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_800.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_800.cs
@@ -232,23 +232,7 @@ namespace CgfConverter.CryEngineCore
                                     SkipBytes(b, 2);
                                     //Vertices[i].W = b.ReadCryHalf();
 
-                                    // Read a Quat, convert it to vector3
-                                    //Vector4 quat = new Vector4();
-                                    //quat.X = b.ReadSByte() / 127.5f;
-                                    //quat.Y = b.ReadSByte() / 127.5f;
-                                    //quat.Z = b.ReadSByte() / 127.5f;
-                                    //quat.W = b.ReadSByte() / 127.5f;
-                                    //Normals[i].X = (2 * (quat.X * quat.Z + quat.Y * quat.W));
-                                    //Normals[i].Y = (2 * (quat.Y * quat.Z - quat.X * quat.W));
-                                    //Normals[i].Z = (2 * (quat.Z * quat.Z + quat.W * quat.W)) - 1;
-
-                                    IRGBA color = new IRGBA();
-                                    color.r = b.ReadByte();
-                                    color.g = b.ReadByte();
-                                    color.b = b.ReadByte();
-                                    color.a = b.ReadByte();
-
-                                    Colors[i] = color;
+                                    Colors[i] = b.ReadColor();
 
                                     // UVs ABSOLUTELY should use the Half structures.
                                     UVs[i].U = b.ReadHalf();

--- a/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_800.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_800.cs
@@ -151,9 +151,9 @@ namespace CgfConverter.CryEngineCore
                                 Tangents[i, 1].z = b.ReadSByte() / 127;
 
                                 // Calculate the normal based on the cross product of the tangents.
-                                //Normals[i].x = (Tangents[i,0].y * Tangents[i,1].z - Tangents[i,0].z * Tangents[i,1].y);
-                                //Normals[i].y = 0 - (Tangents[i,0].x * Tangents[i,1].z - Tangents[i,0].z * Tangents[i,1].x); 
-                                //Normals[i].z = (Tangents[i,0].x * Tangents[i,1].y - Tangents[i,0].y * Tangents[i,1].x);
+                                Normals[i].X = (Tangents[i,0].y * Tangents[i,1].z - Tangents[i,0].z * Tangents[i,1].y);
+                                Normals[i].Y = 0 - (Tangents[i,0].x * Tangents[i,1].z - Tangents[i,0].z * Tangents[i,1].x); 
+                                Normals[i].Z = (Tangents[i,0].x * Tangents[i,1].y - Tangents[i,0].y * Tangents[i,1].x);
                                 break;
                             default:
                                 throw new Exception("Need to add new Tangent Size");
@@ -201,12 +201,12 @@ namespace CgfConverter.CryEngineCore
 
                 case DatastreamType.VERTSUVS:
                     Vertices = new Vector3[NumElements];
-                    Normals = new Vector3[NumElements];
                     Colors = new IRGBA[NumElements];
                     UVs = new UV[NumElements];
                     switch (BytesPerElement)  // new Star Citizen files
                     {
                         case 20:  // Dymek's code.  3 floats for vertex position, 4 bytes for normals, 2 halfs for UVs.  Normals are calculated from Tangents
+                            Normals = new Vector3[NumElements];
                             for (int i = 0; i < NumElements; i++)
                             {
                                 Vertices[i] = b.ReadVector3(); // For some reason, skins are an extra 1 meter in the z direction.
@@ -257,6 +257,7 @@ namespace CgfConverter.CryEngineCore
                             }
                             else
                             {
+                                Normals = new Vector3[NumElements];
                                 // Legacy version using Halfs (Also Hunt models)
                                 for (int i = 0; i < NumElements; i++)
                                 {

--- a/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_800.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_800.cs
@@ -233,14 +233,22 @@ namespace CgfConverter.CryEngineCore
                                     //Vertices[i].W = b.ReadCryHalf();
 
                                     // Read a Quat, convert it to vector3
-                                    Vector4 quat = new Vector4();
-                                    quat.X = b.ReadSByte() / 127.5f;
-                                    quat.Y = b.ReadSByte() / 127.5f;
-                                    quat.Z = b.ReadSByte() / 127.5f;
-                                    quat.W = b.ReadSByte() / 127.5f;
-                                    Normals[i].X = (2 * (quat.X * quat.Z + quat.Y * quat.W));
-                                    Normals[i].Y = (2 * (quat.Y * quat.Z - quat.X * quat.W));
-                                    Normals[i].Z = (2 * (quat.Z * quat.Z + quat.W * quat.W)) - 1;
+                                    //Vector4 quat = new Vector4();
+                                    //quat.X = b.ReadSByte() / 127.5f;
+                                    //quat.Y = b.ReadSByte() / 127.5f;
+                                    //quat.Z = b.ReadSByte() / 127.5f;
+                                    //quat.W = b.ReadSByte() / 127.5f;
+                                    //Normals[i].X = (2 * (quat.X * quat.Z + quat.Y * quat.W));
+                                    //Normals[i].Y = (2 * (quat.Y * quat.Z - quat.X * quat.W));
+                                    //Normals[i].Z = (2 * (quat.Z * quat.Z + quat.W * quat.W)) - 1;
+
+                                    IRGBA color = new IRGBA();
+                                    color.r = b.ReadByte();
+                                    color.g = b.ReadByte();
+                                    color.b = b.ReadByte();
+                                    color.a = b.ReadByte();
+
+                                    Colors[i] = color;
 
                                     // UVs ABSOLUTELY should use the Half structures.
                                     UVs[i].U = b.ReadHalf();

--- a/CgfConverter/CryEngineCore/Chunks/ChunkDatastream_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkDatastream_900.cs
@@ -86,7 +86,6 @@ namespace CgfConverter.CryEngineCore
                 #region IVONORMALS
                 case DatastreamType.IVONORMALS:
                 case DatastreamType.IVONORMALS2:
-                case DatastreamType.IVONORMALS3:
                     switch (BytesPerElement)
                     {
                         case 4:
@@ -114,6 +113,9 @@ namespace CgfConverter.CryEngineCore
                             }
                             break;
                     }
+                    break;
+                case DatastreamType.IVONORMALS3:
+                    // Skip for now...
                     break;
                 #endregion
                 #region IVOTANGENTS

--- a/CgfConverter/CryEngineCore/Material.cs
+++ b/CgfConverter/CryEngineCore/Material.cs
@@ -210,6 +210,9 @@ namespace CgfConverter.CryEngineCore
 
         #region Attributes
 
+        [XmlIgnore]
+        internal string SourceFileName { get; set; }
+
         [XmlAttribute(AttributeName = "Name")]
         [DefaultValue("")]
         public string Name { get; set; }
@@ -325,7 +328,9 @@ namespace CgfConverter.CryEngineCore
             {
                 using (Stream fileStream = materialfile.OpenRead())
                 {
-                    return HoloXPLOR.DataForge.CryXmlSerializer.Deserialize<Material>(fileStream);
+                    Material fileData = HoloXPLOR.DataForge.CryXmlSerializer.Deserialize<Material>(fileStream);
+                    fileData.SourceFileName = materialfile.Name.Replace('.', '_');
+                    return fileData;
                 }
             }
             catch (Exception ex)

--- a/CgfConverter/Renderers/Collada/COLLADA.cs
+++ b/CgfConverter/Renderers/Collada/COLLADA.cs
@@ -588,7 +588,7 @@ namespace CgfConverter
                             {
                                 Vector3 vertex = (tmpVertices.Vertices[j]);
                                 vertString.AppendFormat(culture, "{0:F6} {1:F6} {2:F6} ", vertex.X, vertex.Y, vertex.Z);
-                                Vector3 normal = tmpNormals?.Normals[j] ?? new Vector3(0.0f, 0.0f, 0.0f);
+                                Vector3 normal = tmpNormals?.Normals[j] ?? tmpTangents?.Normals[j] ?? new Vector3(0.0f, 0.0f, 0.0f);
                                 normString.AppendFormat(culture, "{0:F6} {1:F6} {2:F6} ", safe(normal.X), safe(normal.Y), safe(normal.Z));
                             }
                             for (uint j = 0; j < tmpUVs.NumElements; j++)     // Create UV string
@@ -650,7 +650,14 @@ namespace CgfConverter
                                 // TODO:  This isn't right?  VertsUvs may always have color as the 3rd element.
                                 // Normals depend on the data size.  16 byte structures have the normals in the Tangents.  20 byte structures are in the VertsUV.
                                 Vector3 normal = new(); 
-                                normal = tmpVertsUVs.Normals[j];
+                                if (tmpVertsUVs.Normals != null)
+                                {
+                                    normal = tmpVertsUVs.Normals[j];
+                                }
+                                else if (tmpTangents != null && tmpTangents.Normals != null)
+                                {
+                                    normal = tmpTangents.Normals[j];
+                                }
                                 normString.AppendFormat("{0:F6} {1:F6} {2:F6} ", safe(normal.X), safe(normal.Y), safe(normal.Z));
                             }
                             // Create UV string
@@ -689,21 +696,13 @@ namespace CgfConverter
 
                                 triangles[j].Material = MatName + "-material";
                             }
-                            // Create the 4 inputs.  vertex, normal, texcoord, color
+                            // Create the inputs.  vertex, normal, texcoord, color
+                            int inputCount = 3;
                             if (tmpColors != null || tmpVertsUVs?.Colors != null)
                             {
-                                triangles[j].Input = new Grendgine_Collada_Input_Shared[4];
-                                triangles[j].Input[3] = new Grendgine_Collada_Input_Shared
-                                {
-                                    Semantic = Grendgine_Collada_Input_Semantic.COLOR,
-                                    Offset = 3,
-                                    source = "#" + colorSource.ID
-                                };
+                                inputCount++;
                             }
-                            else
-                            {
-                                triangles[j].Input = new Grendgine_Collada_Input_Shared[3];
-                            }
+                            triangles[j].Input = new Grendgine_Collada_Input_Shared[inputCount];
 
                             triangles[j].Input[0] = new Grendgine_Collada_Input_Shared
                             {
@@ -724,34 +723,55 @@ namespace CgfConverter
                                 Offset = 2,
                                 source = "#" + uvSource.ID
                             };
+
+                            int nextInputID = 3;
+                            if (tmpColors != null || tmpVertsUVs?.Colors != null)
+                            {
+                                triangles[j].Input[nextInputID] = new Grendgine_Collada_Input_Shared
+                                {
+                                    Semantic = Grendgine_Collada_Input_Semantic.COLOR,
+                                    Offset = nextInputID,
+                                    source = "#" + colorSource.ID
+                                };
+                                nextInputID++;
+                            }
+
                             // Create the vcount list.  All triangles, so the subset number of indices.
                             StringBuilder vc = new StringBuilder();
                             for (var k = tmpMeshSubsets.MeshSubsets[j].FirstIndex; k < (tmpMeshSubsets.MeshSubsets[j].FirstIndex + tmpMeshSubsets.MeshSubsets[j].NumIndices); k++)
                             {
-                                if (tmpColors == null)
-                                    vc.AppendFormat(culture, "3 ");
-                                else
-                                    vc.AppendFormat(culture, "4 ");
+                                int ccount = 3;
+
+                                if (tmpColors != null || tmpVertsUVs?.Colors != null)
+                                    ccount++;
+
+                                vc.AppendFormat(culture, String.Format("{0} ", ccount));
                                 k += 2;
                             }
 
                             // Create the P node for the Triangles.
                             StringBuilder p = new StringBuilder();
-                            if (tmpColors != null || tmpVertsUVs?.Colors != null)
+                            for (var k = tmpMeshSubsets.MeshSubsets[j].FirstIndex; k < (tmpMeshSubsets.MeshSubsets[j].FirstIndex + tmpMeshSubsets.MeshSubsets[j].NumIndices); k++)
                             {
-                                for (var k = tmpMeshSubsets.MeshSubsets[j].FirstIndex; k < (tmpMeshSubsets.MeshSubsets[j].FirstIndex + tmpMeshSubsets.MeshSubsets[j].NumIndices); k++)
+                                int values = 0;
+                                if (tmpColors != null || tmpVertsUVs?.Colors != null)
                                 {
-                                    p.AppendFormat("{0} {0} {0} {0} {1} {1} {1} {1} {2} {2} {2} {2} ", tmpIndices.Indices[k], tmpIndices.Indices[k + 1], tmpIndices.Indices[k + 2]);
-                                    k += 2;
+                                    values++;
                                 }
-                            }
-                            else
-                            {
-                                for (var k = tmpMeshSubsets.MeshSubsets[j].FirstIndex; k < (tmpMeshSubsets.MeshSubsets[j].FirstIndex + tmpMeshSubsets.MeshSubsets[j].NumIndices); k++)
+
+                                List<string> formatlist = new List<string>();
+                                formatlist.Add("{0} {0} {0} ");
+                                formatlist.Add("{1} {1} {1} ");
+                                formatlist.Add("{2} {2} {2} ");
+                                for (var valuecount = 0; valuecount < values; valuecount++)
                                 {
-                                    p.AppendFormat("{0} {0} {0} {1} {1} {1} {2} {2} {2} ", tmpIndices.Indices[k], tmpIndices.Indices[k + 1], tmpIndices.Indices[k + 2]);
-                                    k += 2;
+                                    formatlist[0] += "{0} ";
+                                    formatlist[1] += "{1} ";
+                                    formatlist[2] += "{2} ";
                                 }
+                                string finalformat = String.Join("",formatlist);
+                                p.AppendFormat(finalformat, tmpIndices.Indices[k], tmpIndices.Indices[k + 1], tmpIndices.Indices[k + 2]);
+                                k += 2;
                             }
                             triangles[j].P = new Grendgine_Collada_Int_Array_String
                             {

--- a/CgfConverter/Renderers/Collada/COLLADA.cs
+++ b/CgfConverter/Renderers/Collada/COLLADA.cs
@@ -197,9 +197,13 @@ namespace CgfConverter
                 }
                 else
                 {
-                    tmpMaterial.Name = CryData.Materials[i].Name;
-                    tmpMaterial.ID = CryData.Materials[i].Name + "-material";          // this is the order the materials appear in the .mtl file.  Needed for geometries.
-                    tmpMaterial.Instance_Effect.URL = "#" + CryData.Materials[i].Name + "-effect";
+                    string MatName = CryData.Materials[i].Name;
+                    if (Args.PrefixMaterialNames)
+                        MatName = CryData.Materials[i].SourceFileName + "_" + MatName;
+
+                    tmpMaterial.Name = MatName;
+                    tmpMaterial.ID = MatName + "-material";          // this is the order the materials appear in the .mtl file.  Needed for geometries.
+                    tmpMaterial.Instance_Effect.URL = "#" + MatName + "-effect";
                 }
 
                 materials[i] = tmpMaterial;
@@ -216,11 +220,15 @@ namespace CgfConverter
             Grendgine_Collada_Effect[] effects = new Grendgine_Collada_Effect[numEffects];
             for (int i = 0; i < numEffects; i++)
             {
+                string MatName = CryData.Materials[i].Name;
+                if (Args.PrefixMaterialNames)
+                    MatName = CryData.Materials[i].SourceFileName + "_" + MatName;
+
                 Grendgine_Collada_Effect tmpEffect = new Grendgine_Collada_Effect
                 {
                     //tmpEffect.Name = CryData.Materials[i].Name;
-                    ID = CryData.Materials[i].Name + "-effect",
-                    Name = CryData.Materials[i].Name
+                    ID = MatName + "-effect",
+                    Name = MatName
                 };
                 effects[i] = tmpEffect;
 
@@ -675,7 +683,11 @@ namespace CgfConverter
                                     // models it's the index - 8 (some Sonic Boom for example)
                                     tmpMeshSubsets.MeshSubsets[j].MatID = 0;  
                                 }
-                                triangles[j].Material = CryData.Materials[tmpMeshSubsets.MeshSubsets[j].MatID].Name + "-material";
+                                string MatName = CryData.Materials[tmpMeshSubsets.MeshSubsets[j].MatID].Name;
+                                if (Args.PrefixMaterialNames)
+                                    MatName = CryData.Materials[tmpMeshSubsets.MeshSubsets[j].MatID].SourceFileName + "_" + MatName;
+
+                                triangles[j].Material = MatName + "-material";
                             }
                             // Create the 4 inputs.  vertex, normal, texcoord, color
                             if (tmpColors != null || tmpVertsUVs?.Colors != null)
@@ -1201,13 +1213,17 @@ namespace CgfConverter
             // node chunk are stored in meshsubsets, so for each subset we need to grab the mat, get the target (id), and make an instance_material for it.
             for (int i = 0; i < CryData.Materials.Count; i++)
             {
+                string MatName = CryData.Materials[i].Name;
+                if (Args.PrefixMaterialNames)
+                    MatName = CryData.Materials[i].SourceFileName + "_" + MatName;
+
                 // For each mesh subset, we want to create an instance material and add it to instanceMaterials list.
                 Grendgine_Collada_Instance_Material_Geometry tmpInstanceMat = new Grendgine_Collada_Instance_Material_Geometry
                 {
                     //tmpInstanceMat.Target = "#" + tmpMeshSubsets.MeshSubsets[i].MatID;
-                    Target = "#" + CryData.Materials[i].Name + "-material",
+                    Target = "#" + MatName + "-material",
                     //tmpInstanceMat.Symbol = CryData.Materials[tmpMeshSubsets.MeshSubsets[i].MatID].Name;
-                    Symbol = CryData.Materials[i].Name + "-material"
+                    Symbol = MatName + "-material"
                 };
                 instanceMaterials.Add(tmpInstanceMat);
             }
@@ -1448,9 +1464,13 @@ namespace CgfConverter
                 //tmpInstanceMat.Target = "#" + tmpMeshSubsets.MeshSubsets[i].MatID;
                 if (CryData.Materials.Count > 0)
                 {
-                    tmpInstanceMat.Target = "#" + CryData.Materials[(int)tmpMeshSubsets.MeshSubsets[i].MatID].Name + "-material";
-                    //tmpInstanceMat.Symbol = CryData.Materials[tmpMeshSubsets.MeshSubsets[i].MatID].Name;
-                    tmpInstanceMat.Symbol = CryData.Materials[(int)tmpMeshSubsets.MeshSubsets[i].MatID].Name + "-material";
+                    string MatName = CryData.Materials[tmpMeshSubsets.MeshSubsets[i].MatID].Name;
+                    if (Args.PrefixMaterialNames)
+                        MatName = CryData.Materials[tmpMeshSubsets.MeshSubsets[i].MatID].SourceFileName + "_" + MatName;
+
+                    tmpInstanceMat.Target = "#" + MatName + "-material";
+                    //tmpInstanceMat.Symbol = MatName;
+                    tmpInstanceMat.Symbol = MatName + "-material";
                 }
 
                 instanceMaterials.Add(tmpInstanceMat);

--- a/CgfConverter/Renderers/Wavefront/Wavefront.Material.cs
+++ b/CgfConverter/Renderers/Wavefront/Wavefront.Material.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Reflection;
 using System.Text;
 using static Extensions.FileHandlingExtensions;
@@ -24,11 +25,13 @@ namespace CgfConverter
                 file.WriteLine("#");
                 foreach (CryEngineCore.Material material in cryEngine.Materials)
                 {
+                    string MatName = material.Name;
+                    if (Args.PrefixMaterialNames)
+                        MatName = material.SourceFileName + "_" + MatName;
 #if DUMP_JSON
-                    File.WriteAllText(String.Format("_material-{0}.json", material.Name.Replace(@"/", "").Replace(@"\", "")), material.ToJSON());
+                    File.WriteAllText(String.Format("_material-{0}.json", MatName.Replace(@"/", "").Replace(@"\", "")), material.ToJSON());
 #endif
-
-                    file.WriteLine("newmtl {0}", material.Name);
+                    file.WriteLine("newmtl {0}", MatName);
                     if (material.Diffuse != null)
                     {
                         file.WriteLine("Ka {0:F6} {1:F6} {2:F6}", material.Diffuse.Red, material.Diffuse.Green, material.Diffuse.Blue);    // Ambient
@@ -36,7 +39,7 @@ namespace CgfConverter
                     }
                     else
                     {
-                        Utils.Log(LogLevelEnum.Debug, "Skipping Diffuse for {0}", material.Name);
+                        Utils.Log(LogLevelEnum.Debug, "Skipping Diffuse for {0}", MatName);
                     }
                     if (material.Specular != null)
                     {
@@ -45,7 +48,7 @@ namespace CgfConverter
                     }
                     else
                     {
-                        Utils.Log(LogLevelEnum.Debug, "Skipping Specular for {0}", material.Name);
+                        Utils.Log(LogLevelEnum.Debug, "Skipping Specular for {0}", MatName);
                     }
                     file.WriteLine("d {0:F6}", material.Opacity);                                                                          // Dissolve
 

--- a/CgfConverter/Renderers/Wavefront/Wavefront.cs
+++ b/CgfConverter/Renderers/Wavefront/Wavefront.cs
@@ -322,7 +322,11 @@ namespace CgfConverter
 
                 if (this.CryData.Materials.Count > meshSubset.MatID)
                 {
-                    f.WriteLine("usemtl {0}", this.CryData.Materials[(int)meshSubset.MatID].Name);
+                    string MatName = this.CryData.Materials[(int)meshSubset.MatID].Name;
+                    if (Args.PrefixMaterialNames)
+                        MatName = this.CryData.Materials[(int)meshSubset.MatID].SourceFileName + "_" + MatName;
+
+                    f.WriteLine("usemtl {0}", MatName);
                 }
                 else
                 {

--- a/CgfConverter/Services/ArgsHandler.cs
+++ b/CgfConverter/Services/ArgsHandler.cs
@@ -37,6 +37,8 @@ namespace CgfConverter
         public bool OutputFBX { get; internal set; }
         /// <summary>Smooth Faces</summary>
         public bool Smooth { get; internal set; }
+        /// <summary>Flag used to toggle if we should prefix exported material names with the material file name</summary>
+        public bool PrefixMaterialNames { get; internal set; }
         /// <summary>Flag used to indicate we should convert texture paths to use TIFF instead of DDS</summary>
         public bool TiffTextures { get; internal set; }
         /// <summary>Flag used to indicate we should convert texture paths to use PNG instead of DDS</summary>
@@ -267,6 +269,14 @@ namespace CgfConverter
                         DumpChunkInfo = true;
                         break;
                     #endregion
+                    #region case "-prefixmatnames"...
+                    case "-prefixmatnames":
+                    case "-prefixmaterialnames":
+                    case "-pmatnames":
+                    case "-pmn":
+                        PrefixMaterialNames = true;
+                        break;
+                    #endregion
                     #region default...
 
                     default:
@@ -312,6 +322,8 @@ namespace CgfConverter
                 Utils.Log(LogLevelEnum.Info, "Allow conflicts for mtl files enabled");
             if (NoConflicts)
                 Utils.Log(LogLevelEnum.Info, "Prevent conflicts for mtl files enabled");
+            if (PrefixMaterialNames)
+                Utils.Log(LogLevelEnum.Info, "Prefix material names with the source material's filename");
             if (DumpChunkInfo)
                 Utils.Log(LogLevelEnum.Info, "Output chunk info for missing or invalid chunks.");
             if (Throw)
@@ -355,6 +367,7 @@ namespace CgfConverter
             Console.WriteLine("-fbx:             Export FBX format files (Not Implemented).");
             Console.WriteLine("-smooth:          Smooth Faces.");
             Console.WriteLine("-group:           Group meshes into single model.");
+            Console.WriteLine("-prefixmatnames:  Prefixes material names with the filename of the source mtl file.");
             Console.WriteLine();
             Console.WriteLine("-notex:           Do not include textures in outputs");
             Console.WriteLine("-tif:             Change the materials to look for .tif files instead of .dds.");


### PR DESCRIPTION
Solves the issue of CGA and CGF Star Citizen files not having any vert colors, as discussed in #87.

Result:
![image](https://user-images.githubusercontent.com/5256123/127761119-2ff86b22-314a-47b4-8dd1-e3162b73ae22.png)

Also added an optional prefix for material names. When enabled, materials will be prefixed with the material file's name, so the material "proxy" would then become "DRAK_Buccaneer_ext_mtl_proxy". Works with both Collada and Wavefront exporters.