### PR TITLE
USD: Export multiple animations as separate files for Blender NLA wor…

### DIFF
--- a/CgfConverter/Renderers/USD/UsdRenderer.Animation.cs
+++ b/CgfConverter/Renderers/USD/UsdRenderer.Animation.cs
@@ -303,4 +303,131 @@ public partial class UsdRenderer
             .Select(parts => string.Join("/", parts.Skip(commonPrefixLen)))
             .ToList();
     }
+
+    /// <summary>
+    /// Exports individual animation files for Blender NLA workflow.
+    /// Blender's USD importer only reads the single bound animation, so we export
+    /// each animation as a separate file with skeleton + that animation bound.
+    /// </summary>
+    /// <param name="controllerIdToJointPath">Mapping from bone controller IDs to USD joint paths.</param>
+    /// <param name="jointPaths">Ordered list of joint paths for skeleton.</param>
+    /// <param name="bonePathMap">Mapping from CompiledBone to joint path.</param>
+    /// <returns>Number of animation files exported.</returns>
+    private int ExportAnimationFiles(
+        Dictionary<uint, string> controllerIdToJointPath,
+        List<string> jointPaths,
+        Dictionary<CompiledBone, string> bonePathMap)
+    {
+        if (_cryData.Animations is null || _cryData.Animations.Count == 0)
+            return 0;
+
+        int exportedCount = 0;
+        var baseFileName = Path.GetFileNameWithoutExtension(usdOutputFile.FullName);
+        var outputDir = usdOutputFile.DirectoryName ?? ".";
+
+        // Collect all animations with their metadata
+        var allAnimations = new List<(string name, UsdSkelAnimation skelAnim, int endFrame)>();
+
+        foreach (var animModel in _cryData.Animations)
+        {
+            var animChunks = animModel.ChunkMap.Values.OfType<ChunkController_905>().ToList();
+
+            foreach (var animChunk in animChunks)
+            {
+                if (animChunk.Animations is null)
+                    continue;
+
+                var names = StripCommonParentPaths(
+                    animChunk.Animations.Select(x => Path.ChangeExtension(x.Name, null)).ToList());
+
+                foreach (var (anim, name) in animChunk.Animations.Zip(names))
+                {
+                    var (skelAnim, endFrame) = CreateSkelAnimation(anim, animChunk, controllerIdToJointPath, name);
+                    if (skelAnim is not null)
+                    {
+                        allAnimations.Add((name, skelAnim, endFrame));
+                    }
+                }
+            }
+        }
+
+        // Skip if only one animation (already in main file)
+        if (allAnimations.Count <= 1)
+        {
+            Log.D("Only one animation found, skipping separate animation file export");
+            return 0;
+        }
+
+        Log.D($"Exporting {allAnimations.Count} animation files for Blender NLA workflow...");
+
+        // Export each animation as a separate file
+        foreach (var (animName, skelAnim, endFrame) in allAnimations)
+        {
+            var cleanAnimName = CleanPathString(animName);
+            var animFileName = $"{baseFileName}_anim_{cleanAnimName}.usda";
+            var animFilePath = Path.Combine(outputDir, animFileName);
+
+            var animDoc = CreateAnimationOnlyDoc(skelAnim, endFrame, jointPaths, bonePathMap);
+
+            using (var writer = new StreamWriter(animFilePath))
+            {
+                usdSerializer.Serialize(animDoc, writer);
+            }
+
+            Log.D($"  Exported: {animFileName}");
+            exportedCount++;
+        }
+
+        return exportedCount;
+    }
+
+    /// <summary>
+    /// Creates a USD document containing only skeleton + single animation.
+    /// This is for Blender import workflow where each animation needs its own file.
+    /// </summary>
+    private UsdDoc CreateAnimationOnlyDoc(
+        UsdSkelAnimation skelAnim,
+        int endFrame,
+        List<string> jointPaths,
+        Dictionary<CompiledBone, string> bonePathMap)
+    {
+        var usdDoc = new UsdDoc
+        {
+            Header = new UsdHeader
+            {
+                TimeCodesPerSecond = 30,
+                StartTimeCode = 0,
+                EndTimeCode = endFrame
+            }
+        };
+
+        // Create root
+        usdDoc.Prims.Add(new UsdXform("root", "/"));
+        var rootPrim = usdDoc.Prims[0];
+
+        // Create skeleton structure (same as main export but without mesh)
+        var skelRoot = new UsdSkelRoot("Armature");
+        var skeleton = new UsdSkeleton("Skeleton");
+
+        // Add joint names array
+        skeleton.Attributes.Add(new UsdTokenArray("joints", jointPaths, isUniform: true));
+
+        // Add bind transforms
+        var bindTransforms = GetBindTransforms(jointPaths, bonePathMap);
+        skeleton.Attributes.Add(new UsdMatrix4dArray("bindTransforms", bindTransforms, isUniform: true));
+
+        // Add rest transforms
+        var restTransforms = GetRestTransforms(jointPaths, bonePathMap);
+        skeleton.Attributes.Add(new UsdMatrix4dArray("restTransforms", restTransforms, isUniform: true));
+
+        // Bind this animation to the skeleton
+        var animPath = $"</root/Armature/{skelAnim.Name}>";
+        skeleton.Attributes.Add(new UsdRelationship("skel:animationSource", animPath));
+
+        skelRoot.Children.Add(skeleton);
+        skelRoot.Children.Add(skelAnim);
+        rootPrim.Children.Add(skelRoot);
+
+        return usdDoc;
+    }
 }

