### PR TITLE
Sped up XmlSerializer constructor

### DIFF
--- a/CgfConverter/CgfConverter.csproj
+++ b/CgfConverter/CgfConverter.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
@@ -14,5 +14,11 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.7" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.IO.Hashing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.XmlSerializer.Generator" Version="8.0.0" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <!-- Needed for XmlSerializer Source Generator -->
+    <SGenTypes>CgfConverter.Renderers.Collada.Collada.ColladaDoc</SGenTypes>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Hello, I hope pull requests are welcome.

I was helping someone in the Star Citizen Modding discord get compile this tool, and because of that i decided to poke around a bit. Some things I noticed were slow:

1. The XmlSerializer constructor takes a *while* to initialize, so I introduced a source generator for it. On my machine, the `ColladaModelRenderer` went from taking around a second to startup to basically nothing. 

2. The other speedup comes from reading chunks. Right now you seem to be saving any unread bytes for something? It's not being used at the moment, so I've removed. This introduces another significant speedup. If the data is needed, I think it's reasonable to enable it on Debug but just increment the offset on Release builds. 

Thoughts?

Note: would you be interested in a Github actions CI script so that users can download preview-builds of this tool without having to compile it themselves? I can write such a script if there's interest on your part.


If there's any change I should make to this please let me know/