### PR TITLE
Pendingchanges

### DIFF
--- a/CgfConverter/CryEngineCore/Chunks/ChunkNode_823.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkNode_823.cs
@@ -21,7 +21,7 @@ namespace CgfConverter.CryEngineCore
             SkipBytes(b, 4);
 
             // Read the 4x4 transform matrix.
-            Transform = new Matrix4x4
+            var transform = new Matrix4x4
             {
                 M11 = b.ReadSingle(),
                 M12 = b.ReadSingle(),
@@ -40,6 +40,11 @@ namespace CgfConverter.CryEngineCore
                 M43 = b.ReadSingle() * VERTEX_SCALE,
                 M44 = b.ReadSingle(),
             };
+
+            //original transform matrix is 3x4 stored as 4x4.
+            transform.M14 = transform.M24 = transform.M34 = 0f;
+            transform.M44 = 1f;
+            Transform = transform;
 
             Pos = b.ReadVector3() * VERTEX_SCALE;
             Rot = b.ReadQuaternion();

--- a/CgfConverter/CryEngineCore/Chunks/ChunkNode_824.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkNode_824.cs
@@ -21,7 +21,7 @@ namespace CgfConverter.CryEngineCore
             SkipBytes(b, 4);
 
             // Read the 4x4 transform matrix.
-            Transform = new Matrix4x4
+            var transform = new Matrix4x4
             {
                 M11 = b.ReadSingle(),
                 M12 = b.ReadSingle(),
@@ -40,6 +40,11 @@ namespace CgfConverter.CryEngineCore
                 M43 = b.ReadSingle() * VERTEX_SCALE,
                 M44 = b.ReadSingle(),
             };
+
+            //original transform matrix is 3x4 stored as 4x4.
+            transform.M14 = transform.M24 = transform.M34 = 0f;
+            transform.M44 = 1f;
+            Transform = transform;
 
             Pos = b.ReadVector3() * VERTEX_SCALE;
             Rot = b.ReadQuaternion();

--- a/CgfConverter/External/Dolkens/Extensions.cs
+++ b/CgfConverter/External/Dolkens/Extensions.cs
@@ -766,7 +766,7 @@ namespace Dolkens.Framework.Extensions
             catch (Exception ex)
             {
                 if (!isNullable && (@default == null))
-                    throw ex;
+                    throw;
 
                 return @default;
             }

--- a/CgfConverter/Renderers/Collada/COLLADA.cs
+++ b/CgfConverter/Renderers/Collada/COLLADA.cs
@@ -618,26 +618,24 @@ namespace CgfConverter
                                 }
                             }
 