--- a/CgfConverter/Renderers/USD/UsdRenderer.Skeleton.cs
+++ b/CgfConverter/Renderers/USD/UsdRenderer.Skeleton.cs
@@ -18,15 +18,20 @@ public partial class UsdRenderer
 
     /// <summary>Creates a USD skeleton hierarchy for skinned meshes.</summary>
     /// <param name="controllerIdToJointPath">Output mapping from bone controller IDs to USD joint paths for animation binding.</param>
+    /// <param name="jointPaths">Output list of joint paths in order.</param>
+    /// <param name="bonePathMap">Output mapping from CompiledBone to joint path.</param>
     /// <returns>The SkelRoot prim containing the skeleton.</returns>
-    private UsdSkelRoot CreateSkeleton(out Dictionary<uint, string> controllerIdToJointPath)
+    private UsdSkelRoot CreateSkeleton(
+        out Dictionary<uint, string> controllerIdToJointPath,
+        out List<string> jointPaths,
+        out Dictionary<CompiledBone, string> bonePathMap)
     {
         var skelRoot = new UsdSkelRoot("Armature");
         var skeleton = new UsdSkeleton("Skeleton");
 
         // Build joint paths (hierarchical bone names)
-        var jointPaths = new List<string>();
-        var bonePathMap = new Dictionary<CompiledBone, string>();
+        jointPaths = new List<string>();
+        bonePathMap = new Dictionary<CompiledBone, string>();
         BuildJointPaths(_cryData.SkinningInfo.RootBone, "", jointPaths, bonePathMap);
 
         // Build controller ID to joint path mapping for animation binding

--- a/CgfConverter/Renderers/USD/UsdRenderer.cs
+++ b/CgfConverter/Renderers/USD/UsdRenderer.cs
@@ -71,6 +71,11 @@ public partial class UsdRenderer : IRenderer
         return shaders;
     }
 
+    // Cached skeleton data for multi-file animation export
+    private Dictionary<uint, string>? _controllerIdToJointPath;
+    private List<string>? _jointPaths;
+    private Dictionary<CompiledBone, string>? _bonePathMap;
+
     public int Render()
     {
         var usdDoc = GenerateUsdObject();
@@ -80,6 +85,17 @@ public partial class UsdRenderer : IRenderer
         Log.D();
 
         WriteUsdToFile(usdDoc);
+
+        // Export individual animation files for Blender NLA workflow
+        // (Blender only imports single bound animation, so we export each separately)
+        if (_controllerIdToJointPath is not null && _jointPaths is not null && _bonePathMap is not null)
+        {
+            var animCount = ExportAnimationFiles(_controllerIdToJointPath, _jointPaths, _bonePathMap);
+            if (animCount > 0)
+            {
+                Log.I($"Exported {animCount} separate animation files for Blender NLA workflow");
+            }
+        }
 
         return 0;
     }
@@ -106,28 +122,28 @@ public partial class UsdRenderer : IRenderer
 
         // Check if this model has skeletal animation
         bool hasSkeleton = _cryData.SkinningInfo?.HasSkinningInfo ?? false;
-        Dictionary<uint, string>? controllerIdToJointPath = null;
 
         if (hasSkeleton)
         {
-            // Create skeleton hierarchy
+            // Create skeleton hierarchy and cache data for multi-file animation export
             Log.D("Model has skeleton with {0} bones", _cryData.SkinningInfo.CompiledBones.Count);
-            var skelRoot = CreateSkeleton(out controllerIdToJointPath);
+            var skelRoot = CreateSkeleton(out _controllerIdToJointPath, out _jointPaths, out _bonePathMap);
             rootPrim.Children.Add(skelRoot);
 
             // Add skinned node hierarchy under the skeleton root
             skelRoot.Children.AddRange(CreateNodeHierarchy());
 
             // Create animations if available
+            // Only include animation in main file if there's exactly one.
+            // Multiple animations go to separate files for Blender NLA workflow.
             if (_cryData.Animations is not null && _cryData.Animations.Count > 0)
             {
-                var animations = CreateAnimations(controllerIdToJointPath, usdDoc.Header);
-                if (animations.Count > 0)
+                var animations = CreateAnimations(_controllerIdToJointPath, usdDoc.Header);
+                if (animations.Count == 1)
                 {
-                    // Add animations under the skeleton root
+                    // Single animation - include it in the main file
                     skelRoot.Children.AddRange(animations);
 
-                    // Add animation source relationship to skeleton (use first animation as default)
                     var firstAnimName = CleanPathString(animations[0].Name);
                     var skeleton = skelRoot.Children.OfType<UsdSkeleton>().FirstOrDefault();
                     if (skeleton is not null)
@@ -135,6 +151,12 @@ public partial class UsdRenderer : IRenderer
                         skeleton.Attributes.Add(
                             new UsdRelationship("skel:animationSource", $"</root/Armature/{firstAnimName}>"));
                     }
+                }
+                else if (animations.Count > 1)
+                {
+                    // Multiple animations - they'll be exported to separate files
+                    // Main file gets skeleton + mesh only (no animation bound)
+                    Log.D($"Multiple animations ({animations.Count}) found - excluding from main file, will export separately");
                 }
             }
         }

