### PR TITLE
Fix globbing on filesystem, detect endianness for ChunkController905

### DIFF
--- a/CgfConverter/PackFileSystem/RealFileSystem.cs
+++ b/CgfConverter/PackFileSystem/RealFileSystem.cs
@@ -81,8 +81,7 @@ public class RealFileSystem : IPackFileSystem
                         try
                         {
                             remainingPatterns.AddRange(
-                                Directory.GetFiles(searchBase, $"{prefix}*{suffix}{remainingPattern}")
-                                    .Select(x => Path.Join(searchBase, x)));
+                                Directory.GetFiles(searchBase, $"{prefix}*{suffix}{remainingPattern}"));
                         }
                         catch (Exception)
                         {
@@ -95,7 +94,7 @@ public class RealFileSystem : IPackFileSystem
                     {
                         remainingPatterns.AddRange(
                             Directory.GetDirectories(searchBase, $"{prefix}*")
-                                .Select(x => Path.Join(searchBase, x, remainingPattern)));
+                                .Select(x => Path.Join(x, remainingPattern)));
                     }
                     catch (Exception)
                     {


### PR DESCRIPTION
When `Path.Combine`s were replaced to `Path.Join`, it revealed an error that appending the parent path should not have been done at the first place. The first commit fixes that.

For ChunkController905, I do hope there's no object with more than 65535 animations contained inside. 