+                            // Dymek's code to rescale by bounding box.  Only apply to geometry (cga or cgf), and not skin or chr objects.
+                            var multiplerVector = Vector3.Abs((tmpMeshChunk.MinBound - tmpMeshChunk.MaxBound) / 2f);
+                            if (multiplerVector.X < 1) { multiplerVector.X = 1; }
+                            if (multiplerVector.Y < 1) { multiplerVector.Y = 1; }
+                            if (multiplerVector.Z < 1) { multiplerVector.Z = 1; }
+                            var boundaryBoxCenter = (tmpMeshChunk.MinBound + tmpMeshChunk.MaxBound) / 2f;
+
                             // Create Vertices, normals and colors string
                             for (uint j = 0; j < tmpMeshChunk.NumVertices; j++)
                             {
                                 // Rotate/translate the vertex
-                                // Dymek's code to rescale by bounding box.  Only apply to geometry (cga or cgf), and not skin or chr objects.
                                 if (!CryData.InputFile.EndsWith("skin") && !CryData.InputFile.EndsWith("chr"))
                                 {
-                                    float multiplerX = Math.Abs(tmpMeshChunk.MinBound.X - tmpMeshChunk.MaxBound.X) / 2f;
-                                    float multiplerY = Math.Abs(tmpMeshChunk.MinBound.Y - tmpMeshChunk.MaxBound.Y) / 2f;
-                                    float multiplerZ = Math.Abs(tmpMeshChunk.MinBound.Z - tmpMeshChunk.MaxBound.Z) / 2f;
-                                    if (multiplerX < 1) { multiplerX = 1; }
-                                    if (multiplerY < 1) { multiplerY = 1; }
-                                    if (multiplerZ < 1) { multiplerZ = 1; }
-                                    tmpVertsUVs.Vertices[j].X = tmpVertsUVs.Vertices[j].X * multiplerX + (tmpMeshChunk.MaxBound.X + tmpMeshChunk.MinBound.X) / 2;
-                                    tmpVertsUVs.Vertices[j].Y = tmpVertsUVs.Vertices[j].Y * multiplerY + (tmpMeshChunk.MaxBound.Y + tmpMeshChunk.MinBound.Y) / 2;
-                                    tmpVertsUVs.Vertices[j].Z = tmpVertsUVs.Vertices[j].Z * multiplerZ + (tmpMeshChunk.MaxBound.Z + tmpMeshChunk.MinBound.Z) / 2;
+                                    tmpVertsUVs.Vertices[j] = (tmpVertsUVs.Vertices[j] * multiplerVector) + boundaryBoxCenter;
                                 }
 
                                 Vector3 vertex = tmpVertsUVs.Vertices[j];
-                                vertString.AppendFormat("{0:F6} {1:F6} {2:F6} ", vertex.X, vertex.Y, vertex.Z);
+                                vertString.AppendFormat("{0:F6} {1:F6} {2:F6} ", safe(vertex.X), safe(vertex.Y), safe(vertex.Z));
 
                                 // TODO:  This isn't right?  VertsUvs may always have color as the 3rd element.
                                 // Normals depend on the data size.  16 byte structures have the normals in the Tangents.  20 byte structures are in the VertsUV.

--- a/CgfConverter/Renderers/Wavefront/Wavefront.cs
+++ b/CgfConverter/Renderers/Wavefront/Wavefront.cs
@@ -217,6 +217,13 @@ namespace CgfConverter
                 {
                     #region Write Vertices Out (v, vt)
 
+                    // Dymek's code.  Scales the object by the bounding box.
+                    var multiplerVector = Vector3.Abs((tmpMesh.MinBound - tmpMesh.MaxBound) / 2f);
+                    if (multiplerVector.X < 1) { multiplerVector.X = 1; }
+                    if (multiplerVector.Y < 1) { multiplerVector.Y = 1; }
+                    if (multiplerVector.Z < 1) { multiplerVector.Z = 1; }
+                    var boundaryBoxCenter = (tmpMesh.MinBound + tmpMesh.MaxBound) / 2f;
+
                     // Probably using VertsUVs (3.7+).  Write those vertices out. Do UVs at same time.
                     for (int j = meshSubset.FirstVertex;
                         j < meshSubset.NumVertices + meshSubset.FirstVertex;
@@ -224,16 +231,7 @@ namespace CgfConverter
                     {
                         // Let's try this using this node chunk's rotation matrix, and the transform is the sum of all the transforms.
                         // Get the transform.
-                        // Dymek's code.  Scales the object by the bounding box.
-                        float multiplerX = Math.Abs(tmpMesh.MinBound.X - tmpMesh.MaxBound.X) / 2f;
-                        float multiplerY = Math.Abs(tmpMesh.MinBound.Y - tmpMesh.MaxBound.Y) / 2f;
-                        float multiplerZ = Math.Abs(tmpMesh.MinBound.Z - tmpMesh.MaxBound.Z) / 2f;
-                        if (multiplerX < 1) { multiplerX = 1; }
-                        if (multiplerY < 1) { multiplerY = 1; }
-                        if (multiplerZ < 1) { multiplerZ = 1; }
-                        tmpVertsUVs.Vertices[j].X = tmpVertsUVs.Vertices[j].X * multiplerX + (tmpMesh.MaxBound.X + tmpMesh.MinBound.X) / 2;
-                        tmpVertsUVs.Vertices[j].Y = tmpVertsUVs.Vertices[j].Y * multiplerY + (tmpMesh.MaxBound.Y + tmpMesh.MinBound.Y) / 2;
-                        tmpVertsUVs.Vertices[j].Z = tmpVertsUVs.Vertices[j].Z * multiplerZ + (tmpMesh.MaxBound.Z + tmpMesh.MinBound.Z) / 2;
+                        tmpVertsUVs.Vertices[j] = (tmpVertsUVs.Vertices[j] * multiplerVector) + boundaryBoxCenter;
 
                         // Use matrix operations for the maximum performance
                         Vector3 vertex = Vector3.Transform(tmpVertsUVs.Vertices[j],transformSoFar);


### PR DESCRIPTION
return the correct matrix transformations for .obj export (https://github.com/Markemp/Cryengine-Converter/issues/56)
vector- and matrix- based calculations to save some time on export