### PR TITLE
Fix for SC 3.23 changes

### DIFF
--- a/CgfConverter/CgfConverter.csproj
+++ b/CgfConverter/CgfConverter.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
@@ -14,5 +14,11 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.7" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.IO.Hashing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.XmlSerializer.Generator" Version="8.0.0" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <!-- Needed for XmlSerializer Source Generator -->
+    <SGenTypes>CgfConverter.Renderers.Collada.Collada.ColladaDoc</SGenTypes>
+  </PropertyGroup>
 </Project>

--- a/CgfConverter/CryEngineCore/Chunks/ChunkMeshSubsets_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkMeshSubsets_900.cs
@@ -17,7 +17,8 @@ internal sealed class ChunkMeshSubsets_900 : ChunkMeshSubsets
         MeshSubsets = new MeshSubset[NumMeshSubset];
         for (int i = 0; i < NumMeshSubset; i++)
         {
-            MeshSubsets[i].MatID = b.ReadInt32();
+            MeshSubsets[i].MatID = b.ReadInt16();
+            SkipBytes(b, 2);  // 2 unknowns; possibly padding;
             MeshSubsets[i].FirstIndex = b.ReadInt32();
             MeshSubsets[i].NumIndices = b.ReadInt32();
             MeshSubsets[i].FirstVertex = b.ReadInt32();

--- a/CgfConverter/Enums/Enums.cs
+++ b/CgfConverter/Enums/Enums.cs
@@ -83,8 +83,9 @@ public enum ChunkType : uint    // complete
     MtlNameIvo = 0x8335674E,
     MtlNameIvo320 = 0x83353333,
     CompiledBonesIvo = 0xC201973C,
-    CompiledBonesIvo320 = 0xc2011111,
-    CompiledPhysicalBonesIvo = 0x90C687DC,  // Physics  
+    CompiledBonesIvo320 = 0xC2011111,
+    CompiledPhysicalBonesIvo = 0x90C687DC,  // Physics
+    CompiledPhysicalBonesIvo320 = 0x90C66666,
     MeshIvo = 0x9293B9D8,           // SkinInfo
     MeshIvo320 = 0x92914444,
     IvoSkin = 0xB875B2D9,           // SkinMesh

--- a/CgfConverterIntegrationTests/CgfConverterTests.csproj
+++ b/CgfConverterIntegrationTests/CgfConverterTests.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="BCnEncoder.Net.ImageSharp" Version="1.1.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.7" />
+    <PackageReference Include="Microsoft.XmlSerializer.Generator" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CgfConverter\CgfConverter.csproj" />

--- a/CgfConverterIntegrationTests/IntegrationTests/SC/StarCitizenTests.cs
+++ b/CgfConverterIntegrationTests/IntegrationTests/SC/StarCitizenTests.cs
@@ -1,4 +1,5 @@
 ﻿using CgfConverter;
+using CgfConverter.CryEngineCore;
 using CgfConverter.Renderers.Collada;
 using CgfConverter.Renderers.Collada.Collada.Enums;
 using CgfConverter.Renderers.Gltf;
@@ -141,6 +142,13 @@ public class StarCitizenTests
         Assert.AreEqual(0, result);
         CryEngine cryData = new(args[0], testUtils.argsHandler.PackFileSystem);
         cryData.ProcessCryengineFiles();
+        var meshChunk = (ChunkMesh)cryData.Chunks[7];  // This is the generated one from the skinm file
+        Assert.AreEqual(-0.443651f, meshChunk.MinBound.X, TestUtils.delta);
+        Assert.AreEqual(-0.2984485f, meshChunk.MinBound.Y, TestUtils.delta);
+        Assert.AreEqual(-2.20503f, meshChunk.MinBound.Z, TestUtils.delta);
+        Assert.AreEqual(0.443650f, meshChunk.MaxBound.X, TestUtils.delta);
+        Assert.AreEqual(3.3411438f, meshChunk.MaxBound.Y, TestUtils.delta);
+        Assert.AreEqual(1.4569355f, meshChunk.MaxBound.Z, TestUtils.delta);
 
         var colladaData = new ColladaModelRenderer(testUtils.argsHandler, cryData);
         colladaData.GenerateDaeObject();
@@ -158,6 +166,13 @@ public class StarCitizenTests
         Assert.AreEqual(0, result);
         CryEngine cryData = new(args[0], testUtils.argsHandler.PackFileSystem);
         cryData.ProcessCryengineFiles();
+        var meshChunk = (ChunkMesh)cryData.Chunks[7];  // This is the generated one from the skinm file
+        Assert.AreEqual(-0.443651f, meshChunk.MinBound.X, TestUtils.delta);
+        Assert.AreEqual(-0.2984485f, meshChunk.MinBound.Y, TestUtils.delta);
+        Assert.AreEqual(-2.20503f, meshChunk.MinBound.Z, TestUtils.delta);
+        Assert.AreEqual(0.443650f, meshChunk.MaxBound.X, TestUtils.delta);
+        Assert.AreEqual(3.3411438f, meshChunk.MaxBound.Y, TestUtils.delta);
+        Assert.AreEqual(1.4569355f, meshChunk.MaxBound.Z, TestUtils.delta);
 
         var colladaData = new ColladaModelRenderer(testUtils.argsHandler, cryData);
         colladaData.GenerateDaeObject();

--- a/CgfConverterIntegrationTests/IntegrationTests/SC/StarCitizenTests.cs
+++ b/CgfConverterIntegrationTests/IntegrationTests/SC/StarCitizenTests.cs
@@ -131,6 +131,40 @@ public class StarCitizenTests
     }
 
     [TestMethod]