--- a/docs/blender_usd_animation_research.md
+++ b/docs/blender_usd_animation_research.md
@@ -1,0 +1,342 @@
+# Blender USD Skeletal Animation Import Research
+
+This document analyzes how Blender imports USD skeletal animations (UsdSkelAnimation) and converts them to Blender Actions. This research is intended for implementing a USD exporter that works well with Blender's importer.
+
+## Executive Summary
+
+Blender's USD importer:
+- **Only imports ONE animation per skeleton** - the one referenced by `skel:animationSource`
+- Does NOT traverse the stage looking for multiple SkelAnimation prims
+- Names the resulting Action after the SkelAnimation prim name
+- Relies heavily on USD's `UsdSkelSkeletonQuery` API to resolve animation bindings
+
+---
+
+## 1. SkelAnimation Import Process
+
+### 1.1 How `skel:animationSource` is Read
+
+Blender does **NOT** directly read the `skel:animationSource` relationship. Instead, it uses the USD SDK's `UsdSkelSkeletonQuery` API which internally resolves this relationship.
+
+**Code path:**
+
+```
+import_skeleton() [usd_skel_convert.cc:726]
+  └─> UsdSkelCache::GetSkelQuery(skel) [line 737]
+        └─> Returns UsdSkelSkeletonQuery that internally resolves animationSource
+              └─> skel_query.GetAnimQuery() [line 102]
+                    └─> Returns UsdSkelAnimQuery for the bound animation
+```
+
+**Key code (`usd_skel_convert.cc:102-107`):**
+```cpp
+const pxr::UsdSkelAnimQuery &anim_query = skel_query.GetAnimQuery();
+
+if (!anim_query) {
+  /* No animation is defined. */
+  return;
+}
+```
+
+The `GetAnimQuery()` method follows the `skel:animationSource` relationship automatically. If no animation is bound, the function returns early.
+
+### 1.2 Time Samples to Keyframes Conversion
+
+**Location:** `import_skeleton_curves()` in `source/blender/io/usd/intern/usd_skel_convert.cc:86-320`
+
+**Step 1: Get time samples**
+```cpp
+std::vector<double> samples;
+anim_query.GetJointTransformTimeSamples(&samples);  // line 110
+```
+
+**Step 2: Create FCurves (10 per joint: 3 location + 4 rotation + 3 scale)**
+```cpp
+constexpr int curves_per_joint = 10;  // line 129
+
+// For each joint, create curves for:
+// - pose.bones["<name>"].location (indices 0-2)
+// - pose.bones["<name>"].rotation_quaternion (indices 3-6)
+// - pose.bones["<name>"].scale (indices 7-9)
+```
+
+**Step 3: Sample animation at each time code**
+```cpp
+for (const double frame : samples) {
+    pxr::VtMatrix4dArray joint_local_xforms;
+    skel_query.ComputeJointLocalTransforms(&joint_local_xforms, frame);  // line 230
+
+    // Decompose each joint's transform
+    pxr::UsdSkelDecomposeTransform(bone_xform, &t, &qrot, &s);  // line 252
+
+    // Set keyframe values using set_fcurve_sample()
+}
+```
+
+**Step 4: Finalize curves**
+```cpp
+for (FCurve *fcu : fcurves) {
+    BKE_fcurve_handles_recalc(fcu);  // line 317
+}
+```
+
+### 1.3 Transform Computation
+
+The importer computes animation relative to the bind pose:
+```cpp
+// line 245-246
+const pxr::GfMatrix4d bone_xform = joint_local_xforms.AsConst()[i] *
+                                   joint_local_bind_xforms[i].GetInverse();
+```
+
+This means the USD animation values represent the full joint-local transform, and Blender computes the delta from the bind pose.
+
+---
+
+## 2. Multiple Animation Handling
+
+### 2.1 Current Behavior
+
+**Blender only imports the SINGLE animation bound via `skel:animationSource`.** There is:
+- No code to discover multiple SkelAnimation prims in the file
+- No import option to select which animation to import
+- No code to import multiple animations as separate Actions
+
+### 2.2 Evidence from Code
+
+The stage traversal in `usd_reader_stage.cc` only creates readers for `UsdSkelSkeleton` prims, not `UsdSkelAnimation` prims:
+
+```cpp
+// usd_reader_stage.cc:271-272
+if (params_.import_skeletons && prim.IsA<pxr::UsdSkelSkeleton>()) {
+  return new USDSkeletonReader(prim, params_, settings_);
+}
+```
+
+There is no `USDSkelAnimationReader` class. Animations are imported as a side effect of importing skeletons.
+
+### 2.3 What This Means for USD File Structure
+
+If your USD file contains multiple SkelAnimation prims (e.g., `walk`, `run`, `idle`):
+- Blender will only import the one pointed to by `skel:animationSource` on the Skeleton
+- Other animations will be completely ignored
+- There is no way to import them without modifying the `skel:animationSource` binding
+
+---
+
+## 3. Action Creation Details
+
+### 3.1 Action Creation Location
+
+**File:** `source/blender/io/usd/intern/usd_skel_convert.cc`
+**Function:** `import_skeleton_curves()` starting at line 86
+
+**Action creation (lines 119-120):**
+```cpp
+bAction *act = blender::animrig::id_action_ensure(bmain, &arm_obj->id);
+BKE_id_rename(*bmain, act->id, anim_query.GetPrim().GetName().GetText());
+```
+
+### 3.2 Action Naming
+
+The Action is named after the **SkelAnimation prim's name**, not the path:
+- USD path `/Root/Skeleton/walk_anim` → Action name: `walk_anim`
+- The prim name comes from `anim_query.GetPrim().GetName().GetText()`
+
+### 3.3 FCurve Creation
+
+Curves are created using Blender's new animation system:
+```cpp
+blender::animrig::Channelbag &channelbag = blender::animrig::action_channelbag_ensure(
+    *act, arm_obj->id);
+
+// FCurve paths follow Blender conventions:
+// "pose.bones[\"BoneName\"].location"
+// "pose.bones[\"BoneName\"].rotation_quaternion"
+// "pose.bones[\"BoneName\"].scale"
+```
+
+---
+
+## 4. Import Options Affecting Animation
+
+### 4.1 Relevant Import Parameters
+
+From `source/blender/io/usd/usd.hh`:
+
+```cpp
+struct USDImportParams {
+  bool import_skeletons;     // Must be true to import armatures AND their animations
+  bool import_blendshapes;   // For blend shape animation (separate from skeletal)
+  // Note: There is NO separate "import_animation" toggle for skeletal animation
+};
+```
+
+### 4.2 Hidden `import_anim` Parameter
+
+The `import_skeleton()` function accepts an `import_anim` parameter:
+```cpp
+void import_skeleton(Main *bmain,
+                     Object *arm_obj,
+                     const pxr::UsdSkelSkeleton &skel,
+                     ReportList *reports,
+                     bool import_anim = true);  // Defaults to true
+```
+
+However, this parameter is **not exposed in the UI** - it always defaults to `true`. There's no user option to import skeleton without animation.
+
+---
+
+## 5. Hardcoded Limitations and TODOs
+
+### 5.1 Negative Determinant Matrices
+
+**Location:** `usd_skel_convert.cc:849-888`
+
+Bones with negative determinant matrices (from mirroring operations) prevent animation import:
+```cpp
+if (negative_determinant) {
+  valid_skeleton = false;
+  BKE_reportf(reports, RPT_WARNING,
+      "USD Skeleton Import: bone matrices with negative determinants detected..."
+      "The skeletal animation won't be imported");
+}
+```
+
+### 5.2 No Multiple Animation Support
+
+There are no TODOs or FIXMEs related to multiple animation import. This appears to be an intentional design decision rather than missing functionality.
+
+### 5.3 Rest Pose vs Bind Pose Handling
+
+The importer distinguishes between:
+- **Bind transforms:** World-space joint transforms at bind time (`GetJointWorldBindTransforms`)
+- **Rest transforms:** Optional rest pose that differs from bind (`HasRestPose()`, `ComputeJointLocalTransforms` with `atRest=true`)
+
+---
+
+## 6. Complete Import Code Path
+
+```
+USD_import() [usd_capi_import.cc]
+  └─> USDStageReader::collect_readers()
+        └─> create_reader_if_allowed() for UsdSkelSkeleton
+              └─> new USDSkeletonReader(prim, params, settings)
+
+  └─> reader->read_object_data()  [for each reader]
+        └─> USDSkeletonReader::read_object_data() [usd_reader_skeleton.cc:24]
+              └─> import_skeleton(bmain, object_, skel_, reports())
+                    [usd_skel_convert.cc:726]
+
+                    └─> UsdSkelCache::GetSkelQuery(skel)  // Creates skeleton query
+                    └─> Creates bones from joint hierarchy
+                    └─> Gets bind transforms
+                    └─> Sets bone parenting and lengths
+                    └─> set_rest_pose()  // If rest pose differs from bind
+                    └─> import_skeleton_curves()  // If import_anim && valid_skeleton
+                          └─> skel_query.GetAnimQuery()  // Resolves skel:animationSource
+                          └─> anim_query.GetJointTransformTimeSamples()
+                          └─> Creates Action, names it after SkelAnimation prim
+                          └─> Creates FCurves for each joint
+                          └─> Samples animation at each time code
+                          └─> Recalculates curve handles
+```
+
+---
+
+## 7. Recommendations for USD Exporter
+
+### 7.1 File Structure for Best Blender Compatibility
+
+```
+/Root
+  /Armature                    (Xform - becomes SkelRoot)
+    /Skeleton                  (UsdSkelSkeleton)
+      skel:animationSource -> </Root/Armature/Skeleton/Animation>
+
+      /Animation               (UsdSkelAnimation - CHILD of skeleton)
+        joints: [...]
+        translations: [...] (time-sampled)
+        rotations: [...] (time-sampled)
+        scales: [...] (time-sampled)
+
+    /SkinnedMesh               (UsdGeomMesh with skel binding)
+```
+
+### 7.2 Key Points
+
+1. **Single animation per skeleton**: Place ONE SkelAnimation as a child of the skeleton and bind it via `skel:animationSource`. Blender will ignore any other animations.
+
+2. **Animation prim naming**: The SkelAnimation prim name becomes the Blender Action name. Choose descriptive names.
+
+3. **Use relative paths for animationSource**: Blender's exporter uses relative paths:
+   ```cpp
+   // usd_writer_armature.cc:115-116
+   usd_skel_api.CreateAnimationSourceRel().SetTargets(
+       pxr::SdfPathVector({pxr::SdfPath(skel_anim.GetPath().GetName())}));
+   ```
+
+4. **Avoid negative scale/mirroring**: Bone matrices with negative determinants will cause animation import to fail.
+
+5. **Store decomposed transforms**: Blender expects translations, rotations (as quaternions), and scales. Using `SetTransforms()` on UsdSkelAnimation will automatically decompose matrices.
+
+6. **Joint ordering must match**: The joint order in the SkelAnimation must match the Skeleton's joint order.
+
+### 7.3 For Multiple Animations Workflow
+
+Since Blender only imports one animation, if you need multiple animations:
+
+1. **Export separate USD files** per animation, each with the animation bound via `skel:animationSource`
+
+2. **Or** modify the USD file's `skel:animationSource` relationship between imports
+
+3. **Or** wait for future Blender versions that may add multi-animation support
+
+### 7.4 Blender Export Structure Reference
+
+When Blender exports, it creates this structure (from `usd_writer_armature.cc`):
+
+```cpp
+// Skeleton path: /Root/Armature/Skeleton
+// Animation path: /Root/Armature/Skeleton/<ActionName>
+
+pxr::SdfPath anim_path = usd_export_context_.usd_path.AppendChild(anim_name);
+skel_anim = pxr::UsdSkelAnimation::Define(stage, anim_path);
+```
+
+The animation is always a direct child of the skeleton, and the action name (sanitized) is used as the prim name.
+
+---
+
+## 8. Blend Shape Animation Notes
+
+Blend shape animation follows a similar pattern but uses:
+- `GetInheritedAnimationSource()` on the skeleton's binding API
+- Falls back to `GetAnimationSource()` if inherited is not available
+- Looks for `blendShapeWeights` attribute on the SkelAnimation
+
+**Location:** `usd_skel_convert.cc:555-678`
+
+```cpp
+pxr::UsdPrim anim_prim = skel_api.GetInheritedAnimationSource();
+
+if (!anim_prim) {
+  skel_api.GetAnimationSource(&anim_prim);
+}
+```
+
+This means blend shape and skeletal animation should use the **same** SkelAnimation prim for Blender to import both correctly.
+
+---
+
+## File References
+
+| File | Description |
+|------|-------------|
+| `source/blender/io/usd/intern/usd_skel_convert.cc` | Main skeletal animation import logic |
+| `source/blender/io/usd/intern/usd_skel_convert.hh` | Header with function declarations |
+| `source/blender/io/usd/intern/usd_reader_skeleton.cc` | Skeleton prim reader |
+| `source/blender/io/usd/intern/usd_armature_utils.cc` | FCurve creation utilities |
+| `source/blender/io/usd/intern/usd_writer_armature.cc` | Export counterpart (for reference) |
+| `source/blender/io/usd/intern/usd_reader_stage.cc` | Stage traversal and reader creation |
+| `source/blender/io/usd/usd.hh` | Import/export parameters |

