### PR TITLE
Add support for alt costumes for RoL, and some fixes

### DIFF
--- a/CgfConverter/Services/ArgsHandler.cs
+++ b/CgfConverter/Services/ArgsHandler.cs
@@ -364,9 +364,15 @@ public sealed class ArgsHandler
         if (OutputDir != null)
             Utilities.Log(LogLevelEnum.Info, "Output directory set to {0}", OutputDir);
 
-        foreach (var dir in lookupDataDirs)
+        foreach (var dirAndOptions in lookupDataDirs)
         {
             var foundAny = false;
+
+            var dirAndOptionStrings = dirAndOptions.Split("?", 2);
+            var dir = dirAndOptionStrings[0].Trim();
+            var packFileSystemOptions = dirAndOptionStrings.Length == 2
+                ? dirAndOptionStrings[1].Split("&").Select(x => x.Split("=", 2)).ToDictionary(x => x[0].ToLowerInvariant(), x => x.Length == 2 ? x[1] : "")
+                : new Dictionary<string, string>();
             
             if (Directory.Exists(dir))
             {
@@ -383,7 +389,7 @@ public sealed class ArgsHandler
                 {
                     Utilities.Log(LogLevelEnum.Info, "Source [Packfile]: {0}", globbed);
                     DataDirs.Add(globbed);
-                    PackFileSystem.Add(new WiiuStreamPackFileSystem(PackFileSystem.GetStream(globbed)));
+                    PackFileSystem.Add(new WiiuStreamPackFileSystem(PackFileSystem.GetStream(globbed), packFileSystemOptions));
                     foundAny = true;
                 }
             }
@@ -429,7 +435,7 @@ public sealed class ArgsHandler
         Console.WriteLine("<.cgf file>:      The name of the .cgf, .cga or .skin file to process.");
         Console.WriteLine("-outputfile:      The name of the file to write the output.  Default is [root].dae");
         Console.WriteLine("-objectdir:       The name where the base Objects directory is located.  Used to read mtl file.");
-        Console.WriteLine("                  Defaults to current directory.");
+        Console.WriteLine("                  Defaults to current directory. Some packfile formats may accept additional options in the form of some.pack.file?key=value&key2=value2.");
         Console.WriteLine("-pp/-preservepath:");
         Console.WriteLine("                  Preserve the path hierarchy.");
         Console.WriteLine("-mt/-maxthreads <number>");

--- a/CgfConverter/Utils/StringExtensions.cs
+++ b/CgfConverter/Utils/StringExtensions.cs
@@ -1,0 +1,15 @@
+﻿namespace CgfConverter.Utils;
+
+public static class StringExtensions
+{
+    public static bool IsTrueyString(this string s, bool emptyIsTrue = false) => s.ToLowerInvariant() switch
+    {
+        "" => emptyIsTrue,
+        "t" => true,
+        "true" => true,
+        "1" => true,
+        "y" => true,
+        "yes" => true,
+        _ => false
+    };
+}

--- a/CgfConverter/Utils/TaggedLogger.cs
+++ b/CgfConverter/Utils/TaggedLogger.cs
@@ -20,7 +20,7 @@ public class TaggedLogger
     public void V(string? format = null, params object?[] args) => DoLog(LogLevelEnum.Verbose, null, format, args);
     public void D(string? format = null, params object?[] args) => DoLog(LogLevelEnum.Debug, null, format, args);
     public void I(string? format = null, params object?[] args) => DoLog(LogLevelEnum.Info, null, format, args);
-    public void W(string? format = null, params object?[] args) => DoLog(LogLevelEnum.Debug, null, format, args);
+    public void W(string? format = null, params object?[] args) => DoLog(LogLevelEnum.Warning, null, format, args);
     public void E(string? format = null, params object?[] args) => DoLog(LogLevelEnum.Error, null, format, args);
     public void C(string? format = null, params object?[] args) => DoLog(LogLevelEnum.Critical, null, format, args);
 
@@ -34,7 +34,7 @@ public class TaggedLogger
         => DoLog(LogLevelEnum.Info, e, format, args);
 
     public void W(Exception e, string? format = null, params object?[] args)
-        => DoLog(LogLevelEnum.Debug, e, format, args);
+        => DoLog(LogLevelEnum.Warning, e, format, args);
 
     public void E(Exception e, string? format = null, params object?[] args)
         => DoLog(LogLevelEnum.Error, e, format, args);
@@ -47,7 +47,7 @@ public class TaggedLogger
 
     public T D<T>(string? format = null, params object?[] args) => DoLog<T>(LogLevelEnum.Debug, null, format, args);
     public T I<T>(string? format = null, params object?[] args) => DoLog<T>(LogLevelEnum.Info, null, format, args);
-    public T W<T>(string? format = null, params object?[] args) => DoLog<T>(LogLevelEnum.Debug, null, format, args);
+    public T W<T>(string? format = null, params object?[] args) => DoLog<T>(LogLevelEnum.Warning, null, format, args);
     public T E<T>(string? format = null, params object?[] args) => DoLog<T>(LogLevelEnum.Error, null, format, args);
     public T C<T>(string? format = null, params object?[] args) => DoLog<T>(LogLevelEnum.Critical, null, format, args);
 
@@ -61,7 +61,7 @@ public class TaggedLogger
         DoLog<T>(LogLevelEnum.Info, e, format, args);
 
     public T W<T>(Exception e, string? format = null, params object?[] args) =>
-        DoLog<T>(LogLevelEnum.Debug, e, format, args);
+        DoLog<T>(LogLevelEnum.Warning, e, format, args);
 
     public T E<T>(Exception e, string? format = null, params object?[] args) =>
         DoLog<T>(LogLevelEnum.Error, e, format, args);

--- a/cgf-converter/cgf-converter.cs
+++ b/cgf-converter/cgf-converter.cs
@@ -105,7 +105,7 @@ public class Program
 
         Log.I("Finished. Rendered {0} file(s)", _args.InputFiles.Count - numErrorsOccurred);
         if (numErrorsOccurred > 0)
-            Log.E("Failed to convert {1} file(s).", numErrorsOccurred);
+            Log.E("Failed to convert {0} file(s).", numErrorsOccurred);
 
         return numErrorsOccurred;
     }


### PR DESCRIPTION
Packfile input provider will accept `?k=v&k2=v2` like query strings in URL. For .wiiu.stream, you can extract the luminous suit by providing `?alt=1` or alike, like `-datadir content\Sonic_Crytek\**.wiiu.stream?alt`.

It will now split up alpha channel into emissive texture for glTF export, if GlowAmount is set.

Also, fixed some minor bugs I've introduced in previous PR, such as printing warning log as debug level.
