### PR TITLE
Fix for Star Citizen Vert Colors, that are actually in a BGRA format.

### DIFF
--- a/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_800.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkDataStream_800.cs
@@ -232,7 +232,14 @@ namespace CgfConverter.CryEngineCore
                                     SkipBytes(b, 2);
                                     //Vertices[i].W = b.ReadCryHalf();
 
-                                    Colors[i] = b.ReadColor();
+                                    Colors[i] = b.ReadColorBGRA();
+
+                                    // Hack to export Alpha to G channel, as Blender doesn't support vertex alphas, and in
+                                    // Star Citizen, the Alpha (wear map) is more important than the Green (Damage Glow map).
+                                    byte alpha = Colors[i].a;
+                                    byte green = Colors[i].g;
+                                    Colors[i].a = green;
+                                    Colors[i].g = alpha;
 
                                     // UVs ABSOLUTELY should use the Half structures.
                                     UVs[i].U = b.ReadHalf();

--- a/CgfConverter/Utils/BinaryReaderExtensions.cs
+++ b/CgfConverter/Utils/BinaryReaderExtensions.cs
@@ -94,6 +94,18 @@ namespace Extensions
             return c;
         }
 
+        public static IRGBA ReadColorBGRA(this BinaryReader r)
+        {
+            var c = new IRGBA()
+            {
+                b = r.ReadByte(),
+                g = r.ReadByte(),
+                r = r.ReadByte(),
+                a = r.ReadByte()
+            };
+            return c;
+        }
+
         public static Matrix3x3 ReadMatrix3x3(this BinaryReader reader)
         {
             // Reads a Matrix33 structure


### PR DESCRIPTION
-Also a hack for SC Vert Colors that swaps Green and Alpha, as Blender doesn't support Vertex Color Alphas. (And at least for SC, Alpha is more important than green.)