+    public void ANVL_Hurricane_Front_LandingGear_Ivo_Skin_3_22()
+    {
+        var args = new string[] {
+            @"D:\depot\SC3.22\Data\Objects\Spaceships\Ships\ANVL\LandingGear\Hurricane\anvl_hurricane_landing_gear_front_SKIN.skin",
+            "-dds", "-dae",
+            "-objectdir", @"d:\depot\sc3.22\data" };
+        int result = testUtils.argsHandler.ProcessArgs(args);
+        Assert.AreEqual(0, result);
+        CryEngine cryData = new(args[0], testUtils.argsHandler.PackFileSystem);
+        cryData.ProcessCryengineFiles();
+
+        var colladaData = new ColladaModelRenderer(testUtils.argsHandler, cryData);
+        colladaData.GenerateDaeObject();
+        var daeObject = colladaData.DaeObject;
+    }
+
+    [TestMethod]
+    public void ANVL_Hurricane_Front_LandingGear_Ivo_Skin_3_23()
+    {
+        var args = new string[] {
+            @"D:\depot\SC3.23\Data\Objects\Spaceships\Ships\ANVL\LandingGear\Hurricane\anvl_hurricane_landing_gear_front_SKIN.skin",
+            "-dds", "-dae",
+            "-objectdir", @"d:\depot\sc3.23\data" };
+        int result = testUtils.argsHandler.ProcessArgs(args);
+        Assert.AreEqual(0, result);
+        CryEngine cryData = new(args[0], testUtils.argsHandler.PackFileSystem);
+        cryData.ProcessCryengineFiles();
+
+        var colladaData = new ColladaModelRenderer(testUtils.argsHandler, cryData);
+        colladaData.GenerateDaeObject();
+        var daeObject = colladaData.DaeObject;
+    }
+
+    [TestMethod]
     public void M_ccc_bear_helmet_01_320IvoSkinFile()
     {
         var args = new string[] {

--- a/cgf-converter/cgf-converter.csproj
+++ b/cgf-converter/cgf-converter.csproj
@@ -40,10 +40,10 @@
     <ProductName>Cryengine Converter</ProductName>
     <Title>Cryengine Converter</Title>
     <PublisherName>Heffay Presents</PublisherName>
-    <FileVersion>1.6.0.0</FileVersion>
-    <AssemblyVersion>1.6.0</AssemblyVersion>
+    <FileVersion>1.6.1.0</FileVersion>
+    <AssemblyVersion>1.6.1</AssemblyVersion>
     <Description>Converts Cryengine game files to commonly supported 3D formats.</Description>
-    <Copyright>©2015-2023</Copyright>
+    <Copyright>©2015-2024</Copyright>
     <SupportUrl>https://github.com/Markemp/Cryengine-Converter/</SupportUrl>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
- Fix issue with submesh chunk changes for 3.23.  The material ID changed from an int to an int16, with the second half set to 0xFFFF.  As a result, it was reading negative numbers and throwing an error when trying to look up the index for that material.