### PR TITLE
Support XML files with preceding spaces or BOM

### DIFF
--- a/CgfConverter/CgfConverter.csproj
+++ b/CgfConverter/CgfConverter.csproj
@@ -6,6 +6,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Authors>Geoff Gerber</Authors>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BCnEncoder.Net" Version="2.1.0" />

--- a/CgfConverter/CryEngine/CryEngine.cs
+++ b/CgfConverter/CryEngine/CryEngine.cs
@@ -4,10 +4,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using CgfConverter.CryXmlB;
 using CgfConverter.PackFileSystem;
 using CgfConverter.Utils;
 using Extensions;
-using HoloXPLOR.DataForge;
 using Material = CgfConverter.Materials.Material;
 
 namespace CgfConverter;

--- a/CgfConverter/CryEngineCore/Chunks/ChunkBinaryXmlData_3.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkBinaryXmlData_3.cs
@@ -1,7 +1,7 @@
-﻿using HoloXPLOR.DataForge;
-using System;
+﻿using System;
 using System.IO;
 using System.Xml;
+using CgfConverter.CryXmlB;
 
 namespace CgfConverter.CryEngineCore;
 

--- a/CgfConverter/CryXmlB/CryXmlNode.cs
+++ b/CgfConverter/CryXmlB/CryXmlNode.cs
@@ -1,4 +1,4 @@
-﻿namespace HoloXPLOR.DataForge;
+﻿namespace CgfConverter.CryXmlB;
 
 public sealed record CryXmlNode
 {

--- a/CgfConverter/CryXmlB/CryXmlReference.cs
+++ b/CgfConverter/CryXmlB/CryXmlReference.cs
@@ -1,4 +1,4 @@
-﻿namespace HoloXPLOR.DataForge;
+﻿namespace CgfConverter.CryXmlB;
 
 public sealed record CryXmlReference
 {

--- a/CgfConverter/CryXmlB/CryXmlValue.cs
+++ b/CgfConverter/CryXmlB/CryXmlValue.cs
@@ -1,4 +1,4 @@
-﻿namespace HoloXPLOR.DataForge;
+﻿namespace CgfConverter.CryXmlB;
 
 public class CryXmlValue
 {

--- a/CgfConverter/Materials/MaterialUtilities.cs
+++ b/CgfConverter/Materials/MaterialUtilities.cs
@@ -1,7 +1,7 @@
 ﻿using System.Diagnostics;
 using System.IO;
 using System;
-using HoloXPLOR.DataForge;
+using CgfConverter.CryXmlB;
 
 namespace CgfConverter.Materials;
 

--- a/CgfConverter/Models/Prefab.cs
+++ b/CgfConverter/Models/Prefab.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using CgfConverter.CryXmlB;
 
 namespace CgfConverter.Models
 {
@@ -49,7 +50,7 @@ namespace CgfConverter.Models
         {
             try
             {
-                return HoloXPLOR.DataForge.CryXmlSerializer.Deserialize<PrefabsLibrary>(stream);
+                return CryXmlSerializer.Deserialize<PrefabsLibrary>(stream);
                 //return HoloXPLOR.DataForge.CryXmlSerializer.Deserialize<CryEngineCore.Material>(materialfile.FullName);
             }
             catch (Exception ex)

--- a/CgfConverter/Terrain/CryTerrain.cs
+++ b/CgfConverter/Terrain/CryTerrain.cs
@@ -4,11 +4,11 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Numerics;
+using CgfConverter.CryXmlB;
 using CgfConverter.PackFileSystem;
 using CgfConverter.Terrain.Xml;
 using CgfConverter.Utils;
 using Extensions;
-using HoloXPLOR.DataForge;
 
 namespace CgfConverter.Terrain;
 


### PR DESCRIPTION
While at it...
* Fixed namespace declarations for a few files.
* Instead of suppressing unused warnings from CryXmlB deserialization, log the unused variables when writeLog is set.