--- a/docs/usd_animation_research.md
+++ b/docs/usd_animation_research.md
@@ -1,0 +1,468 @@
+# USD Skeletal Animation Architecture Research
+
+This document provides research findings for implementing a USD exporter with skeletal animation support. It covers animation binding, multiple animations, and recommended organization patterns.
+
+---
+
+## 1. Multiple Animations Per Skeleton
+
+### Answer: One Animation Source Per Skeleton Instance
+
+The `skel:animationSource` relationship is **single-target only**. A skeleton can only have one active animation at any given time.
+
+### Evidence
+
+**Schema Definition** (`pxr/usd/usdSkel/schema.usda:162-169`):
+```usda
+rel skel:animationSource (
+    customData = {
+        string apiName = "animationSource"
+    }
+    doc = """Animation source to be bound to Skeleton primitives at or
+    beneath the location at which this property is defined.
+    """
+)
+```
+
+**Warning for Multiple Targets** (`pxr/usd/usdSkel/bindingAPI.cpp:361-386`):
+```cpp
+UsdPrim
+_GetFirstTargetPrimForRel(const UsdRelationship& rel,
+                          const SdfPathVector& targets)
+{
+    if (targets.size() > 0) {
+        if (targets.size() > 1) {
+            TF_WARN("%s -- relationship has more than one target. "
+                    "Only the first will be used.",
+                    rel.GetPath().GetText());
+        }
+        const SdfPath& target = targets.front();
+        // ...
+    }
+    return UsdPrim();
+}
+```
+
+This function explicitly warns and discards additional targets if multiple are specified.
+
+### API Signatures
+
+**bindingAPI.h:328-338**:
+```cpp
+/// Animation source to be bound to Skeleton primitives at or
+/// beneath the location at which this property is defined.
+USDSKEL_API
+UsdRelationship GetAnimationSourceRel() const;
+
+USDSKEL_API
+UsdRelationship CreateAnimationSourceRel() const;
+```
+
+**bindingAPI.h:440-450** (Query methods):
+```cpp
+/// Returns true if an animation source binding is defined, and sets
+/// \p prim to the target prim.
+USDSKEL_API
+bool GetAnimationSource(UsdPrim* prim) const;
+
+/// Returns the animation source bound at this prim, or one of its ancestors.
+USDSKEL_API
+UsdPrim GetInheritedAnimationSource() const;
+```
+
+---
+
+## 2. Animation Switching/Blending Support
+
+### Answer: No Native Blending - Use Value Clips for Sequencing
+
+USD does **not** have native animation blending or clip switching within UsdSkel. However:
+
+1. **Value Clips**: The official USD mechanism for animation sequencing
+2. **Future Support**: Architecture anticipates compound animation sources
+
+### No SkelAnimationClip Schema
+
+There is no `SkelAnimationClip`, `AnimationLibrary`, or animation stack concept in UsdSkel. The schema only defines:
+- `UsdSkelSkeleton` - The skeleton definition
+- `UsdSkelAnimation` - A single animation source
+- `UsdSkelBindingAPI` - Binds animations to geometry
+
+### Future Animation Blending (Not Yet Implemented)
+
+**From `pxr/usd/usdSkel/doxygen/objectModel.dox:83-87`**:
+```
+A UsdSkelAnimQuery is created through a UsdSkelCache instance. This is because
+we anticipate adding _compound_ animation sources like animation blenders
+in the future, and expect that different instances of blenders may reference
+many of the same animations, so requiring a UsdSkelAnimQuery to be constructed
+through a UsdSkelCache presents an opportunity to share references to queries
+internally.
+```
+
+### Value Clips: The Official Approach
+
+**From `pxr/usd/usdSkel/doxygen/schemas.dox:14-16`**:
+```
+Animations can be published individually and referenced back into scenes.
+This not only allows re-use, but also enables sequencing of animations as
+Value Clips.
+```
+
+Value Clips allow you to sequence multiple USD files containing animation data, switching between them over time.
+
+---
+
+## 3. Recommended Organization for Multiple Animations
+
+### Pattern A: Separate Animation Files with Value Clips (Recommended)
+
+Store each animation (walk, run, idle) as a separate `.usda` file with a `SkelAnimation`, then use Value Clips to sequence them.
+
+**Animation File Structure:**
+```
+/assets/
+  character.usda          # Main character with Skeleton
+  animations/
+    walk.usda             # SkelAnimation for walk
+    run.usda              # SkelAnimation for run
+    idle.usda             # SkelAnimation for idle
+  instances/
+    character_walking.usda   # References character + walk clips
+    character_running.usda   # References character + run clips
+```
+
+**walk.usda:**
+```usda
+#usda 1.0
+
+def SkelAnimation "WalkAnim" {
+    uniform token[] joints = ["Root", "Root/Spine", "Root/Spine/Head", ...]
+
+    float3[] translations.timeSamples = {
+        0: [(0,0,0), (0,1,0), ...],
+        1: [(0.1,0,0), (0,1,0), ...],
+        // ...
+    }
+
+    quatf[] rotations.timeSamples = {
+        0: [(1,0,0,0), (1,0,0,0), ...],
+        1: [(0.99,0.1,0,0), ...],
+        // ...
+    }
+
+    half3[] scales.timeSamples = {
+        0: [(1,1,1), (1,1,1), ...],
+    }
+}
+```
+
+**Sequence with Value Clips:**
+```usda
+#usda 1.0
+
+def SkelRoot "Character" (
+    references = @./character.usda@</Character>
+    prepend apiSchemas = ["SkelBindingAPI"]
+
+    clips = {
+        dictionary default = {
+            asset[] assetPaths = [
+                @./animations/idle.usda@,
+                @./animations/walk.usda@,
+                @./animations/run.usda@
+            ]
+            string primPath = "/WalkAnim"  # Path within each clip file
+
+            # (stage_time, clip_index) - which clip is active when
+            double2[] active = [
+                (0, 0),    # idle at frame 0
+                (30, 1),   # walk at frame 30
+                (60, 2),   # run at frame 60
+                (90, 0)    # back to idle at frame 90
+            ]
+
+            # (stage_time, clip_time) - time remapping
+            double2[] times = [
+                (0, 0), (30, 30),      # idle: stage 0-30 maps to clip 0-30
+                (30, 0), (60, 30),     # walk: stage 30-60 maps to clip 0-30
+                (60, 0), (90, 30),     # run: stage 60-90 maps to clip 0-30
+                (90, 0), (120, 30)     # idle: stage 90-120 maps to clip 0-30
+            ]
+        }
+    }
+) {
+    rel skel:animationSource = </Character/Skeleton/Anim>
+    rel skel:skeleton = </Character/Skeleton>
+}
+```
+
+### Pattern B: Hierarchical Binding Override
+
+Different skeleton instances can use different animations via inheritance override.
+
+**From test `pxr/usd/usdSkel/testenv/testUsdSkelCache/populate.usda`:**
+```usda
+def SkelRoot "AnimBinding" {
+    def Scope "Scope" (prepend apiSchemas = ["SkelBindingAPI"]) {
+        rel skel:animationSource = </Anim1>
+
+        def Skeleton "Inherit" {}
+
+        def Skeleton "Override" (prepend apiSchemas = ["SkelBindingAPI"]) {
+            rel skel:animationSource = </Anim2>
+        }
+    }
+}
+```
+
+- `Skeleton "Inherit"` uses `</Anim1>` (inherited from parent)
+- `Skeleton "Override"` uses `</Anim2>` (explicitly overridden)
+
+### Pattern C: Instance-Based Animation
+
+**From `pxr/usd/usdSkel/doxygen/schemas.dox:486-542`:**
+```usda
+over "A" (prepend apiSchemas = ["SkelBindingAPI"]) {
+    rel skel:skeleton = </Skel>
+    rel skel:animationSource = </Anim1>
+
+    over "B" (prepend apiSchemas = ["SkelBindingAPI"]) {
+        rel skel:animationSource = </Anim2>
+    }
+    over "C" (prepend apiSchemas = ["SkelBindingAPI"]) {
+        rel skel:animationSource = </Anim2>
+        rel skel:skeleton = </Skel>
+    }
+}
+```
+
+This creates two skeleton instances:
+- One at `</A>` with animation `</Anim1>`
+- One at `</A/C>` with animation `</Anim2>`
+
+---
+
+## 4. SkelAnimation Schema Definition
+
+**Full schema from `pxr/usd/usdSkel/schema.usda:92-142`:**
+
+```usda
+class SkelAnimation "SkelAnimation" (
+    inherits = </Typed>
+    doc = """Describes a skel animation, where joint animation is stored in a
+    vectorized form."""
+    customData = {
+        string className = "Animation"
+    }
+) {
+    uniform token[] joints (
+        doc = """Array of tokens identifying which joints this animation's
+        data applies to. The tokens for joints correspond to the tokens of
+        Skeleton primitives. The order of the joints as listed here may
+        vary from the order of joints on the Skeleton itself."""
+    )
+
+    float3[] translations (
+        doc = """Joint-local translations of all affected joints. Array length
+        should match the size of the *joints* attribute."""
+    )
+
+    quatf[] rotations (
+        doc = """Joint-local unit quaternion rotations of all affected joints,
+        in 32-bit precision. Array length should match the size of the
+        *joints* attribute."""
+    )
+
+    half3[] scales (
+        doc = """Joint-local scales of all affected joints, in
+        16 bit precision. Array length should match the size of the *joints*
+        attribute."""
+    )
+
+    uniform token[] blendShapes (
+         doc = """Array of tokens identifying which blend shapes this
+         animation's data applies to."""
+    )
+
+    float[] blendShapeWeights (
+        doc = """Array of weight values for each blend shape."""
+    )
+}
+```
+
+### Key Characteristics
+
+| Feature | Details |
+|---------|---------|
+| Sparse Animation | Can animate subset of joints; `joints` array specifies which |
+| Joint Order | Can differ from Skeleton's joint order |
+| Time-Sampling | `translations`, `rotations`, `scales` support `.timeSamples` |
+| Precision | rotations=32-bit float, scales=16-bit half |
+| Blend Shapes | Supported via `blendShapes` + `blendShapeWeights` |
+
+---
+
+## 5. Value Clips API Reference
+
+For animation sequencing, use `UsdClipsAPI` from `pxr/usd/usd/clipsAPI.h`.
+
+### Key Metadata
+
+| Metadata | Purpose |
+|----------|---------|
+| `assetPaths` | Array of clip file paths |
+| `primPath` | Path within clips to source data from |
+| `active` | `(stage_time, clip_index)` pairs - which clip at what time |
+| `times` | `(stage_time, clip_time)` pairs - time remapping |
+| `manifestAssetPath` | Optional manifest for optimization |
+
+### Example from `pxr/usd/usd/testenv/testUsdValueClips/multiclip/root.usda`:
+```usda
+def "Model_1" (
+    references = @./ref.usda@</Model>
+
+    clips = {
+        dictionary default = {
+            asset[] assetPaths = [@./clip1.usda@, @./clip2.usda@]
+            string primPath = "/Model"
+            double2[] active = [(0.0, 0), (16.0, 1)]
+            double2[] times = [(0.0, 0.0), (16.0, 16.0), (16.0, 0.0), (32.0, 16.0)]
+        }
+    }
+)
+{
+}
+```
+
+This sequences `clip1.usda` (frames 0-16) then `clip2.usda` (frames 16-32).
+
+---
+
+## 6. Implementation Recommendations for USD Exporter
+
+### Critical Requirements
+
+1. **Single Animation Per Skeleton Instance**
+   - Do NOT attempt multiple targets on `skel:animationSource`
+   - Export one `SkelAnimation` per binding location
+   - If source has multiple animations, export to separate files
+
+2. **Animation Source Validation**
+   ```cpp
+   // Validate before export
+   if (!UsdSkelIsSkelAnimationPrim(animPrim)) {
+       // Invalid animation source
+   }
+   ```
+
+3. **Array Size Consistency**
+   - `joints.size() == translations.size() == rotations.size() == scales.size()`
+   - All must match or export will fail silently
+
+4. **Sparse Animation Support**
+   - Animation can reference subset of skeleton joints
+   - Order doesn't need to match skeleton's joint order
+   - UsdSkel handles remapping internally
+
+5. **Joint Order Note**
+   - **Skeleton** joints: Must be topologically sorted (parent before children)
+   - **Animation** joints: No ordering requirement
+
+### Recommended Export Strategy
+
+```
+For each character with multiple animations (walk, run, idle):
+
+1. Export skeleton definition once:
+   /Character/Skeleton  (SkelSkeleton with joints, bindTransforms, restTransforms)
+
+2. Export each animation to separate prim or file:
+   /Character/Animations/Walk  (SkelAnimation)
+   /Character/Animations/Run   (SkelAnimation)
+   /Character/Animations/Idle  (SkelAnimation)
+
+3. For single-animation use:
+   - Bind directly: rel skel:animationSource = </Character/Animations/Walk>
+
+4. For animation sequencing:
+   - Use Value Clips metadata to sequence animation files
+   - Each animation in separate .usda file
+   - Clips metadata specifies timing
+```
+
+### Code Example (Pseudocode)
+
+```cpp
+// Create animation prim
+UsdSkelAnimation anim = UsdSkelAnimation::Define(stage, SdfPath("/Anim"));
+
+// Set joints (can be sparse subset)
+VtTokenArray joints = {"Root", "Root/Spine", "Root/Spine/Head"};
+anim.GetJointsAttr().Set(joints);
+
+// Set time-sampled transforms
+for (double time : keyframeTimes) {
+    VtVec3fArray translations = GetTranslationsAtTime(time);
+    VtQuatfArray rotations = GetRotationsAtTime(time);
+    VtVec3hArray scales = GetScalesAtTime(time);
+
+    anim.GetTranslationsAttr().Set(translations, UsdTimeCode(time));
+    anim.GetRotationsAttr().Set(rotations, UsdTimeCode(time));
+    anim.GetScalesAttr().Set(scales, UsdTimeCode(time));
+}
+
+// Bind animation to skeleton
+UsdSkelBindingAPI binding = UsdSkelBindingAPI::Apply(skelRootPrim);
+binding.CreateAnimationSourceRel().SetTargets({anim.GetPath()});
+```
+
+---
+
+## 7. Limitations and Caveats
+
+### Current Limitations
+
+1. **No Native Blending**: Cannot blend walk+run animations simultaneously
+2. **Single Active Animation**: Only one animation per skeleton instance at runtime
+3. **No Animation Layers**: Unlike Maya/Blender, no layered animation system
+4. **Value Clips Overhead**: Runtime clip switching has performance implications
+
+### Workarounds
+
+| Need | Solution |
+|------|----------|
+| Multiple animations | Separate files + Value Clips |
+| Blending | Pre-bake blended result, or custom runtime code |
+| Animation layers | Flatten to single animation on export |
+| Runtime switching | Value Clips or application-level logic |
+
+### Future Considerations
+
+The UsdSkel team anticipates adding "compound animation sources" including blenders. The current architecture (UsdSkelAnimQuery through UsdSkelCache) is designed to support this future expansion without breaking existing code.
+
+---
+
+## 8. File References
+
+| File | Content |
+|------|---------|
+| `pxr/usd/usdSkel/schema.usda` | Schema definitions for Skeleton, Animation |
+| `pxr/usd/usdSkel/bindingAPI.h/cpp` | Animation binding API |
+| `pxr/usd/usdSkel/animQuery.h` | Animation query interface |
+| `pxr/usd/usdSkel/doxygen/schemaOverview.dox` | Architecture documentation |
+| `pxr/usd/usdSkel/doxygen/schemas.dox` | Detailed schema docs |
+| `pxr/usd/usdSkel/doxygen/objectModel.dox` | Object model & future plans |
+| `pxr/usd/usd/clipsAPI.h` | Value Clips API |
+| `pxr/usd/usdSkel/testenv/testUsdSkelCache/populate.usda` | Binding examples |
+| `pxr/usd/usd/testenv/testUsdValueClips/multiclip/root.usda` | Clip sequencing example |
+
+---
+
+## Summary
+
+- **One animation per skeleton instance** - `skel:animationSource` is single-target
+- **Use Value Clips for sequencing** - Official USD approach for walk/run/idle switching
+- **Export animations to separate files** - Enables reuse and Value Clips composition
+- **No native blending** - Pre-bake or handle at application level
+- **Sparse animations supported** - Can animate subset of joints in any order


### PR DESCRIPTION
Blender's USD importer only reads the single animation bound via skel:animationSource, ignoring any other SkelAnimation prims in the file. This is a limitation of both UsdSkel (single-target relationship) and Blender's importer implementation.

Changes:
- When 2+ animations exist, export each to separate file (model_anim_*.usda)
- Each animation file contains skeleton + single bound animation
- Main file (model.usda) contains skeleton + mesh only (no animation)
- Single animation models still include animation in main file

Workflow in Blender:
1. Import main file (skeleton + mesh)
2. Import animation files (each creates temp armature with Action)
3. Assign Actions to main armature in Action Editor
4. Delete temp armatures, use NLA to sequence

Also adds research documentation on USD/Blender animation architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)