### PR TITLE
ArcheAge CAF animation support (0x827/0x828) + renderer cleanup

### DIFF
--- a/CgfConverter/CryEngine/CryEngine.cs
+++ b/CgfConverter/CryEngine/CryEngine.cs
@@ -460,16 +460,34 @@ public partial class CryEngine
 
     private void CreateMaterials()
     {
-        var materialStrategies = new List<Func<bool>>
-        {
-            TryLoadExplicitMaterialFiles,
-            TryLoadMaterialLibraryFiles,
-            CreateDefaultMaterials
-        };
+        if (TryLoadExplicitMaterialFiles())
+            return;
 
-        foreach (var strategy in materialStrategies)
+        var libraryFiles = GetMaterialLibraryFileNames().ToList();
+
+        if (libraryFiles.Any())
         {
-            if (strategy()) return;
+            foreach (var libraryFile in libraryFiles)
+            {
+                var key = Path.GetFileNameWithoutExtension(libraryFile) ?? "unknown";
+
+                if (TryLoadSingleMaterialFile(libraryFile))
+                {
+                    if (!MaterialFiles.Contains(libraryFile))
+                        MaterialFiles.Add(libraryFile);
+                    continue;
+                }
+
+                if (TryLoadModelNameMaterialFile(key))
+                    continue;
+
+                CreateDefaultMaterialsForLibrary(key);
+            }
+        }
+        else
+        {
+            if (!TryLoadModelNameMaterialFile(null))
+                CreateDefaultMaterials();
         }
     }
 
@@ -491,62 +509,61 @@ public partial class CryEngine
         return loadedAny;
     }
 
-    private bool TryLoadMaterialLibraryFiles()
+    private bool TryLoadModelNameMaterialFile(string? libraryKey)
     {
-        var libraryFiles = GetMaterialLibraryFileNames();
-        if (!libraryFiles.Any())
+        var modelName = Name;
+        var key = libraryKey ?? modelName;
+
+        if (Materials.ContainsKey(key))
+            return true;
+
+        var fullyQualifiedPath = GetFullMaterialFilePath(modelName);
+        if (fullyQualifiedPath is null)
+            return false;
+
+        try
         {
-            Log.I("No material library files found in model chunks");
+            var material = MaterialUtilities.FromStream(
+                PackFileSystem.GetStream(fullyQualifiedPath),
+                modelName,
+                ObjectDir,
+                closeAfter: true);
+
+            Materials.Add(key, material);
+            if (!MaterialFiles.Contains(key))
+                MaterialFiles.Add(key);
+
+            Log.I("Loaded model-name material file: {0} (stored as '{1}')", modelName, key);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.W("Failed to load model-name material file {0}: {1}", modelName, ex.Message);
             return false;
         }
-
-        Log.I("Loading materials from library chunks: {0}", string.Join(", ", libraryFiles));
-
-        var loadedAny = false;
-        foreach (var libraryFile in libraryFiles)
-        {
-            if (TryLoadSingleMaterialFile(libraryFile))
-            {
-                loadedAny = true;
-                // Add to MaterialFiles list for consistency
-                if (!MaterialFiles.Contains(libraryFile))
-                    MaterialFiles.Add(libraryFile);
-            }
-        }
-
-        return loadedAny;
     }
 
-    private bool CreateDefaultMaterials()
+    private void CreateDefaultMaterialsForLibrary(string key)
+    {
+        if (Materials.ContainsKey(key))
+            return;
+
+        Log.W("Creating dummy materials for library: {0}", key);
+        var maxMaterials = CalculateMaxMaterialCount();
+        Materials.Add(key, CreateDefaultMaterialSet(maxMaterials));
+        if (!MaterialFiles.Contains(key))
+            MaterialFiles.Add(key);
+    }
+
+    private void CreateDefaultMaterials()
     {
         Log.W("Unable to find any material files for this model. Creating dummy materials.");
 
-        var libraryFiles = GetMaterialLibraryFileNames();
-        if (!libraryFiles.Any())
-        {
-            // Create a single default material with unknown key
-            var defaultKey = "default";
-            var maxMats = CalculateMaxMaterialCount();
-            var defaultMaterial = CreateDefaultMaterialSet(maxMats);
-            Materials.Add(defaultKey, defaultMaterial);
-            MaterialFiles.Add(defaultKey);
-            return true;
-        }
-
-        // Create default materials for each library file found
-        var maxMaterials = CalculateMaxMaterialCount();
-        foreach (var libraryFile in libraryFiles)
-        {
-            var key = Path.GetFileNameWithoutExtension(libraryFile) ?? "unknown";
-            if (!Materials.ContainsKey(key))
-            {
-                var defaultMaterial = CreateDefaultMaterialSet(maxMaterials);
-                Materials.Add(key, defaultMaterial);
-                MaterialFiles.Add(libraryFile);
-            }
-        }
-
-        return Materials.Count > 0;
+        var defaultKey = "default";
+        var maxMats = CalculateMaxMaterialCount();
+        var defaultMaterial = CreateDefaultMaterialSet(maxMats);
+        Materials.Add(defaultKey, defaultMaterial);
+        MaterialFiles.Add(defaultKey);
     }
 
     private bool TryLoadSingleMaterialFile(string materialFile)

--- a/CgfConverter/CryEngine/CryEngine.cs
+++ b/CgfConverter/CryEngine/CryEngine.cs
@@ -1169,12 +1169,27 @@ public partial class CryEngine
             }
         }
 
-        // Process controller chunks (829/831 = compressed, 830 = uncompressed CryKeyPQLog)
+        // Process controller chunks (829/831 = compressed, 827/830 = uncompressed CryKeyPQLog)
+        var controllers827 = cafModel.ChunkMap.Values.OfType<ChunkController_827>().ToList();
         var controllers829 = cafModel.ChunkMap.Values.OfType<CryEngineCore.Chunks.ChunkController_829>().ToList();
         var controllers830 = cafModel.ChunkMap.Values.OfType<ChunkController_830>().ToList();
         var controllers831 = cafModel.ChunkMap.Values.OfType<ChunkController_831>().ToList();
 
-        // 830 uses unified key times for both rotation and position
+        // 827 and 830 use unified key times for both rotation and position
+        foreach (var ctrl in controllers827)
+        {
+            var keyTimes = ctrl.KeyTimes.Select(t => (float)t).ToList();
+            var track = new BoneTrack
+            {
+                ControllerId = ctrl.ControllerId,
+                RotationKeyTimes = keyTimes,
+                PositionKeyTimes = keyTimes,
+                Positions = ctrl.KeyPositions.ToList(),
+                Rotations = ctrl.KeyRotations.ToList()
+            };
+            animation.BoneTracks[ctrl.ControllerId] = track;
+        }
+
         foreach (var ctrl in controllers830)
         {
             var keyTimes = ctrl.KeyTimes.Select(t => (float)t).ToList();

--- a/CgfConverter/CryEngine/CryEngine.cs
+++ b/CgfConverter/CryEngine/CryEngine.cs
@@ -467,6 +467,7 @@ public partial class CryEngine
 
         if (libraryFiles.Any())
         {
+            var loadedAny = false;
             foreach (var libraryFile in libraryFiles)
             {
                 var key = Path.GetFileNameWithoutExtension(libraryFile) ?? "unknown";
@@ -475,13 +476,27 @@ public partial class CryEngine
                 {
                     if (!MaterialFiles.Contains(libraryFile))
                         MaterialFiles.Add(libraryFile);
+                    loadedAny = true;
                     continue;
                 }
 
                 if (TryLoadModelNameMaterialFile(key))
+                {
+                    loadedAny = true;
                     continue;
+                }
 
-                CreateDefaultMaterialsForLibrary(key);
+                Log.W("Could not find material file for library: {0}, skipping", key);
+            }
+
+            // Only create dummy materials if nothing at all could be loaded
+            if (!loadedAny)
+            {
+                foreach (var libraryFile in libraryFiles)
+                {
+                    var key = Path.GetFileNameWithoutExtension(libraryFile) ?? "unknown";
+                    CreateDefaultMaterialsForLibrary(key);
+                }
             }
         }
         else

--- a/CgfConverter/CryEngineCore/Chunks/ChunkController_827.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkController_827.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Numerics;
+using CgfConverter.Services;
+using Extensions;
+
+namespace CgfConverter.CryEngineCore;
+
+/// <summary>
+/// Controller chunk version 0x827 - Uncompressed CryKeyPQLog format (legacy).
+/// Used in old 0x744-format CAF animation files (e.g. ArcheAge).
+///
+/// Identical to 0x830 but without the Flags field and without an embedded local
+/// chunk header — the chunk data starts directly at the offset from the chunk table.
+///
+/// Binary layout:
+///   uint32  numKeys
+///   uint32  nControllerId  (CRC32 of bone name)
+///   [numKeys × CryKeyPQLog]:
+///     int32   nTime   (keyframe tick)
+///     float3  vPos    (position)
+///     float3  vRotLog (quaternion logarithm: axis × half-angle)
+/// </summary>
+internal sealed class ChunkController_827 : ChunkController
+{
+    /// <summary>Number of keyframes.</summary>
+    public uint NumKeys { get; internal set; }
+
+    /// <summary>CRC32 of the bone name this controller animates.</summary>
+    public uint ControllerId { get; internal set; }
+
+    /// <summary>Keyframe times in ticks.</summary>
+    public List<int> KeyTimes { get; internal set; } = [];
+
+    /// <summary>Keyframe positions.</summary>
+    public List<Vector3> KeyPositions { get; internal set; } = [];
+
+    /// <summary>Keyframe rotations (converted from log quaternion).</summary>
+    public List<Quaternion> KeyRotations { get; internal set; } = [];
+
+    public override void Read(BinaryReader b)
+    {
+        // 0x827 chunks have no embedded local header — bypass the base.Read() local-header
+        // logic and initialise directly from the chunk table header.
+        ChunkType = _header.ChunkType;
+        VersionRaw = _header.VersionRaw;
+        Offset = _header.Offset;
+        ID = _header.ID;
+        Size = _header.Size;
+        DataSize = Size;
+
+        b.BaseStream.Seek(_header.Offset, SeekOrigin.Begin);
+        ((EndiannessChangeableBinaryReader)b).IsBigEndian = false;
+
+        NumKeys = b.ReadUInt32();
+        ControllerId = b.ReadUInt32();
+
+        for (int i = 0; i < NumKeys; i++)
+        {
+            int time = b.ReadInt32();
+            Vector3 position = b.ReadVector3();
+            Vector3 rotLog = b.ReadVector3();
+
+            KeyTimes.Add(time);
+            KeyPositions.Add(position);
+            KeyRotations.Add(LogToQuaternion(rotLog));
+        }
+    }
+
+    /// <summary>
+    /// Converts a CryKeyPQLog rotation logarithm to a quaternion.
+    /// vRotLog = axis × half-angle; mirrors CryEngine's Quat::exp(Vec3).
+    /// </summary>
+    private static Quaternion LogToQuaternion(Vector3 rotLog)
+    {
+        float theta = rotLog.Length(); // = half-angle
+        if (theta < 0.0001f)
+            return Quaternion.Identity;
+
+        float sinTheta = MathF.Sin(theta);
+        float cosTheta = MathF.Cos(theta);
+        float s = sinTheta / theta;
+
+        return new Quaternion(rotLog.X * s, rotLog.Y * s, rotLog.Z * s, cosTheta);
+    }
+
+    public override string ToString() =>
+        $"ChunkController_827: ID={ID:X}, ControllerId={ControllerId:X}, NumKeys={NumKeys}";
+}

--- a/CgfConverter/CryEngineCore/Chunks/ChunkController_828.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkController_828.cs
@@ -1,6 +1,4 @@
 using System.IO;
-using CgfConverter.Services;
-using Extensions;
 
 namespace CgfConverter.CryEngineCore;
 

--- a/CgfConverter/CryEngineCore/Chunks/ChunkController_828.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkController_828.cs
@@ -1,0 +1,32 @@
+using System.IO;
+using CgfConverter.Services;
+using Extensions;
+
+namespace CgfConverter.CryEngineCore;
+
+/// <summary>
+/// Controller chunk version 0x828 - Empty/unsupported format.
+///
+/// In the Lumberyard source (CryHeaders.h), CONTROLLER_CHUNK_DESC_0828 is defined as an
+/// empty struct with no fields. The engine logs a warning and skips it entirely.
+/// We read no data and produce no bone tracks.
+/// </summary>
+internal sealed class ChunkController_828 : ChunkController
+{
+    public override void Read(BinaryReader b)
+    {
+        // 0x828 has no data fields — initialise from chunk table header only.
+        ChunkType = _header.ChunkType;
+        VersionRaw = _header.VersionRaw;
+        Offset = _header.Offset;
+        ID = _header.ID;
+        Size = _header.Size;
+        DataSize = Size;
+
+        Utilities.HelperMethods.Log(Utilities.LogLevelEnum.Warning,
+            $"ChunkController_828 (ID={ID:X}) is not supported by CryEngine and will be skipped.");
+    }
+
+    public override string ToString() =>
+        $"ChunkController_828: ID={ID:X} (unsupported/empty)";
+}

--- a/CgfConverter/CryEngineCore/Model.cs
+++ b/CgfConverter/CryEngineCore/Model.cs
@@ -181,10 +181,13 @@ public class Model
     {
         b.BaseStream.Seek(ChunkTableOffset, SeekOrigin.Begin);
 
-        // For 0x744 format the NumChunks header field is unreliable in CAF animation files
-        // (it contains unrelated data rather than chunk count). Compute the actual count
-        // from the bytes remaining in the file, since ChunkHeader_744 is exactly 16 bytes.
-        if (FileVersion == FileVersion.x0744)
+        // For 0x744-format CAF animation files the NumChunks header field is unreliable
+        // (it contains frame count or other unrelated data rather than the chunk count).
+        // Compute the actual count from the bytes remaining at the chunk table position,
+        // since ChunkHeader_744 is exactly 16 bytes.  Other 0x744 file types (.cga, .cgf,
+        // .chr, .skin) have a correct NumChunks in their header, so we leave those alone.
+        if (FileVersion == FileVersion.x0744 &&
+            string.Equals(Path.GetExtension(FileName), ".caf", StringComparison.OrdinalIgnoreCase))
         {
             var availableBytes = b.BaseStream.Length - b.BaseStream.Position;
             NumChunks = (uint)(availableBytes / 16);

--- a/CgfConverter/CryEngineCore/Model.cs
+++ b/CgfConverter/CryEngineCore/Model.cs
@@ -181,6 +181,15 @@ public class Model
     {
         b.BaseStream.Seek(ChunkTableOffset, SeekOrigin.Begin);
 
+        // For 0x744 format the NumChunks header field is unreliable in CAF animation files
+        // (it contains unrelated data rather than chunk count). Compute the actual count
+        // from the bytes remaining in the file, since ChunkHeader_744 is exactly 16 bytes.
+        if (FileVersion == FileVersion.x0744)
+        {
+            var availableBytes = b.BaseStream.Length - b.BaseStream.Position;
+            NumChunks = (uint)(availableBytes / 16);
+        }
+
         for (int i = 0; i < NumChunks; i++)
         {
             ChunkHeader header = Chunk.New<ChunkHeader>((uint)FileVersion);

--- a/CgfConverter/Renderers/Gltf/BaseGltfRenderer.Geometry.cs
+++ b/CgfConverter/Renderers/Gltf/BaseGltfRenderer.Geometry.cs
@@ -19,7 +19,12 @@ public partial class BaseGltfRenderer
     protected void CreateGltfNodeInto(List<int> nodes, CryEngine cryData, bool omitSkins = false)
     {
         if (cryData.MaterialFiles is not null)
-            WriteMaterial(cryData.MaterialFiles.FirstOrDefault(), cryData.Materials.Values.FirstOrDefault());
+        {
+            var materialFile = cryData.MaterialFiles.FirstOrDefault();
+            var material = cryData.Materials.Values.FirstOrDefault();
+            if (materialFile is not null && material is not null)
+                WriteMaterial(materialFile, material);
+        }
 
         // For Ivo format with skinning, create skeleton first and attach meshes to skeleton nodes
         // This ensures geometry moves with the skeleton
@@ -1081,11 +1086,6 @@ public partial class BaseGltfRenderer
         WrittenMaterial? FindMaterial(int matId)
         {
             // TODO: This only works for models with a single material file. Should be almost all models, but some may fail here.
-            var allSubMaterials = cryData.Materials.Values
-                .Where(material => material?.SubMaterials != null)
-                .SelectMany(material => material.SubMaterials);
-
-
             if (cryData.Materials?.First().Value.SubMaterials is not {} submats)
                 return null;
             if (matId >= submats.Length || matId < 0)

--- a/CgfConverter/Renderers/Gltf/BaseGltfRenderer.Geometry.cs
+++ b/CgfConverter/Renderers/Gltf/BaseGltfRenderer.Geometry.cs
@@ -1,4 +1,5 @@
-﻿using CgfConverter.CryEngineCore;
+﻿using System.IO;
+using CgfConverter.CryEngineCore;
 using CgfConverter.Renderers.Gltf.Models;
 using Extensions;
 using System;
@@ -20,10 +21,12 @@ public partial class BaseGltfRenderer
     {
         if (cryData.MaterialFiles is not null)
         {
-            var materialFile = cryData.MaterialFiles.FirstOrDefault();
-            var material = cryData.Materials.Values.FirstOrDefault();
-            if (materialFile is not null && material is not null)
-                WriteMaterial(materialFile, material);
+            foreach (var materialFile in cryData.MaterialFiles)
+            {
+                var key = Path.GetFileNameWithoutExtension(materialFile) ?? materialFile;
+                if (cryData.Materials.TryGetValue(key, out var material))
+                    WriteMaterial(materialFile, material);
+            }
         }
 
         // For Ivo format with skinning, create skeleton first and attach meshes to skeleton nodes

--- a/CgfConverter/Renderers/Gltf/BaseGltfRenderer.Material.cs
+++ b/CgfConverter/Renderers/Gltf/BaseGltfRenderer.Material.cs
@@ -118,7 +118,10 @@ public partial class BaseGltfRenderer
 
     protected void WriteMaterial(string materialFile, Material material)
     {
-        foreach (Material submat in material.SubMaterials!)
+        if (material.SubMaterials is null)
+            return;
+
+        foreach (Material submat in material.SubMaterials)
         {
             (string MaterialFile, string SubMaterialName) key = (materialFile, submat.Name!);
             if (_materialMap.ContainsKey(key))

--- a/CgfConverter/Renderers/USD/UsdRenderer.Skeleton.cs
+++ b/CgfConverter/Renderers/USD/UsdRenderer.Skeleton.cs
@@ -53,7 +53,8 @@ public partial class UsdRenderer
         // Build joint paths (hierarchical bone names)
         jointPaths = new List<string>();
         bonePathMap = new Dictionary<CompiledBone, string>();
-        BuildJointPaths(_cryData.SkinningInfo.RootBone, "", jointPaths, bonePathMap);
+        var usedPaths = new HashSet<string>();
+        BuildJointPaths(_cryData.SkinningInfo.RootBone, "", jointPaths, bonePathMap, usedPaths);
 
         // Build controller ID to joint path mapping for animation binding
         // Add both stored controller IDs and computed CRC32 hashes of bone names
@@ -129,7 +130,7 @@ public partial class UsdRenderer
     }
 
     /// <summary>Recursively builds joint path strings in USD format (e.g., "Bip01/bip_01_Pelvis/bip_01_Spine").</summary>
-    private void BuildJointPaths(CompiledBone? bone, string parentPath, List<string> jointPaths, Dictionary<CompiledBone, string> bonePathMap)
+    private void BuildJointPaths(CompiledBone? bone, string parentPath, List<string> jointPaths, Dictionary<CompiledBone, string> bonePathMap, HashSet<string> usedPaths)
     {
         if (bone == null) return;
 
@@ -144,6 +145,16 @@ public partial class UsdRenderer
             ? cleanName
             : $"{parentPath}/{cleanName}";
 
+        // Deduplicate: if path already exists, append numeric suffix
+        if (!usedPaths.Add(bonePath))
+        {
+            int suffix = 1;
+            while (!usedPaths.Add($"{bonePath}_{suffix}"))
+                suffix++;
+            bonePath = $"{bonePath}_{suffix}";
+            Log.W($"Duplicate bone path detected for '{bone.BoneName}', renamed to '{bonePath}'");
+        }
+
         jointPaths.Add(bonePath);
         bonePathMap[bone] = bonePath;
 
@@ -151,7 +162,7 @@ public partial class UsdRenderer
         var childBones = _cryData.SkinningInfo.GetChildBones(bone);
         foreach (var childBone in childBones)
         {
-            BuildJointPaths(childBone, bonePath, jointPaths, bonePathMap);
+            BuildJointPaths(childBone, bonePath, jointPaths, bonePathMap, usedPaths);
         }
     }
 

--- a/CgfConverter/Utilities/FileHandlingExtensions.cs
+++ b/CgfConverter/Utilities/FileHandlingExtensions.cs
@@ -25,7 +25,7 @@ public static class FileHandlingExtensions
             // 1. Check in objectDir (most common case for Cryengine)
             if (dataDirs is not null && dataDirs.Count > 0)
             {
-                foreach (var dataDir in dataDirs)
+                foreach (var dataDir in dataDirs.Where(d => d is not null))
                 {
                     var texturePath = Path.Combine(dataDir, img);
                     if (fs.Exists(texturePath))

--- a/CgfConverterIntegrationTests/IntegrationTests/ArcheAge/ArcheAgeTests.cs
+++ b/CgfConverterIntegrationTests/IntegrationTests/ArcheAge/ArcheAgeTests.cs
@@ -9,6 +9,7 @@ using CgfConverterTests.TestUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Threading;
 
 namespace CgfConverterTests.IntegrationTests;
@@ -267,8 +268,9 @@ public class ArcheAgeTests
         var gltf = GenerateGltf(cryData);
 
         Assert.AreEqual(5, gltf.Materials.Count);
-        Assert.AreEqual(1, gltf.Meshes.Count);
-        Assert.AreEqual("basket_mix_ani", gltf.Nodes[0].Name);
+        Assert.AreEqual(2, gltf.Meshes.Count);
+        Assert.IsTrue(gltf.Nodes.Any(n => n.Name == "basket_mix_ani"), "Should contain basket_mix_ani node");
+        Assert.IsTrue(gltf.Nodes.Any(n => n.Name == "tool_farm_d"), "Should contain tool_farm_d node");
     }
 
     [TestMethod]

--- a/CgfConverterIntegrationTests/IntegrationTests/ArcheAge/ArcheAgeTests.cs
+++ b/CgfConverterIntegrationTests/IntegrationTests/ArcheAge/ArcheAgeTests.cs
@@ -1,8 +1,14 @@
-﻿using CgfConverter;
+using CgfConverter;
 using CgfConverter.Renderers.Collada;
+using CgfConverter.Renderers.Collada.Collada;
+using CgfConverter.Renderers.Gltf;
+using CgfConverter.Renderers.Gltf.Models;
+using CgfConverter.Renderers.USD;
+using CgfConverter.Renderers.USD.Models;
 using CgfConverterTests.TestUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Globalization;
+using System.IO;
 using System.Threading;
 
 namespace CgfConverterTests.IntegrationTests;
@@ -11,9 +17,8 @@ namespace CgfConverterTests.IntegrationTests;
 [TestCategory("integration")]
 public class ArcheAgeTests
 {
-    // Archeage tests have the objectdir at the game directory level instead of object dir.  So although the
-    // game files are under d:\depot\archeage\game, the object dir is d:\depot\archeage.  The material files
-    // are referencing the game directory.
+    // Archeage objectdir is at the game directory level (d:\depot\archeage), not the objects subdirectory.
+    // Material files reference paths relative to this root (e.g., game\objects\...).
     private readonly TestUtils testUtils = new();
     private readonly string objectDir = @"d:\depot\archeage";
 
@@ -23,53 +28,86 @@ public class ArcheAgeTests
         CultureInfo customCulture = (CultureInfo)Thread.CurrentThread.CurrentCulture.Clone();
         customCulture.NumberFormat.NumberDecimalSeparator = ".";
         Thread.CurrentThread.CurrentCulture = customCulture;
-
         testUtils.GetSchemaSet();
     }
 
-    [TestMethod]
-    public void ArcheAge_ChrFileTest()
-    {
-        var args = new string[]
-        {
-            @"d:\depot\archeage\game\objects\characters\animals\bird\bird_a.chr",
-            "-dds",
-            "-obj", objectDir,
-            "-mtl", "bird_a.mtl"
-        };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(args[5], args[3]));
-        cryData.ProcessCryengineFiles();
+    #region Shared Helpers
 
-        var colladaData = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
-        var daeObject = colladaData.DaeObject;
-        colladaData.GenerateDaeObject();
-        int actualMaterialsCount = colladaData.DaeObject.Library_Materials.Material.Length;
-        Assert.AreEqual(2, actualMaterialsCount);
+    private CryEngine ProcessCryEngineFile(string file, string? matFile = null, bool includeAnimations = false)
+    {
+        var args = new string[] { file, "-objectdir", objectDir };
+        testUtils.argsHandler.ProcessArgs(args);
+
+        var options = new CryEngineOptions(matFile, objectDir, includeAnimations);
+        var cryData = new CryEngine(file, testUtils.argsHandler.Args.PackFileSystem, options);
+        cryData.ProcessCryengineFiles();
+        return cryData;
+    }
+
+    private ColladaDoc GenerateCollada(CryEngine cryData, bool validate = true)
+    {
+        var colladaRenderer = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
+        colladaRenderer.GenerateDaeObject();
+
+        if (validate)
+            testUtils.ValidateColladaXml(colladaRenderer);
+
+        return colladaRenderer.DaeObject;
+    }
+
+    private GltfRoot GenerateGltf(CryEngine cryData)
+    {
+        var gltfRenderer = new GltfModelRenderer(testUtils.argsHandler.Args, cryData);
+        return gltfRenderer.GenerateGltfObject();
+    }
+
+    private string GenerateUsdString(CryEngine cryData)
+    {
+        var usdRenderer = new UsdRenderer(testUtils.argsHandler.Args, cryData);
+        var usdDoc = usdRenderer.GenerateUsdObject();
+
+        var serializer = new UsdSerializer();
+        using var writer = new StringWriter();
+        serializer.Serialize(usdDoc, writer);
+        return writer.ToString();
+    }
+
+    #endregion
+
+    #region Bird .chr
+
+    [TestMethod]
+    public void Bird_Collada_SkeletonAndMaterials()
+    {
+        var cryData = ProcessCryEngineFile(
+            $@"{objectDir}\game\objects\characters\animals\bird\bird_a.chr", "bird_a.mtl");
+        var dae = GenerateCollada(cryData);
+
+        Assert.AreEqual(2, dae.Library_Materials.Material.Length);
 
         // Controller check
-        var controller = daeObject.Library_Controllers.Controller;
+        var controller = dae.Library_Controllers.Controller;
         var expectedBones = "Bone04 Bone05 Bone01 Bone06 Bone06(mirrored) Bone02 Bone07 Bone08 Bone07(mirrored) Bone08(mirrored)";
         Assert.IsTrue(controller[0].Skin.Source[0].Name_Array.Value_Pre_Parse.StartsWith(expectedBones));
         var expectedBpm = "1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 1 0 0 0.100000 0 1 0 0 0 0 1 0 0 0 0 1 -0 0 -1 -0 -0.999108 0.042216 0 -0.071707 0.042216 0.999108 0 0.018175 0 0 0 1 0.967510 -0.183784 -0.173634 0.007351 0.186228 0.982504 -0.002255 -0.008423 0.171010 -0.030154 0.984808 0.026689";
         Assert.IsTrue(controller[0].Skin.Source[1].Float_Array.Value_As_String.StartsWith(expectedBpm));
         Assert.AreEqual(160, controller[0].Skin.Source[1].Float_Array.Count);
 
-        // Visual Scene Check
-        Assert.AreEqual("Scene", daeObject.Scene.Visual_Scene.Name);
-        Assert.AreEqual("#Scene", daeObject.Scene.Visual_Scene.URL);
-        Assert.AreEqual(1, daeObject.Library_Visual_Scene.Visual_Scene.Length);
-        Assert.AreEqual("Scene", daeObject.Library_Visual_Scene.Visual_Scene[0].ID);
-        Assert.AreEqual(2, daeObject.Library_Visual_Scene.Visual_Scene[0].Node.Length);
+        // Visual scene
+        Assert.AreEqual("Scene", dae.Scene.Visual_Scene.Name);
+        Assert.AreEqual("#Scene", dae.Scene.Visual_Scene.URL);
+        Assert.AreEqual(1, dae.Library_Visual_Scene.Visual_Scene.Length);
+        Assert.AreEqual("Scene", dae.Library_Visual_Scene.Visual_Scene[0].ID);
+        Assert.AreEqual(2, dae.Library_Visual_Scene.Visual_Scene[0].Node.Length);
 
-        // Armature Node check
-        var node = daeObject.Library_Visual_Scene.Visual_Scene[0].Node[0];
+        // Armature root bone
+        var node = dae.Library_Visual_Scene.Visual_Scene[0].Node[0];
         Assert.AreEqual("Bone04", node.ID);
         Assert.AreEqual("Bone04", node.sID);
         Assert.AreEqual("Bone04", node.Name);
         Assert.AreEqual("JOINT", node.Type.ToString());
         Assert.AreEqual("1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1", node.Matrix[0].Value_As_String);
+
         var locatorBone = node.node[0];
         Assert.AreEqual("Bone05", locatorBone.ID);
         Assert.AreEqual("Bone05", locatorBone.Name);
@@ -79,125 +117,214 @@ public class ArcheAgeTests
     }
 
     [TestMethod]
-    public void ArcheAge_ChrFileTest_VerifyMaterials()
+    public void Bird_Collada_MaterialAutoDiscovery()
     {
-        var args = new string[]
-        {
-            $@"{objectDir}\game\objects\characters\animals\bird\bird_a.chr"
-        };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir));
-        cryData.ProcessCryengineFiles();
+        var cryData = ProcessCryEngineFile(
+            $@"{objectDir}\game\objects\characters\animals\bird\bird_a.chr");
+        var dae = GenerateCollada(cryData);
 
-        var colladaData = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
-        var daeObject = colladaData.DaeObject;
-        colladaData.GenerateDaeObject();
-        int actualMaterialsCount = colladaData.DaeObject.Library_Materials.Material.Length;
-        Assert.AreEqual(2, actualMaterialsCount);
+        Assert.AreEqual(2, dae.Library_Materials.Material.Length);
     }
 
     [TestMethod]
-    public void DrugBoy_Chr()
+    public void Bird_Gltf_SkeletonAndMaterials()
     {
-        // Camera has controller id 0xffffffff just like parent Bip01.
-        var args = new string[]
-        {
-            $@"{objectDir}\game\objects\characters\people\drug_boy01\face\drug_boy01_face01\drug_boy01_face01.chr"
-        };
+        var cryData = ProcessCryEngineFile(
+            $@"{objectDir}\game\objects\characters\animals\bird\bird_a.chr", "bird_a.mtl");
+        var gltf = GenerateGltf(cryData);
 
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir));
-        cryData.ProcessCryengineFiles();
+        Assert.AreEqual(2, gltf.Materials.Count);
+        Assert.AreEqual(1, gltf.Meshes.Count);
 
-        var colladaData = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
-        var daeObject = colladaData.DaeObject;
-        colladaData.GenerateDaeObject();
+        // Skeleton: 10 bones (Bone04..Bone08 + mirrored variants)
+        Assert.AreEqual(1, gltf.Skins.Count);
+        Assert.AreEqual(10, gltf.Skins[0].Joints.Count);
+
+        // Root bone
+        Assert.AreEqual("Bone04", gltf.Nodes[0].Name);
     }
 
     [TestMethod]
-    public void Basket_Mix_Ani_Cga()
+    public void Bird_Usd_SkeletonAndMaterials()
     {
-        // 2 material files used in this model.  Make sure both are loaded.
-        // The textures for the basket mtl file are missing.
-        var args = new string[] { @"D:\depot\archeage\game\objects\env\01_nuia\001_housing\01_tools\basket_mix_ani.cga" };
+        var cryData = ProcessCryEngineFile(
+            $@"{objectDir}\game\objects\characters\animals\bird\bird_a.chr", "bird_a.mtl");
+        var usdOutput = GenerateUsdString(cryData);
 
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions("basket_mix.mtl,tool_farm_d.mtl", @"d:\depot\archeage"));
-        cryData.ProcessCryengineFiles();
+        Assert.IsTrue(usdOutput.Contains("def Skeleton \"Skeleton\""), "Should have Skeleton prim");
+        Assert.IsTrue(usdOutput.Contains("Bone04"), "Should contain root bone Bone04");
+        Assert.IsTrue(usdOutput.Contains("Bone05"), "Should contain child bone Bone05");
+        Assert.IsTrue(usdOutput.Contains("point3f[] points"), "Should have geometry points");
+        Assert.IsTrue(usdOutput.Contains("normal3f[] normals"), "Should have normals");
+        Assert.IsTrue(usdOutput.Contains("primvars:skel:jointIndices"), "Should have joint indices");
+        Assert.IsTrue(usdOutput.Contains("primvars:skel:jointWeights"), "Should have joint weights");
+    }
 
-        var colladaData = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
-        colladaData.GenerateDaeObject();
-        var daeObject = colladaData.DaeObject;
-        var imageLibrary = daeObject.Library_Images;
-        var materialLibrary = daeObject.Library_Materials;
-        var effectLibrary = daeObject.Library_Effects;
-        var visualSceneLibrary = daeObject.Library_Visual_Scene;
+    #endregion
 
-        // Material library checks
-        Assert.AreEqual(5, materialLibrary.Material.Length);
-        Assert.AreEqual("basket_mix_mtl_basket_mix-material", materialLibrary.Material[0].ID);
-        Assert.AreEqual("#basket_mix_mtl_basket_mix-effect", materialLibrary.Material[0].Instance_Effect.URL);
-        // Library images checks
-        Assert.AreEqual(7, imageLibrary.Image.Length);
-        Assert.AreEqual("tool_farm_d_mtl_wood_Diffuse", imageLibrary.Image[3].Name);
-        // Library effects checks
-        Assert.AreEqual(5, effectLibrary.Effect.Length);
-        Assert.AreEqual("basket_mix_mtl_basket_mix-effect", effectLibrary.Effect[0].ID);
-        Assert.AreEqual("basket_mix_mtl_basket_mix_Diffuse-sampler", effectLibrary.Effect[0].Profile_COMMON[0].Technique.Phong.Diffuse.Texture.Texture);
-        Assert.AreEqual(6, effectLibrary.Effect[0].Profile_COMMON[0].New_Param.Length);
-        // Library visual scenes checks
-        Assert.AreEqual(1, visualSceneLibrary.Visual_Scene.Length);
-        Assert.AreEqual("basket_mix_ani", visualSceneLibrary.Visual_Scene[0].Node[0].Name);
-        Assert.AreEqual("basket_mix_ani", visualSceneLibrary.Visual_Scene[0].Node[0].Instance_Geometry[0].Name);
-        Assert.AreEqual("#basket_mix_ani-mesh", visualSceneLibrary.Visual_Scene[0].Node[0].Instance_Geometry[0].URL);
-        Assert.AreEqual("#basket_mix_mtl_basket_mix-material", visualSceneLibrary.Visual_Scene[0].Node[0].Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[0].Target);
-        Assert.AreEqual("#basket_mix_mtl_proxy-material", visualSceneLibrary.Visual_Scene[0].Node[0].Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[1].Target);
+    #region DrugBoy .chr (camera controller edge case)
+
+    [TestMethod]
+    public void DrugBoy_Collada_CameraControllerEdgeCase()
+    {
+        // Camera has controller id 0xffffffff just like parent Bip01 — verify it doesn't throw.
+        var cryData = ProcessCryEngineFile(
+            $@"{objectDir}\game\objects\characters\people\drug_boy01\face\drug_boy01_face01\drug_boy01_face01.chr");
+        GenerateCollada(cryData);
     }
 
     [TestMethod]
-    public void Basket_Mix_Ani_Cga_NoMtlFileProvided()
+    public void DrugBoy_Gltf_CameraControllerEdgeCase()
     {
-        // 2 material files used in this model.  Make sure both are loaded.
-        var args = new string[]
-        {
-            @"D:\depot\archeage\game\objects\env\01_nuia\001_housing\01_tools\basket_mix_ani.cga"
-        };
-
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir));
-        cryData.ProcessCryengineFiles();
-
-        var colladaData = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
-        colladaData.GenerateDaeObject();
-        var daeObject = colladaData.DaeObject;
-        var imageLibrary = daeObject.Library_Images;
-        var materialLibrary = daeObject.Library_Materials;
-        var effectLibrary = daeObject.Library_Effects;
-        var visualSceneLibrary = daeObject.Library_Visual_Scene;
-
-        // Material library checks
-        Assert.AreEqual(5, materialLibrary.Material.Length);
-        Assert.AreEqual("basket_mix_mtl_basket_mix-material", materialLibrary.Material[0].ID);
-        Assert.AreEqual("#basket_mix_mtl_basket_mix-effect", materialLibrary.Material[0].Instance_Effect.URL);
-        // Library images checks
-        Assert.AreEqual(7, imageLibrary.Image.Length);
-        Assert.AreEqual("tool_farm_d_mtl_wood_Diffuse", imageLibrary.Image[3].Name);
-        //Assert.AreEqual(@"game\objects\env\01_nuia\001_housing\01_tools\basket_mix_df.dds", imageLibrary.Image[0].Init_From.Uri);
-        // Library effects checks
-        Assert.AreEqual(5, effectLibrary.Effect.Length);
-        Assert.AreEqual("basket_mix_mtl_basket_mix-effect", effectLibrary.Effect[0].ID);
-        Assert.AreEqual("basket_mix_mtl_basket_mix_Diffuse-sampler", effectLibrary.Effect[0].Profile_COMMON[0].Technique.Phong.Diffuse.Texture.Texture);
-        Assert.AreEqual(6, effectLibrary.Effect[0].Profile_COMMON[0].New_Param.Length);
-        // Library visual scenes checks
-        Assert.AreEqual(1, visualSceneLibrary.Visual_Scene.Length);
-        Assert.AreEqual("basket_mix_ani", visualSceneLibrary.Visual_Scene[0].Node[0].Name);
-        Assert.AreEqual("basket_mix_ani", visualSceneLibrary.Visual_Scene[0].Node[0].Instance_Geometry[0].Name);
-        Assert.AreEqual("#basket_mix_ani-mesh", visualSceneLibrary.Visual_Scene[0].Node[0].Instance_Geometry[0].URL);
-        Assert.AreEqual("#basket_mix_mtl_basket_mix-material", visualSceneLibrary.Visual_Scene[0].Node[0].Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[0].Target);
-        Assert.AreEqual("#basket_mix_mtl_proxy-material", visualSceneLibrary.Visual_Scene[0].Node[0].Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[1].Target);
+        var cryData = ProcessCryEngineFile(
+            $@"{objectDir}\game\objects\characters\people\drug_boy01\face\drug_boy01_face01\drug_boy01_face01.chr");
+        GenerateGltf(cryData);
     }
+
+    [TestMethod]
+    public void DrugBoy_Usd_CameraControllerEdgeCase()
+    {
+        var cryData = ProcessCryEngineFile(
+            $@"{objectDir}\game\objects\characters\people\drug_boy01\face\drug_boy01_face01\drug_boy01_face01.chr");
+        GenerateUsdString(cryData);
+    }
+
+    #endregion
+
+    #region BasketMix .cga (multi-material)
+
+    [TestMethod]
+    public void BasketMix_Collada_MultiMaterial()
+    {
+        // 2 material files used in this model. The textures for the basket mtl file are missing.
+        var cryData = ProcessCryEngineFile(
+            @"D:\depot\archeage\game\objects\env\01_nuia\001_housing\01_tools\basket_mix_ani.cga",
+            "basket_mix.mtl,tool_farm_d.mtl");
+        var dae = GenerateCollada(cryData);
+
+        // Material library
+        Assert.AreEqual(5, dae.Library_Materials.Material.Length);
+        Assert.AreEqual("basket_mix_mtl_basket_mix-material", dae.Library_Materials.Material[0].ID);
+        Assert.AreEqual("#basket_mix_mtl_basket_mix-effect", dae.Library_Materials.Material[0].Instance_Effect.URL);
+
+        // Image library
+        Assert.AreEqual(7, dae.Library_Images.Image.Length);
+        Assert.AreEqual("tool_farm_d_mtl_wood_Diffuse", dae.Library_Images.Image[3].Name);
+
+        // Effect library
+        Assert.AreEqual(5, dae.Library_Effects.Effect.Length);
+        Assert.AreEqual("basket_mix_mtl_basket_mix-effect", dae.Library_Effects.Effect[0].ID);
+        Assert.AreEqual("basket_mix_mtl_basket_mix_Diffuse-sampler", dae.Library_Effects.Effect[0].Profile_COMMON[0].Technique.Phong.Diffuse.Texture.Texture);
+        Assert.AreEqual(6, dae.Library_Effects.Effect[0].Profile_COMMON[0].New_Param.Length);
+
+        // Visual scene
+        var rootNode = dae.Library_Visual_Scene.Visual_Scene[0].Node[0];
+        Assert.AreEqual("basket_mix_ani", rootNode.Name);
+        Assert.AreEqual("basket_mix_ani", rootNode.Instance_Geometry[0].Name);
+        Assert.AreEqual("#basket_mix_ani-mesh", rootNode.Instance_Geometry[0].URL);
+        Assert.AreEqual("#basket_mix_mtl_basket_mix-material", rootNode.Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[0].Target);
+        Assert.AreEqual("#basket_mix_mtl_proxy-material", rootNode.Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[1].Target);
+    }
+
+    [TestMethod]
+    public void BasketMix_Collada_AutoDiscoverMaterials()
+    {
+        // Without an explicit mtl, both material files should still be auto-discovered.
+        var cryData = ProcessCryEngineFile(
+            @"D:\depot\archeage\game\objects\env\01_nuia\001_housing\01_tools\basket_mix_ani.cga");
+        var dae = GenerateCollada(cryData);
+
+        // Material library
+        Assert.AreEqual(5, dae.Library_Materials.Material.Length);
+        Assert.AreEqual("basket_mix_mtl_basket_mix-material", dae.Library_Materials.Material[0].ID);
+        Assert.AreEqual("#basket_mix_mtl_basket_mix-effect", dae.Library_Materials.Material[0].Instance_Effect.URL);
+
+        // Image library
+        Assert.AreEqual(7, dae.Library_Images.Image.Length);
+        Assert.AreEqual("tool_farm_d_mtl_wood_Diffuse", dae.Library_Images.Image[3].Name);
+
+        // Effect library
+        Assert.AreEqual(5, dae.Library_Effects.Effect.Length);
+        Assert.AreEqual("basket_mix_mtl_basket_mix-effect", dae.Library_Effects.Effect[0].ID);
+        Assert.AreEqual("basket_mix_mtl_basket_mix_Diffuse-sampler", dae.Library_Effects.Effect[0].Profile_COMMON[0].Technique.Phong.Diffuse.Texture.Texture);
+        Assert.AreEqual(6, dae.Library_Effects.Effect[0].Profile_COMMON[0].New_Param.Length);
+
+        // Visual scene
+        var rootNode = dae.Library_Visual_Scene.Visual_Scene[0].Node[0];
+        Assert.AreEqual("basket_mix_ani", rootNode.Name);
+        Assert.AreEqual("basket_mix_ani", rootNode.Instance_Geometry[0].Name);
+        Assert.AreEqual("#basket_mix_ani-mesh", rootNode.Instance_Geometry[0].URL);
+        Assert.AreEqual("#basket_mix_mtl_basket_mix-material", rootNode.Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[0].Target);
+        Assert.AreEqual("#basket_mix_mtl_proxy-material", rootNode.Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[1].Target);
+    }
+
+    [TestMethod]
+    public void BasketMix_Gltf_MultiMaterial()
+    {
+        var cryData = ProcessCryEngineFile(
+            @"D:\depot\archeage\game\objects\env\01_nuia\001_housing\01_tools\basket_mix_ani.cga",
+            "basket_mix.mtl,tool_farm_d.mtl");
+        var gltf = GenerateGltf(cryData);
+
+        Assert.AreEqual(5, gltf.Materials.Count);
+        Assert.AreEqual(1, gltf.Meshes.Count);
+        Assert.AreEqual("basket_mix_ani", gltf.Nodes[0].Name);
+    }
+
+    [TestMethod]
+    public void BasketMix_Usd_MultiMaterial()
+    {
+        var cryData = ProcessCryEngineFile(
+            @"D:\depot\archeage\game\objects\env\01_nuia\001_housing\01_tools\basket_mix_ani.cga",
+            "basket_mix.mtl,tool_farm_d.mtl");
+        var usdOutput = GenerateUsdString(cryData);
+
+        Assert.IsTrue(usdOutput.Contains("basket_mix"), "Should contain basket_mix material");
+        Assert.IsTrue(usdOutput.Contains("tool_farm_d"), "Should contain tool_farm_d material");
+        Assert.IsTrue(usdOutput.Contains("point3f[] points"), "Should have geometry points");
+        Assert.IsTrue(usdOutput.Contains("elementType = \"face\""), "GeomSubsets should use face element type");
+    }
+
+    #endregion
+
+    #region Fishboat .chr (0x828 controller edge case)
+
+    [TestMethod]
+    public void Fishboat_Collada_SkeletonAndMaterials()
+    {
+        // fishboat.cal references CAF files with 0x828 controller chunks — verify no exception is thrown.
+        var cryData = ProcessCryEngineFile(
+            $@"{objectDir}\game\objects\env\06_unit\01_ship\fishboat\fishboat.chr",
+            "fishboat.mtl");
+        var dae = GenerateCollada(cryData);
+
+        Assert.IsNotNull(dae.Library_Visual_Scene);
+        Assert.IsTrue(dae.Library_Visual_Scene.Visual_Scene[0].Node.Length > 0);
+    }
+
+    [TestMethod]
+    public void Fishboat_Gltf_SkeletonAndMaterials()
+    {
+        var cryData = ProcessCryEngineFile(
+            $@"{objectDir}\game\objects\env\06_unit\01_ship\fishboat\fishboat.chr",
+            "fishboat.mtl");
+        var gltf = GenerateGltf(cryData);
+
+        Assert.IsTrue(gltf.Meshes.Count > 0);
+        Assert.AreEqual("Bip01", gltf.Nodes[0].Name);
+    }
+
+    [TestMethod]
+    public void Fishboat_Usd_SkeletonAndMaterials()
+    {
+        var cryData = ProcessCryEngineFile(
+            $@"{objectDir}\game\objects\env\06_unit\01_ship\fishboat\fishboat.chr",
+            "fishboat.mtl");
+        var usdOutput = GenerateUsdString(cryData);
+
+        Assert.IsTrue(usdOutput.Contains("point3f[] points"), "Should have geometry points");
+        Assert.IsTrue(usdOutput.Contains("fishboat"), "Should contain fishboat prim");
+    }
+
+    #endregion
 }

--- a/CgfConverterIntegrationTests/IntegrationTests/ArmoredWarfare/AWIntegrationTests.cs
+++ b/CgfConverterIntegrationTests/IntegrationTests/ArmoredWarfare/AWIntegrationTests.cs
@@ -339,7 +339,7 @@ public class ArmoredWarfareIntegrationTests
         int result = testUtils.argsHandler.ProcessArgs(args);
         Assert.AreEqual(0, result);
 
-        var cryData = new CryEngine(modelFile, testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir));
+        var cryData = new CryEngine(modelFile, testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir, IncludeAnimations: true));
         cryData.ProcessCryengineFiles();
 
         // Animations are loaded automatically via chrparams

--- a/CgfConverterIntegrationTests/IntegrationTests/MWO/MWOIntegrationTests.cs
+++ b/CgfConverterIntegrationTests/IntegrationTests/MWO/MWOIntegrationTests.cs
@@ -35,12 +35,12 @@ public class MWOIntegrationTests
 
     #region Shared Helpers
 
-    private CryEngine ProcessCryEngineFile(string file, string? matFile = null)
+    private CryEngine ProcessCryEngineFile(string file, string? matFile = null, bool includeAnimations = false)
     {
         var args = new string[] { file, "-objectdir", objectDir };
         testUtils.argsHandler.ProcessArgs(args);
 
-        var options = new CryEngineOptions(matFile, objectDir);
+        var options = new CryEngineOptions(matFile, objectDir, includeAnimations);
         var cryData = new CryEngine(file, testUtils.argsHandler.Args.PackFileSystem, options);
         cryData.ProcessCryengineFiles();
         return cryData;
@@ -337,7 +337,7 @@ public class MWOIntegrationTests
     [TestMethod]
     public void Adder_Collada_SkeletonAndAnimations()
     {
-        var cryData = ProcessCryEngineFile($@"{objectDir}\objects\mechs\adder\body\adder.chr");
+        var cryData = ProcessCryEngineFile($@"{objectDir}\objects\mechs\adder\body\adder.chr", includeAnimations: true);
         var dae = GenerateCollada(cryData);
 
         // Materials (default, no textures)
@@ -379,15 +379,14 @@ public class MWOIntegrationTests
         Assert.AreEqual(1, geometryNode.Instance_Controller.Length);
         Assert.AreEqual("#Controller", geometryNode.Instance_Controller[0].URL);
 
-        // Animations present
-        Assert.IsNotNull(dae.Library_Animations);
-        Assert.IsTrue(dae.Library_Animations.Animation.Length > 0, "Should have animations from DBA files");
+        // Animations loaded at data level (exported to separate files for Blender compatibility)
+        Assert.IsTrue(cryData.Animations.Count > 0, "Should have animations from DBA files");
     }
 
     [TestMethod]
     public void Adder_Gltf_SkeletonAndAnimations()
     {
-        var cryData = ProcessCryEngineFile($@"{objectDir}\objects\mechs\adder\body\adder.chr");
+        var cryData = ProcessCryEngineFile($@"{objectDir}\objects\mechs\adder\body\adder.chr", includeAnimations: true);
         var gltf = GenerateGltf(cryData);
 
         Assert.AreEqual(11, gltf.Materials.Count);

--- a/CgfConverterIntegrationTests/IntegrationTests/MWO/MWOIntegrationTests.cs
+++ b/CgfConverterIntegrationTests/IntegrationTests/MWO/MWOIntegrationTests.cs
@@ -1,23 +1,19 @@
-﻿using CgfConverter;
+using CgfConverter;
 using CgfConverter.CryEngineCore;
 using CgfConverter.Renderers.Collada;
 using CgfConverter.Renderers.Collada.Collada;
 using CgfConverter.Renderers.Collada.Collada.Enums;
 using CgfConverter.Renderers.Gltf;
+using CgfConverter.Renderers.Gltf.Models;
 using CgfConverter.Renderers.USD;
 using CgfConverter.Renderers.USD.Models;
 using CgfConverterIntegrationTests.Extensions;
 using CgfConverterTests.TestUtilities;
-using Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Numerics;
 using System.Threading;
-using System.Xml.Linq;
-using System.Xml.Serialization;
 
 namespace CgfConverterTests.IntegrationTests;
 
@@ -26,7 +22,6 @@ namespace CgfConverterTests.IntegrationTests;
 public class MWOIntegrationTests
 {
     private readonly TestUtils testUtils = new();
-    private readonly string userHome = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
     private readonly string objectDir = @"d:\depot\mwo";
 
     [TestInitialize]
@@ -38,1393 +33,59 @@ public class MWOIntegrationTests
         testUtils.GetSchemaSet();
     }
 
-    [TestMethod]
-    public void Box_Collada()
+    #region Shared Helpers
+
+    private CryEngine ProcessCryEngineFile(string file, string? matFile = null)
     {
-        var args = new string[] { $@"{objectDir}\Objects\default\box.cgf", "-dds", "-dae", "-objectdir", objectDir };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
+        var args = new string[] { file, "-objectdir", objectDir };
+        testUtils.argsHandler.ProcessArgs(args);
 
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir));
+        var options = new CryEngineOptions(matFile, objectDir);
+        var cryData = new CryEngine(file, testUtils.argsHandler.Args.PackFileSystem, options);
         cryData.ProcessCryengineFiles();
-
-        var colladaData = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
-        colladaData.GenerateDaeObject();
-        var daeObject = colladaData.DaeObject;
-
-        // Visual Scene checks
-        var boxNode = daeObject.Library_Visual_Scene.Visual_Scene[0].Node[0];
-        Assert.AreEqual("box", boxNode.ID);
-        Assert.AreEqual(ColladaNodeType.NODE, boxNode.Type);
-        Assert.AreEqual("1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 0", boxNode.Matrix[0].Value_As_String);
-        Assert.AreEqual("#helper_mtl_material0-material", boxNode.Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[0].Target);
-        Assert.AreEqual("helper_mtl_material0-material", boxNode.Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[0].Symbol);
-
-        // Geometry Checks
-        var geometry = daeObject.Library_Geometries.Geometry[0];
-        Assert.AreEqual("box-mesh", geometry.ID);
-        Assert.AreEqual(1, daeObject.Library_Geometries.Geometry.Length);
-        var mesh = geometry.Mesh;
-        Assert.AreEqual(4, mesh.Source.Length);
-        Assert.AreEqual(2, mesh.Triangles.Length);
-        Assert.AreEqual(12, mesh.Triangles[0].Count);
-        Assert.AreEqual(0, mesh.Triangles[1].Count);
-
-        // Materials Checks
-        var mats = daeObject.Library_Materials;
-        Assert.AreEqual(2, mats.Material.Length);
-        Assert.AreEqual("helper_mtl_material0", mats.Material[0].Name);
-        Assert.AreEqual("helper_mtl_material0-material", mats.Material[0].ID);
-        Assert.AreEqual("#helper_mtl_material0-effect", mats.Material[0].Instance_Effect.URL);
-        Assert.AreEqual("helper_mtl_material1", mats.Material[1].Name);
-        var boundMaterials = boxNode.Instance_Geometry[0].Bind_Material;
-        Assert.AreEqual("#helper_mtl_material0-material", boundMaterials[0].Technique_Common.Instance_Material[0].Target);
-        Assert.AreEqual("helper_mtl_material0-material", boundMaterials[0].Technique_Common.Instance_Material[0].Symbol);
-        Assert.AreEqual("#helper_mtl_material1-material", boundMaterials[0].Technique_Common.Instance_Material[1].Target);
-        Assert.AreEqual("helper_mtl_material1-material", boundMaterials[0].Technique_Common.Instance_Material[1].Symbol);
+        return cryData;
     }
 
-    [TestMethod]
-    public void Box_Gltf()
+    private ColladaDoc GenerateCollada(CryEngine cryData, bool validate = true)
     {
-        var args = new string[] { $@"{objectDir}\Objects\default\box.cgf", "-dds", "-dae", "-objectdir", objectDir };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
+        var colladaRenderer = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
+        colladaRenderer.GenerateDaeObject();
 
-        CryEngine cryData = new(args[0], testUtils.argsHandler.Args.PackFileSystem);
-        cryData.ProcessCryengineFiles();
+        if (validate)
+            testUtils.ValidateColladaXml(colladaRenderer);
 
-        GltfModelRenderer gltfData = new(testUtils.argsHandler.Args, cryData);
-        gltfData.GenerateGltfObject();
+        return colladaRenderer.DaeObject;
     }
 
-    [TestMethod]
-    public void Box_Usd()
+    private GltfRoot GenerateGltf(CryEngine cryData)
     {
-        var args = new string[] { $@"{objectDir}\Objects\default\box.cgf", "-dds", "-dae", "-objectdir", objectDir };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-
-        CryEngine cryData = new(args[0], testUtils.argsHandler.Args.PackFileSystem);
-        cryData.ProcessCryengineFiles();
-
-        UsdRenderer usdData = new(testUtils.argsHandler.Args, cryData);
-        usdData.GenerateUsdObject();
+        var gltfRenderer = new GltfModelRenderer(testUtils.argsHandler.Args, cryData);
+        return gltfRenderer.GenerateGltfObject();
     }
 
-    [TestMethod]
-    public void Box_Usd_WithMaterials()
+    private string GenerateUsdString(CryEngine cryData)
     {
-        var matFile = $@"{objectDir}\Objects\default\box.mtl";
-        var args = new string[] { $@"{objectDir}\Objects\default\box.cgf", "-objectdir", objectDir, "-mat", matFile };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-
-        CryEngine cryData = new(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(matFile, objectDir));
-        cryData.ProcessCryengineFiles();
-
-        // Verify materials were loaded
-        Assert.IsTrue(cryData.Materials.Count > 0, "Materials should be loaded");
-        var firstMat = cryData.Materials.First().Value;
-        Assert.IsTrue(firstMat.SubMaterials.Length >= 2, "Should have at least 2 submaterials");
-
-        // Generate USD
-        UsdRenderer usdRenderer = new(testUtils.argsHandler.Args, cryData);
+        var usdRenderer = new UsdRenderer(testUtils.argsHandler.Args, cryData);
         var usdDoc = usdRenderer.GenerateUsdObject();
 
-        // Serialize to string for inspection
         var serializer = new UsdSerializer();
         using var writer = new StringWriter();
         serializer.Serialize(usdDoc, writer);
-        var usdOutput = writer.ToString();
-
-        // Verify material properties are in output
-        // Material #25: Diffuse="0.588,0.588,0.588" Opacity="1"
-        Assert.IsTrue(usdOutput.Contains("inputs:diffuseColor"), "Should have diffuseColor");
-        Assert.IsTrue(usdOutput.Contains("inputs:opacity"), "Should have opacity");
-        Assert.IsTrue(usdOutput.Contains("inputs:roughness"), "Should have roughness");
-        Assert.IsTrue(usdOutput.Contains("inputs:metallic"), "Should have metallic");
-
-        // Verify colors use parentheses (not angle brackets)
-        Assert.IsTrue(usdOutput.Contains("inputs:diffuseColor = ("), "Color values should use parentheses");
-        Assert.IsFalse(usdOutput.Contains("inputs:diffuseColor = <0"), "Color values should NOT use angle brackets for values");
-
-        // Material #26: Diffuse="0.658824,0,0" (red) Opacity="0.24"
-        Assert.IsTrue(usdOutput.Contains("0.658824"), "Should have red diffuse color from Material #26");
-        Assert.IsTrue(usdOutput.Contains("0.24"), "Should have 0.24 opacity from Material #26");
-
-        // Verify material names are cleaned
-        Assert.IsTrue(usdOutput.Contains("Material__25"), "Material #25 should be cleaned to Material__25");
-        Assert.IsTrue(usdOutput.Contains("Material__26"), "Material #26 should be cleaned to Material__26");
-
-        // Verify GeomSubset uses face indices (not vertex indices)
-        // The box has 12 triangles, so face indices should be 0-11
-        Assert.IsTrue(usdOutput.Contains("elementType = \"face\""), "GeomSubset should use face element type");
-        // Should NOT contain raw vertex indices like [0, 1, 2, 2, 3, 0, ...]
-        Assert.IsFalse(usdOutput.Contains("indices = [0, 1, 2, 2, 3, 0"), "Should not use vertex indices for face elementType");
-
-        // Optional: write to file for manual inspection
-        // usdRenderer.WriteUsdToFile(usdDoc);
+        return writer.ToString();
     }
 
-    [TestMethod]
-    public void HulaGirl_Usd_WithMaterials()
+    private (string Output, UsdDoc Doc) GenerateUsd(CryEngine cryData)
     {
-        var modelFile = $@"{objectDir}\Objects\purchasable\cockpit_standing\hulagirl\hulagirl_a.cga";
-
-        // Check if file exists
-        if (!File.Exists(modelFile))
-        {
-            Assert.Inconclusive($"Model file not found: {modelFile}");
-            return;
-        }
-
-        var args = new string[] { modelFile, "-objectdir", objectDir };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-
-        // Let materials auto-discover from MtlName chunk
-        CryEngine cryData = new(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir));
-        cryData.ProcessCryengineFiles();
-
-        // Verify materials were loaded
-        Assert.IsTrue(cryData.Materials.Count > 0, "Materials should be loaded");
-
-        // Check if materials have textures
-        var firstMat = cryData.Materials.First().Value;
-        if (firstMat.SubMaterials != null && firstMat.SubMaterials.Length > 0)
-        {
-            var submat = firstMat.SubMaterials[0];
-            if (submat.Textures != null)
-            {
-                foreach (var texture in submat.Textures)
-                {
-                    // This is where you can set a breakpoint to inspect texture.File
-                    Console.WriteLine($"Texture Map: {texture.Map}, File: {texture.File ?? "NULL"}");
-                }
-            }
-        }
-
-        // Generate USD
-        UsdRenderer usdRenderer = new(testUtils.argsHandler.Args, cryData);
+        var usdRenderer = new UsdRenderer(testUtils.argsHandler.Args, cryData);
         var usdDoc = usdRenderer.GenerateUsdObject();
 
-        // Serialize to string for inspection
         var serializer = new UsdSerializer();
         using var writer = new StringWriter();
         serializer.Serialize(usdDoc, writer);
-        var usdOutput = writer.ToString();
-
-        // Verify material properties are in output
-        Assert.IsTrue(usdOutput.Contains("inputs:diffuseColor"), "Should have diffuseColor");
-
-        // Optional: write to file for manual inspection
-        // usdRenderer.WriteUsdToFile(usdDoc);
+        return (writer.ToString(), usdDoc);
     }
 
-    [TestMethod]
-    public void Teapot_Collada()
-    {
-        var args = new string[] {$@"{objectDir}\Objects\default\teapot.cgf" };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-
-        CryEngine cryData = new(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir));
-        cryData.ProcessCryengineFiles();
-
-        var colladaData = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
-        colladaData.GenerateDaeObject();
-        var daeObject = colladaData.DaeObject;
-    }
-
-
-    [TestMethod]
-    public void Teapot_Gltf()
-    {
-        var args = new string[] { $@"{objectDir}\Objects\default\teapot.cgf", "-objectDir", objectDir };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-
-        CryEngine cryData = new(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir));
-        cryData.ProcessCryengineFiles();
-
-        GltfModelRenderer gltfData = new(testUtils.argsHandler.Args, cryData);
-        gltfData.GenerateGltfObject();
-    }
-
-    [TestMethod]
-    public void ClanBanner_Adder_VerifyMaterials()
-    {
-        var matFile = $@"{objectDir}\Objects\purchasable\cockpit_mounted\clanbanner\clanbanner_a.mtl";
-        var args = new string[] { $@"{objectDir}\Objects\purchasable\cockpit_mounted\clanbanner\clanbanner_a_adder.cga" };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(matFile, objectDir));
-        cryData.ProcessCryengineFiles();
-
-        var mtlChunks = cryData.Chunks.Where(a => a.ChunkType == ChunkType.MtlName).ToList();
-        Assert.AreEqual(1, (int)((ChunkMtlName)mtlChunks[0]).NumChildren);
-        Assert.AreEqual(MtlNameType.Library, ((ChunkMtlName)mtlChunks[0]).MatType);
-        Assert.AreEqual(MtlNameType.Child, ((ChunkMtlName)mtlChunks[1]).MatType);
-
-        var colladaData = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
-        colladaData.GenerateDaeObject();
-        var daeObject = colladaData.DaeObject;
-        Assert.AreEqual(1, daeObject.Library_Materials.Material.Length);
-        Assert.AreEqual(1, daeObject.Library_Effects.Effect.Length);
-        Assert.AreEqual(2, daeObject.Library_Images.Image.Length);
-        Assert.AreEqual("clanbanner_a_mtl_clanbanner_a", daeObject.Library_Materials.Material[0].Name);
-        Assert.AreEqual("clanbanner_a_mtl_clanbanner_a-material", daeObject.Library_Materials.Material[0].ID);
-        Assert.AreEqual("#clanbanner_a_mtl_clanbanner_a-effect", daeObject.Library_Materials.Material[0].Instance_Effect.URL);
-        Assert.AreEqual("clanbanner_a_mtl_clanbanner_a_Diffuse", daeObject.Library_Images.Image[0].Name);
-        Assert.AreEqual("clanbanner_a_mtl_clanbanner_a_Diffuse", daeObject.Library_Images.Image[0].ID);
-        Assert.AreEqual("clanbanner_a_mtl_clanbanner_a_Normals", daeObject.Library_Images.Image[1].Name);
-        Assert.AreEqual("clanbanner_a_mtl_clanbanner_a_Normals", daeObject.Library_Images.Image[1].ID);
-    }
-
-    [TestMethod]
-    public void ClanBanner_Adder_VerifyMaterialsWithNoMtlFileArg()
-    {
-        var args = new string[] { $@"D:\depot\mwo\Objects\purchasable\cockpit_mounted\clanbanner\clanbanner_a_adder.cga" };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir));
-        cryData.ProcessCryengineFiles();
-
-        var mtlChunks = cryData.Chunks.Where(a => a.ChunkType == ChunkType.MtlName).ToList();
-        Assert.AreEqual(1, (int)((ChunkMtlName)mtlChunks[0]).NumChildren);
-        Assert.AreEqual(MtlNameType.Library, ((ChunkMtlName)mtlChunks[0]).MatType);
-        Assert.AreEqual(MtlNameType.Child, ((ChunkMtlName)mtlChunks[1]).MatType);
-
-        var colladaData = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
-        colladaData.GenerateDaeObject();
-        var daeObject = colladaData.DaeObject;
-        Assert.AreEqual(1, daeObject.Library_Materials.Material.Length);
-        Assert.AreEqual(1, daeObject.Library_Effects.Effect.Length);
-        Assert.AreEqual(2, daeObject.Library_Images.Image.Length);
-        Assert.AreEqual("clanbanner_a_mtl_clanbanner_a", daeObject.Library_Materials.Material[0].Name);
-        Assert.AreEqual("clanbanner_a_mtl_clanbanner_a-material", daeObject.Library_Materials.Material[0].ID);
-        Assert.AreEqual("#clanbanner_a_mtl_clanbanner_a-effect", daeObject.Library_Materials.Material[0].Instance_Effect.URL);
-        Assert.AreEqual("clanbanner_a_mtl_clanbanner_a_Diffuse", daeObject.Library_Images.Image[0].Name);
-        Assert.AreEqual("clanbanner_a_mtl_clanbanner_a_Diffuse", daeObject.Library_Images.Image[0].ID);
-        Assert.AreEqual("clanbanner_a_mtl_clanbanner_a_Normals", daeObject.Library_Images.Image[1].Name);
-        Assert.AreEqual("clanbanner_a_mtl_clanbanner_a_Normals", daeObject.Library_Images.Image[1].ID);
-    }
-
-    [TestMethod]
-    public void AtlasBodyPart_VerifyMaterials()
-    {
-        var matFile = @"D:\depot\mwo\Objects\mechs\atlas\body\atlas_body.mtl";
-        var args = new string[] { $@"D:\depot\mwo\Objects\mechs\atlas\body\as7_centre_torso.cga" };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(matFile, objectDir));
-        cryData.ProcessCryengineFiles();
-
-        var colladaData = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
-        colladaData.GenerateDaeObject();
-        var daeObject = colladaData.DaeObject;
-        Assert.AreEqual(5, daeObject.Library_Materials.Material.Length);
-        Assert.AreEqual(5, daeObject.Library_Effects.Effect.Length);
-        Assert.AreEqual(31, daeObject.Library_Images.Image.Length);
-        Assert.AreEqual("atlas_body_mtl_atlas_body", daeObject.Library_Materials.Material[0].Name);
-        Assert.AreEqual("atlas_body_mtl_atlas_body-material", daeObject.Library_Materials.Material[0].ID);
-        Assert.AreEqual("#atlas_body_mtl_atlas_body-effect", daeObject.Library_Materials.Material[0].Instance_Effect.URL);
-        Assert.AreEqual("atlas_body_mtl_atlas_body_Diffuse", daeObject.Library_Images.Image[0].Name);
-        Assert.AreEqual("atlas_body_mtl_atlas_body_Diffuse", daeObject.Library_Images.Image[0].ID);
-        Assert.AreEqual("atlas_body_mtl_atlas_body_Specular", daeObject.Library_Images.Image[1].Name);
-        Assert.AreEqual("atlas_body_mtl_atlas_body_Specular", daeObject.Library_Images.Image[1].ID);
-    }
-
-    [TestMethod]
-    public void Atlas_VerifyArmature()
-    {
-        var args = new string[] { $@"{userHome}\OneDrive\ResourceFiles\MWO\atlas.chr", "-dds", "-dae", "-objectdir", objectDir };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem);
-        cryData.ProcessCryengineFiles();
-
-        var colladaData = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
-        colladaData.GenerateDaeObject();
-        var daeObject = colladaData.DaeObject;
-    }
-
-    [TestMethod]
-    public void Atlas_VerifyArmature2()
-    {
-        var args = new string[] { $@"d:\depot\mwo\objects\mechs\atlas\body\atlas.chr", "-dds", "-dae", "-objectdir", objectDir };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem);
-        cryData.ProcessCryengineFiles();
-
-        var colladaData = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
-        colladaData.GenerateDaeObject();
-        var daeObject = colladaData.DaeObject;
-    }
-
-    [TestMethod]
-    public void Adder_VerifyArmatureAndAnimations_Collada()
-    {
-        var args = new string[] { $@"d:\depot\mwo\objects\mechs\adder\body\adder.chr", "-dds", "-dae", "-objectdir", objectDir };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem);
-        cryData.ProcessCryengineFiles();
-
-        var colladaData = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
-        colladaData.GenerateDaeObject();
-        var daeObject = colladaData.DaeObject;
-
-        // === Library Materials ===
-        var materials = daeObject.Library_Materials;
-        Assert.AreEqual(11, materials.Material.Length);
-        Assert.AreEqual("adder_mtl_centre_torso", materials.Material[0].Name);
-        Assert.AreEqual("adder_mtl_centre_torso-material", materials.Material[0].ID);
-        Assert.AreEqual("#adder_mtl_centre_torso-effect", materials.Material[0].Instance_Effect.URL);
-        Assert.AreEqual("adder_mtl_right_torso", materials.Material[1].Name);
-        Assert.AreEqual("adder_mtl_left_torso", materials.Material[2].Name);
-        Assert.AreEqual("adder_mtl_left_arm", materials.Material[3].Name);
-        Assert.AreEqual("adder_mtl_right_arm", materials.Material[4].Name);
-        Assert.AreEqual("adder_mtl_left_leg", materials.Material[5].Name);
-        Assert.AreEqual("adder_mtl_right_leg", materials.Material[6].Name);
-        Assert.AreEqual("adder_mtl_head", materials.Material[7].Name);
-
-        // === Library Images (no textures in this test) ===
-        Assert.AreEqual(0, daeObject.Library_Images.Image.Length);
-
-        // === Library Geometries ===
-        var geometries = daeObject.Library_Geometries;
-        Assert.AreEqual(1, geometries.Geometry.Length);
-        var geometry = geometries.Geometry[0];
-        Assert.AreEqual("adder-mesh", geometry.ID);
-        Assert.AreEqual("adder", geometry.Name);
-
-        var mesh = geometry.Mesh;
-        Assert.AreEqual(4, mesh.Source.Length); // pos, norm, UV, color
-
-        // Verify positions source
-        var posSource = mesh.Source.First(s => s.ID == "adder-mesh-pos");
-        Assert.AreEqual(9, posSource.Float_Array.Count); // 3 vertices * 3 components
-        Assert.AreEqual("adder-mesh-pos-array", posSource.Float_Array.ID);
-        Assert.AreEqual((uint)3, posSource.Technique_Common.Accessor.Count); // 3 vertices
-        Assert.AreEqual((uint)3, posSource.Technique_Common.Accessor.Stride); // x, y, z
-
-        // Verify normals source
-        var normSource = mesh.Source.First(s => s.ID == "adder-mesh-norm");
-        Assert.AreEqual(9, normSource.Float_Array.Count);
-        Assert.AreEqual("adder-mesh-norm-array", normSource.Float_Array.ID);
-
-        // Verify UV source
-        var uvSource = mesh.Source.First(s => s.ID == "adder-mesh-UV");
-        Assert.AreEqual(6, uvSource.Float_Array.Count); // 3 UVs * 2 components
-        Assert.AreEqual("adder-mesh-UV-array", uvSource.Float_Array.ID);
-        Assert.AreEqual((uint)3, uvSource.Technique_Common.Accessor.Count);
-        Assert.AreEqual((uint)2, uvSource.Technique_Common.Accessor.Stride); // s, t
-
-        // Verify triangles
-        Assert.AreEqual(1, mesh.Triangles.Length);
-        Assert.AreEqual(1, mesh.Triangles[0].Count); // 1 triangle
-        Assert.AreEqual("adder_mtl_centre_torso-material", mesh.Triangles[0].Material);
-
-        // Verify vertices reference
-        Assert.AreEqual("adder-vertices", mesh.Vertices.ID);
-        Assert.AreEqual("#adder-mesh-pos", mesh.Vertices.Input[0].source);
-
-        // === Library Controllers ===
-        var controllers = daeObject.Library_Controllers;
-        Assert.AreEqual(1, controllers.Controller.Length);
-        var controller = controllers.Controller[0];
-        Assert.AreEqual("Controller", controller.ID);
-
-        var skin = controller.Skin;
-        Assert.AreEqual("#adder-mesh", skin.source);
-        Assert.AreEqual("1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1", skin.Bind_Shape_Matrix.Value_As_String);
-
-        // Verify joints source
-        Assert.AreEqual(3, skin.Source.Length);
-        var jointsSource = skin.Source.First(s => s.ID == "Controller-joints");
-        Assert.AreEqual(73, jointsSource.Name_Array.Count);
-        Assert.AreEqual("Controller-joints-array", jointsSource.Name_Array.ID);
-        var jointNames = jointsSource.Name_Array.Value();
-        Assert.AreEqual(73, jointNames.Length);
-        Assert.AreEqual("Bip01", jointNames[0]);
-        Assert.AreEqual("Bip01_Pelvis", jointNames[1]);
-        Assert.AreEqual("Bip01_L_Hip", jointNames[2]);
-        Assert.IsTrue(jointNames.Contains("Bip01_R_Toe0Nub")); // Last joint
-
-        // Verify bind poses source
-        var bindPosesSource = skin.Source.First(s => s.ID == "Controller-bind_poses");
-        Assert.AreEqual(1168, bindPosesSource.Float_Array.Count); // 73 joints * 16 matrix elements
-        Assert.AreEqual("Controller-bind_poses-array", bindPosesSource.Float_Array.ID);
-        Assert.AreEqual((uint)73, bindPosesSource.Technique_Common.Accessor.Count);
-        Assert.AreEqual((uint)16, bindPosesSource.Technique_Common.Accessor.Stride);
-
-        // Verify weights source
-        var weightsSource = skin.Source.First(s => s.ID == "Controller-weights");
-        Assert.AreEqual((uint)12, weightsSource.Technique_Common.Accessor.Count);
-        Assert.AreEqual("Controller-weights-array", weightsSource.Float_Array.ID);
-
-        // Verify vertex_weights
-        Assert.AreEqual(3, skin.Vertex_Weights.Count);
-
-        // === Library Visual Scenes ===
-        var visualScene = daeObject.Library_Visual_Scene.Visual_Scene[0];
-        Assert.AreEqual("Scene", visualScene.ID);
-
-        // Verify armature root node (Bip01)
-        var rootNode = visualScene.Node[0];
-        Assert.AreEqual("Bip01", rootNode.ID);
-        Assert.AreEqual("Bip01", rootNode.Name);
-        Assert.AreEqual("Bip01", rootNode.sID);
-        Assert.AreEqual(ColladaNodeType.JOINT, rootNode.Type);
-        Assert.AreEqual("-0 1 -0 0 -1 -0 0 0 0 0 1 -0 0 0 0 1", rootNode.Matrix[0].Value_As_String);
-
-        // Verify Bip01_Pelvis child node
-        var pelvisNode = rootNode.node[0];
-        Assert.AreEqual("Bip01_Pelvis", pelvisNode.ID);
-        Assert.AreEqual("Bip01_Pelvis", pelvisNode.Name);
-        Assert.AreEqual(ColladaNodeType.JOINT, pelvisNode.Type);
-        Assert.AreEqual("-0 -0 1 -6.997413 -0 1 0 -0 -1 -0 -0 0 0 0 0 1", pelvisNode.Matrix[0].Value_As_String);
-
-        // Verify pelvis has correct children (L_Hip, Pitch, R_Hip)
-        Assert.AreEqual(3, pelvisNode.node.Length);
-        var leftHipNode = pelvisNode.node.FirstOrDefault(n => n.ID == "Bip01_L_Hip");
-        var pitchNode = pelvisNode.node.FirstOrDefault(n => n.ID == "Bip01_Pitch");
-        var rightHipNode = pelvisNode.node.FirstOrDefault(n => n.ID == "Bip01_R_Hip");
-        Assert.IsNotNull(leftHipNode);
-        Assert.IsNotNull(pitchNode);
-        Assert.IsNotNull(rightHipNode);
-
-        // Verify L_Hip transform
-        Assert.AreEqual("-1 -0 -0 -0.971270 -0 -0.022217 0.999753 -6.995683 -0 0.999753 0.022217 -0.155460 0 0 0 1", leftHipNode.Matrix[0].Value_As_String);
-
-        // Verify Pitch transform
-        Assert.AreEqual("-0 -0 1 -7.570391 -0 1 0 -0 -1 -0 -0 0 0 0 0 1", pitchNode.Matrix[0].Value_As_String);
-
-        // Verify geometry node with controller instance
-        Assert.AreEqual(2, visualScene.Node.Length);
-        var geometryNode = visualScene.Node[1];
-        Assert.AreEqual("adder", geometryNode.ID);
-        Assert.AreEqual("adder", geometryNode.Name);
-        Assert.AreEqual(ColladaNodeType.NODE, geometryNode.Type);
-        Assert.IsNull(geometryNode.Instance_Geometry); // No direct geometry, uses controller
-        Assert.AreEqual(1, geometryNode.Instance_Controller.Length);
-        Assert.AreEqual("#Controller", geometryNode.Instance_Controller[0].URL);
-        Assert.AreEqual("#Bip01", geometryNode.Instance_Controller[0].Skeleton[0].Value);
-
-        // Verify material binding on controller instance
-        var bindMaterial = geometryNode.Instance_Controller[0].Bind_Material[0];
-        Assert.IsNotNull(bindMaterial);
-        Assert.AreEqual(1, bindMaterial.Technique_Common.Instance_Material.Length);
-        Assert.AreEqual("adder_mtl_centre_torso-material", bindMaterial.Technique_Common.Instance_Material[0].Symbol);
-        Assert.AreEqual("#adder_mtl_centre_torso-material", bindMaterial.Technique_Common.Instance_Material[0].Target);
-
-        // === Library Animations ===
-        Assert.IsNotNull(daeObject.Library_Animations);
-        Assert.IsTrue(daeObject.Library_Animations.Animation.Length > 0, "Should have animations from DBA files");
-
-        testUtils.ValidateColladaXml(colladaData);
-    }
-
-    [TestMethod]
-    public void Adder_VerifyArmatureAndAnimations_Gltf()
-    {
-        var args = new string[] { $@"d:\depot\mwo\objects\mechs\adder\body\adder.chr", "-dds", "-gltf", "-objectdir", objectDir };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem);
-        cryData.ProcessCryengineFiles();
-
-        GltfModelRenderer gltfRenderer = new(testUtils.argsHandler.Args, cryData);
-        var gltfData = gltfRenderer.GenerateGltfObject();
-
-        // === Materials ===
-        Assert.AreEqual(11, gltfData.Materials.Count);
-        Assert.AreEqual("centre_torso", gltfData.Materials[0].Name);
-        Assert.AreEqual("right_torso", gltfData.Materials[1].Name);
-        Assert.AreEqual("left_torso", gltfData.Materials[2].Name);
-        Assert.AreEqual("left_arm", gltfData.Materials[3].Name);
-        Assert.AreEqual("right_arm", gltfData.Materials[4].Name);
-        Assert.AreEqual("left_leg", gltfData.Materials[5].Name);
-        Assert.AreEqual("right_leg", gltfData.Materials[6].Name);
-        Assert.AreEqual("head", gltfData.Materials[7].Name);
-
-        // === Meshes ===
-        Assert.AreEqual(1, gltfData.Meshes.Count);
-        Assert.AreEqual("adder/mesh", gltfData.Meshes[0].Name);
-        Assert.AreEqual(1, gltfData.Meshes[0].Primitives.Count);
-
-        // === Nodes (skeleton) ===
-        Assert.IsTrue(gltfData.Nodes.Count >= 73, "Should have at least 73 bone nodes");
-        Assert.AreEqual("Bip01", gltfData.Nodes[0].Name);
-        Assert.AreEqual("Bip01 Pelvis", gltfData.Nodes[1].Name); // glTF uses spaces, not underscores
-
-        // Verify root bone rotation (Bip01 transform) - quaternion [x, y, z, w]
-        AssertExtensions.AreEqual([0.0f, 0.70710677f, 0.0f, 0.70710677f], gltfData.Nodes[0].Rotation, 1e-5f);
-
-        // === Skins ===
-        Assert.AreEqual(1, gltfData.Skins.Count);
-        Assert.AreEqual(73, gltfData.Skins[0].Joints.Count);
-        Assert.AreEqual("adder/skin", gltfData.Skins[0].Name);
-
-        // === Animations ===
-        Assert.IsTrue(gltfData.Animations.Count > 0, "Should have animations from DBA files");
-    }
-
-    [TestMethod]
-    public void Adder_VerifyArmatureAndAnimations_Usd()
-    {
-        var args = new string[] { $@"d:\depot\mwo\objects\mechs\adder\body\adder.chr", "-usd", "-objectdir", objectDir };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem);
-        cryData.ProcessCryengineFiles();
-
-        UsdRenderer usdRenderer = new(testUtils.argsHandler.Args, cryData);
-        var usdDoc = usdRenderer.GenerateUsdObject();
-
-        // Serialize to string for inspection
-        var serializer = new UsdSerializer();
-        using var writer = new StringWriter();
-        serializer.Serialize(usdDoc, writer);
-        var usdOutput = writer.ToString();
-
-        // Verify root prim exists
-        Assert.IsTrue(usdOutput.Contains("def Xform \"adder\""), "Should have root prim");
-
-        // Verify skeleton exists
-        Assert.IsTrue(usdOutput.Contains("def Skeleton \"Skeleton\""), "Should have skeleton");
-
-        // Verify mesh exists with skin binding
-        Assert.IsTrue(usdOutput.Contains("def Mesh \"adder\"") || usdOutput.Contains("def Mesh \"Mesh\""), "Should have mesh");
-
-        // Verify skeleton joints include key bones
-        Assert.IsTrue(usdOutput.Contains("Bip01"), "Skeleton should include Bip01");
-        Assert.IsTrue(usdOutput.Contains("Bip01_Pelvis"), "Skeleton should include Bip01_Pelvis");
-        Assert.IsTrue(usdOutput.Contains("Bip01_L_Hip"), "Skeleton should include Bip01_L_Hip");
-        Assert.IsTrue(usdOutput.Contains("Bip01_R_Hip"), "Skeleton should include Bip01_R_Hip");
-
-        // Verify materials
-        Assert.IsTrue(usdOutput.Contains("adder_mtl_centre_torso"), "Should have centre_torso material");
-
-        // Verify points (geometry)
-        Assert.IsTrue(usdOutput.Contains("point3f[] points"), "Should have geometry points");
-
-        // Verify normals
-        Assert.IsTrue(usdOutput.Contains("normal3f[] normals"), "Should have normals");
-    }
-
-    [TestMethod]
-    public void HarnessCable_VerifyArmatureAndAnimations_Gltf()
-    {
-        var args = new string[] { @"D:\depot\MWO\Objects\environments\frontend\mechlab_a\mechbay_cables\harness_cable.chr", "-dds", "-dae", "-objectdir", objectDir };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem);
-        cryData.ProcessCryengineFiles();
-
-        GltfModelRenderer gltfRenderer = new(testUtils.argsHandler.Args, cryData);
-        var gltfData = gltfRenderer.GenerateGltfObject();
-    }
-
-    [TestMethod]
-    public void HarnessCable_VerifyArmatureAndAnimations_Collada()
-    {
-        var args = new string[] { $@"{objectDir}\Objects\environments\frontend\mechlab_a\mechbay_cables\harness_cable.chr",
-            "-dds", "-dae",
-            "-objectdir", objectDir };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir));
-        cryData.ProcessCryengineFiles();
-
-        var colladaData = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
-        colladaData.GenerateDaeObject();
-        var daeObject = colladaData.DaeObject;
-    }
-
-    [TestMethod]
-    public void Adr_right_torso_uac20_bh1_Collada()
-    {
-        // This model has 4 mtl files, all variations of mechdefault.  No mtl file provided, so it should create default materials only.
-        var args = new string[] { $@"{objectDir}\objects\mechs\adder\body\adr_right_torso_uac20_bh1.cga", "-dds", "-dae", "-objectdir", objectDir };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir));
-        cryData.ProcessCryengineFiles();
-        var matNameChunks = cryData.Chunks.Where(c => c.ChunkType == ChunkType.MtlName).ToList();
-
-        var colladaData = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
-        colladaData.GenerateDaeObject();
-        Assert.AreEqual(0, colladaData.DaeObject.Library_Images.Image.Length);
-        Assert.AreEqual(22, colladaData.DaeObject.Library_Materials.Material.Length); // default materials
-        Assert.AreEqual("mechDefault_mtl_material0", colladaData.DaeObject.Library_Materials.Material[0].Name);
-        Assert.AreEqual(0, colladaData.DaeObject.Library_Images.Image.Length);
-        Assert.AreEqual("mechDefault_mtl_material0", colladaData.DaeObject.Library_Effects.Effect[0].Name);
-        Assert.AreEqual("mechDefault_mtl_material0-effect", colladaData.DaeObject.Library_Effects.Effect[0].ID);
-
-        var visualSceneLibrary = colladaData.DaeObject.Library_Visual_Scene.Visual_Scene[0];
-        var imageLibrary = colladaData.DaeObject.Library_Images;
-
-        Assert.AreEqual(0, colladaData.DaeObject.Library_Images.Image.Length);
-        Assert.AreEqual("mechDefault_mtl_material0", colladaData.DaeObject.Library_Materials.Material[0].Name);
-        Assert.AreEqual("mechDefault_mtl_material0-material", colladaData.DaeObject.Library_Materials.Material[0].ID);
-        Assert.AreEqual(22, colladaData.DaeObject.Library_Materials.Material.Length);
-        // library_effects
-        Assert.AreEqual("mechDefault_mtl_material0", colladaData.DaeObject.Library_Effects.Effect[0].Name);
-        Assert.AreEqual("mechDefault_mtl_material1", colladaData.DaeObject.Library_Effects.Effect[1].Name);
-        Assert.AreEqual("mechDefault_mtl_material0-effect", colladaData.DaeObject.Library_Effects.Effect[0].ID);
-
-        // library_geometries
-        Assert.AreEqual("mechDefault_mtl_material4-material", colladaData.DaeObject.Library_Geometries.Geometry[0].Mesh.Triangles[0].Material);
-        Assert.AreEqual("05_-_Default_mtl_material4-material", colladaData.DaeObject.Library_Geometries.Geometry[1].Mesh.Triangles[0].Material);
-        Assert.AreEqual("mechDefault_mtl_material2-material", colladaData.DaeObject.Library_Geometries.Geometry[2].Mesh.Triangles[0].Material);
-        Assert.AreEqual("05_-_Default_mtl_material4-material", colladaData.DaeObject.Library_Geometries.Geometry[1].Mesh.Triangles[0].Material);
-        Assert.AreEqual("mechDefault_mtl_material2-material", colladaData.DaeObject.Library_Geometries.Geometry[2].Mesh.Triangles[0].Material);
-
-        // Verify visual scene material ids are set right
-        // bh1
-        Assert.AreEqual("adr_right_torso_uac20_bh1", visualSceneLibrary.Node[0].Name);
-        Assert.AreEqual("mechDefault_mtl_material4-material", visualSceneLibrary.Node[0].Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[0].Symbol);
-        Assert.AreEqual("#mechDefault_mtl_material4-material", visualSceneLibrary.Node[0].Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[0].Target);
-        // mount
-        Assert.AreEqual("adr_right_torso_uac20_bh1_mount", visualSceneLibrary.Node[0].node[3].Name);
-        Assert.AreEqual("mechDefault_mtl_material2-material", visualSceneLibrary.Node[0].node[3].Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[0].Symbol);
-        // barrel
-        Assert.AreEqual("barrel013", visualSceneLibrary.Node[0].node[0].node[0].Name);
-        Assert.AreEqual("05_-_Default_mtl_material4-material", visualSceneLibrary.Node[0].node[0].node[0].Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[0].Symbol);
-        // animations (no bind_mat)
-        Assert.AreEqual("animation068", visualSceneLibrary.Node[0].node[0].Name);
-        Assert.IsNull(visualSceneLibrary.Node[0].node[0].Instance_Geometry);
-    }
-
-    [TestMethod]
-    public void Adr_right_torso_uac20_bh1_Gltf()
-    {
-        // This model has 4 mtl files, all variations of mechdefault.  No mtl file provided, so it should create default materials only.
-        var args = new string[] { $@"d:\depot\mwo\objects\mechs\adder\body\adr_right_torso_uac20_bh1.cga", "-dds", "-gltf", "-objectdir", objectDir };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir));
-        cryData.ProcessCryengineFiles();
-        var matNameChunks = cryData.Chunks.Where(c => c.ChunkType == ChunkType.MtlName).ToList();
-
-        GltfModelRenderer gltfData = new(testUtils.argsHandler.Args, cryData);
-        gltfData.GenerateGltfObject();
-    }
-
-    [TestMethod]
-    public void Adr_right_torso_uac20_bh1_ProvidedMtlFile()
-    {
-        // mtl file provided, so materials are created.
-        var matFile = @"D:\depot\mwo\Objects\mechs\adder\body\adder_body.mtl";
-        var args = new string[] { $@"d:\depot\mwo\objects\mechs\adder\body\adr_right_torso_uac20_bh1.cga", objectDir, matFile };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(matFile, objectDir));
-        cryData.ProcessCryengineFiles();
-        var matNameChunks = cryData.Chunks.Where(c => c.ChunkType == ChunkType.MtlName).ToList();
-
-        var colladaData = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
-        colladaData.GenerateDaeObject();
-
-        var visualSceneLibrary = colladaData.DaeObject.Library_Visual_Scene.Visual_Scene[0];
-        var imageLibrary = colladaData.DaeObject.Library_Images;
-
-        Assert.AreEqual(28, colladaData.DaeObject.Library_Images.Image.Length);
-        Assert.AreEqual("adder_body_mtl_adder_body", colladaData.DaeObject.Library_Materials.Material[0].Name);
-        Assert.AreEqual("adder_body_mtl_adder_body-material", colladaData.DaeObject.Library_Materials.Material[0].ID);
-        Assert.AreEqual(5, colladaData.DaeObject.Library_Materials.Material.Length);
-        // library_effects
-        Assert.AreEqual("adder_body_mtl_adder_body", colladaData.DaeObject.Library_Effects.Effect[0].Name);
-        Assert.AreEqual("adder_body_mtl_decals", colladaData.DaeObject.Library_Effects.Effect[1].Name);
-        Assert.AreEqual("adder_body_mtl_adder_body-effect", colladaData.DaeObject.Library_Effects.Effect[0].ID);
-
-        // library_geometries
-        Assert.AreEqual("adder_body_mtl_generic-material", colladaData.DaeObject.Library_Geometries.Geometry[0].Mesh.Triangles[0].Material);
-        Assert.AreEqual("adder_body_mtl_generic-material", colladaData.DaeObject.Library_Geometries.Geometry[1].Mesh.Triangles[0].Material);
-        Assert.AreEqual("adder_body_mtl_adder_variant-material", colladaData.DaeObject.Library_Geometries.Geometry[2].Mesh.Triangles[0].Material);
-        Assert.AreEqual("adder_body_mtl_generic-material", colladaData.DaeObject.Library_Geometries.Geometry[1].Mesh.Triangles[0].Material);
-        Assert.AreEqual("adder_body_mtl_adder_variant-material", colladaData.DaeObject.Library_Geometries.Geometry[2].Mesh.Triangles[0].Material);
-
-        // Verify visual scene material ids are set right
-        // bh1
-        Assert.AreEqual("adr_right_torso_uac20_bh1", visualSceneLibrary.Node[0].Name);
-        Assert.AreEqual("adder_body_mtl_generic-material", visualSceneLibrary.Node[0].Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[0].Symbol);
-        Assert.AreEqual("#adder_body_mtl_generic-material", visualSceneLibrary.Node[0].Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[0].Target);
-        Assert.AreEqual("adder_body_mtl_generic_Diffuse", imageLibrary.Image[19].ID);
-        // mount
-        Assert.AreEqual("adr_right_torso_uac20_bh1_mount", visualSceneLibrary.Node[0].node[3].Name);
-        Assert.AreEqual("adder_body_mtl_adder_variant-material", visualSceneLibrary.Node[0].node[3].Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[0].Symbol);
-        // barrel
-        Assert.AreEqual("barrel013", visualSceneLibrary.Node[0].node[0].node[0].Name);
-        Assert.AreEqual("adder_body_mtl_generic-material", visualSceneLibrary.Node[0].node[0].node[0].Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[0].Symbol);
-        // animations (no bind_mat)
-        Assert.AreEqual("animation068", visualSceneLibrary.Node[0].node[0].Name);
-        Assert.IsNull(visualSceneLibrary.Node[0].node[0].Instance_Geometry);
-    }
-
-    [TestMethod]
-    public void FiftyCalNecklace_ColladaVerifyMaterials()
-    {
-        var args = new string[] { $@"d:\depot\mwo\objects\purchasable\cockpit_hanging\50calnecklace\50calnecklace_a.chr" };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir));
-        cryData.ProcessCryengineFiles();
-
-        var colladaData = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
-        colladaData.GenerateDaeObject();
-
-        var daeObject = colladaData.DaeObject;
-        Assert.AreEqual(1, daeObject.Library_Materials.Material.Length);
-        Assert.AreEqual(1, daeObject.Library_Effects.Effect.Length);
-        Assert.AreEqual(4, daeObject.Library_Images.Image.Length);
-    }
-
-    [TestMethod]
-    public void FiftyCalNecklace_GltfConversion()
-    {
-        var args = new string[] { $@"d:\depot\mwo\objects\purchasable\cockpit_hanging\50calnecklace\50calnecklace_a.chr", "-dds", "-objectdir", objectDir };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-        CryEngine cryData = new(args[0], testUtils.argsHandler.Args.PackFileSystem);
-        cryData.ProcessCryengineFiles();
-
-        GltfModelRenderer gltfRenderer = new(testUtils.argsHandler.Args, cryData);
-        var gltfData = gltfRenderer.GenerateGltfObject();
-
-        Assert.AreEqual(1, gltfData.Materials.Count);
-        Assert.AreEqual(1, gltfData.Meshes.Count);
-
-        // Nodes check
-        Assert.AreEqual(9, gltfData.Nodes.Count);
-        Assert.AreEqual("Bip01", gltfData.Nodes[0].Name);
-        Assert.AreEqual("hang seg1", gltfData.Nodes[1].Name);
-        Assert.AreEqual("hang seg2", gltfData.Nodes[2].Name);
-
-        AssertExtensions.AreEqual([-0.4963841f, -0.5035906f, 0.491474152f, 0.5083822f], gltfData.Nodes[0].Rotation, TestUtils.delta);
-        AssertExtensions.AreEqual([0.00154118659f, -0.008913527f, 0.0122360326f, 0.9998842f], gltfData.Nodes[1].Rotation, TestUtils.delta);
-
-        AssertExtensions.AreEqual([2.09588125E-13f, 0.0204448365f, -8.731578E-10f], gltfData.Nodes[0].Translation, TestUtils.delta);
-        AssertExtensions.AreEqual([-0.0209655762f, -8.90577E-09f, 3.4356154E-10f], gltfData.Nodes[1].Translation, TestUtils.delta);
-
-        Assert.AreEqual(1, gltfData.Nodes[0].Children.Count);
-        Assert.AreEqual(1, gltfData.Nodes[1].Children.Count);
-        Assert.AreEqual(1, gltfData.Nodes[2].Children.Count);
-
-        // Accessors check
-        Assert.AreEqual(7, gltfData.Accessors.Count);
-
-        // Skins check
-        Assert.AreEqual(1, gltfData.Skins.Count);
-        Assert.AreEqual(8, gltfData.Skins[0].Joints.Count);
-        Assert.AreEqual(6, gltfData.Skins[0].InverseBindMatrices);
-        Assert.AreEqual("50calnecklace_a/skin", gltfData.Skins[0].Name);
-    }
-
-    [TestMethod]
-    public void Uav_VerifyMaterials()
-    {
-        var args = new string[] { $@"{userHome}\OneDrive\ResourceFiles\MWO\uav.cga", "-dds", "-dae", "-objectdir", objectDir };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem);
-        cryData.ProcessCryengineFiles();
-
-        var colladaData = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
-
-    }
-
-    [TestMethod]
-    public void Industrial_wetlamp_a_MaterialFileNotFound()
-    {
-        var args = new string[] {$@"{objectDir}\Objects\environments\frontend\mechlab_a\lights\industrial_wetlamp_a.cgf" };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir));
-        cryData.ProcessCryengineFiles();
-
-        ColladaModelRenderer colladaData = new(testUtils.argsHandler.Args, cryData);
-        colladaData.GenerateDaeObject();
-        testUtils.ValidateColladaXml(colladaData);
-    }
-
-    [TestMethod]
-    public void Timberwolf_chr()
-    {
-        var args = new string[] { $@"{userHome}\OneDrive\ResourceFiles\timberwolf.chr" };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-        CryEngine cryData = new(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir));
-        cryData.ProcessCryengineFiles();
-
-        ColladaModelRenderer colladaData = new(testUtils.argsHandler.Args, cryData);
-        var daeObject = colladaData.DaeObject;
-        colladaData.GenerateDaeObject();
-
-        // Visual Scene Check
-        Assert.AreEqual("Scene", daeObject.Scene.Visual_Scene.Name);
-        Assert.AreEqual("#Scene", daeObject.Scene.Visual_Scene.URL);
-        Assert.AreEqual(1, daeObject.Library_Visual_Scene.Visual_Scene.Length);
-        Assert.AreEqual("Scene", daeObject.Library_Visual_Scene.Visual_Scene[0].ID);
-        Assert.AreEqual(2, daeObject.Library_Visual_Scene.Visual_Scene[0].Node.Length);
-
-        // Armature Node check
-        var node = daeObject.Library_Visual_Scene.Visual_Scene[0].Node[0];
-        Assert.AreEqual("Bip01", node.ID);
-        Assert.AreEqual("Bip01", node.sID);
-        Assert.AreEqual("Bip01", node.Name);
-        Assert.AreEqual("JOINT", node.Type.ToString());
-        Assert.AreEqual("-0 1 0 0 -1 -0 0 0 0 0 1 -0 0 0 0 1", node.Matrix[0].Value_As_String);
-        var pelvisNode = node.node[0];
-        Assert.AreEqual("Bip01_Pelvis", pelvisNode.ID);
-        Assert.AreEqual("Bip01_Pelvis", pelvisNode.Name);
-        Assert.AreEqual("Bip01_Pelvis", pelvisNode.sID);
-        Assert.AreEqual("JOINT", pelvisNode.Type.ToString());
-        Assert.AreEqual("0 0 1 -8.346858 0 1 -0 0.000002 -1 0 0 -0.000001 0 0 0 1", pelvisNode.Matrix[0].Value_As_String);
-        Assert.AreEqual(3, pelvisNode.node.Length);
-        var pitchNode = pelvisNode.node.Where(a => a.ID == "Bip01_Pitch").FirstOrDefault();
-        var leftHipNode = pelvisNode.node.Where(a => a.ID == "Bip01_L_Hip").FirstOrDefault();
-        var rightHipNode = pelvisNode.node.Where(a => a.ID == "Bip01_R_Hip").FirstOrDefault();
-        Assert.IsNotNull(pitchNode);
-        Assert.AreEqual("Bip01_Pitch", pitchNode.sID);
-        Assert.AreEqual("-1 -0 0 -1.627027 0 -0.022216 0.999753 -8.344796 -0 0.999753 0.022216 -0.185437 0 0 0 1", leftHipNode.Matrix[0].Value_As_String);
-        Assert.AreEqual("1 -0 -0 -1.627022 -0 0.022216 -0.999753 8.344796 0 0.999753 0.022216 -0.185438 0 0 0 1", rightHipNode.Matrix[0].Value_As_String);
-        Assert.AreEqual("0 -0.891905 0.452222 -4.127187 0.009909 0.452200 0.891861 -8.139535 -0.999951 0.004481 0.008838 -0.080661 0 0 0 1", pitchNode.Matrix[0].Value_As_String);
-
-        // Geometry Node check
-        node = daeObject.Library_Visual_Scene.Visual_Scene[0].Node[1];
-        Assert.AreEqual("timberwolf", node.ID);
-        Assert.AreEqual("timberwolf", node.Name);
-        Assert.AreEqual("NODE", node.Type.ToString());
-        Assert.IsNull(node.Instance_Geometry);
-        Assert.AreEqual(1, node.Instance_Controller.Length);
-        Assert.AreEqual("#Bip01", node.Instance_Controller[0].Skeleton[0].Value);
-
-        // Controller check
-        var controller = daeObject.Library_Controllers.Controller[0];
-        Assert.AreEqual("Controller", controller.ID);
-        var skin = controller.Skin;
-        Assert.AreEqual("#timberwolf-mesh", skin.source);
-        Assert.AreEqual("1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1", skin.Bind_Shape_Matrix.Value_As_String);
-        Assert.AreEqual(3, skin.Source.Length);
-        var controllerJoints = skin.Source.Where(a => a.ID == "Controller-joints").First();
-        var controllerBindPose = skin.Source.Where(a => a.ID == "Controller-bind_poses").First();
-        var controllerWeights = skin.Source.Where(a => a.ID == "Controller-weights").First();
-        var joints = skin.Joints;
-        Assert.AreEqual(64, controllerJoints.Name_Array.Count);
-        Assert.AreEqual("Controller-joints-array", controllerJoints.Name_Array.ID);
-        var nameArray = controllerJoints.Name_Array.Value();
-        Assert.AreEqual(64, nameArray.Length);
-        Assert.IsTrue(nameArray.Contains("Bip01"));
-        Assert.IsTrue(nameArray.Contains("Bip01_L_Thigh"));
-        Assert.IsTrue(nameArray.Contains("Bip01_R_Toe0Nub"));
-
-        var bindPoseArray = "-0 1 0 0 -1 -0 0 0 0 0 1 -0 0 0 0 1 0 0 1 -8.346858 0 1 -0 0.000002 -1 0 0 -0.000001 0 0 0 1 -1 -0 0 -1.627027 0 -0.022216 0.999753 -8.344796 -0 0.999753 0.022216 -0.185437 0 0 0 1 0 -0.891905 0.452222 -4.127187 0.009909 0.452200 0.891861 -8.139535 -0.999951 0.004481 0.008838 -0.080661 0 0 0 1 1 -0 -0 -1.627022 -0 0.022216 -0.999753 8.344796 0 0.999753 0.022216 -0.185438 0 0 0 1 -0.003118 -0.652256 -0.757992 6.317856 0.003048 0.757986 -0.652263 5.453145 0.999990 -0.004344 -0.000376 2.888252 0 0 0 1 0.002098 0.554768 -0.832002 6.014472 0.003823 0.831994 0.554772 -1.264842 0.999990 -0.004344 -0.000376 2.888253 0 0 0 1 0 -0.000001 -1 1.399999 -0 1 -0.000001 -0.599996 1 0 0 2.885148 0 0 0 1 0.999961 -0.008298 -0.003012 2.504233 0.008648 0.989305 0.145603 1.111563 0.001772 -0.145624 0.989338 -5.841687 0 0 0 1 1 0 0 2.885148 -0 1 -0.000001 -0.599996 -0 0.000001 1 0.000002 0 0 0 1 0.256676 0.957929 -0.128409 -0.833228 -0.011007 0.135749 0.990682 -0.751913 0.966435 -0.252871 0.045388 2.090546 0 0 0 1 -0.256595 0.957623 -0.130836 -2.347204 -0.011012 0.132463 0.991127 -0.773801 0.966456 0.255758 -0.023444 3.607112 0 0 0 1 0 -0.972471 -0.233025 -0.390619 0 -0.233025 0.972471 -0.564066 -1 -0 0 -2.885148 0 0 0 1 -0 0.959551 -0.281534 -1.044431 -0.010661 0.281518 0.959497 -0.941531 0.999943 0.003002 0.010229 2.875273 0 0 0 1 0.257573 0.957690 -0.128399 -1.369874 0.012224 0.129642 0.991485 -0.701470 0.966181 -0.256950 0.021686 2.109286 0 0 0 1 0.210433 0.842365 -0.496124 -1.189731 0.011021 0.505411 0.862808 -1.430004 0.977546 -0.187031 0.097072 1.947561 0 0 0 1 0.210433 0.842365 -0.496124 -2.132204 0.011021 0.505411 0.862808 -1.430004 0.977546 -0.187031 0.097072 1.947561 0 0 0 1 -0.257518 0.957376 -0.130827 -2.893456 -0.035051 0.126049 0.991405 -0.863275 0.965638 0.259890 0.001097 3.583981 0 0 0 1 -0.225088 0.836700 -0.499268 -2.485888 -0.031675 0.505863 0.862032 -1.584614 0.973823 0.209848 -0.087362 3.763780 0 0 0 1 -0.225089 0.836700 -0.499268 -3.424760 -0.031675 0.505863 0.862032 -1.584614 0.973823 0.209848 -0.087362 3.763782 0 0 0 1 -0 -0.972471 -0.233025 -1.168555 0 -0.233025 0.972471 -0.564066 -1 0 0 -2.885148 0 0 0 1 -0 0.959551 -0.281534 -2.961370 -0.010661 0.281518 0.959497 -0.941530 0.999943 0.003002 0.010229 2.875274 0 0 0 1 1 0 -0 2.885148 -0 1 0.000001 -3.098014 0 -0.000001 1 0.000009 0 0 0 1 0 -0 1 -9.282160 -0 1 0 0.307090 -1 -0 0 0 0 0 0 1 0.000001 -0 1 -10.726149 -0 1 0 0.307090 -1 -0 0.000001 -0.000005 0 0 0 1 0.000001 -0 1 -10.957759 -0.000001 1 0 0.307090 -1 -0.000001 0.000001 -0.000009 0 0 0 1 -0.531478 -0.000001 -0.847072 8.086329 0 -1 0 -1.700724 -0.847072 -0 0.531478 -10.162396 0 0 0 1 0.531477 0.000001 -0.847073 8.086336 -0 -1 -0.000001 -1.700709 -0.847073 0 -0.531477 10.162374 0 0 0 1 1 0.000001 -0.000001 0.000010 -0.000001 1 0 -2.857098 0.000001 -0 1 -12.291666 0 0 0 1 1 0.000001 -0.000001 0.000009 -0.000001 1 0 -2.857097 0.000001 -0 1 -12.291667 0 0 0 1 -1 -0.000001 0.000001 -1.454218 -0 -0.707107 -0.707107 5.404586 0.000001 -0.707107 0.707107 -8.957491 0 0 0 1 -1 -0.000001 0.000001 -1.710584 -0 -0.707107 -0.707107 5.344195 0.000001 -0.707107 0.707107 -9.317745 0 0 0 1 -1 -0.000001 0.000001 1.511648 -0 -0.707107 -0.707107 5.402447 0.000002 -0.707107 0.707107 -8.954850 0 0 0 1 -1 -0.000001 0.000001 1.767603 -0 -0.707107 -0.707107 5.342055 0.000002 -0.707107 0.707107 -9.315106 0 0 0 1 -1 -0.000001 0.000001 0.041891 -0 -0.707107 -0.707107 5.313381 0.000001 -0.707107 0.707107 -9.133546 0 0 0 1 1 0.000001 -0.000001 0.000006 -0.000001 1 -0 -1.442909 0.000001 0 1 -11.937682 0 0 0 1 1 0.000001 -0.000001 -1.749993 -0.000001 1 0 -0.788977 0.000001 -0 1 -11.937676 0 0 0 1 1 0.000001 -0.000001 1.750005 -0.000001 1 -0 -0.788976 0.000001 0 1 -11.937681 0 0 0 1 -0.000001 -0.016842 -0.999858 11.221415 0.000188 -0.999858 0.016842 -1.889054 -1 -0.000188 0.000004 -4.937831 0 0 0 1 -0.000188 1 -0.000001 1.745410 -0.000004 -0.000001 -1 8.543955 -1 -0.000188 0.000004 -4.937831 0 0 0 1 -0 1 -0.000001 -1.278729 -0.011111 -0.000001 -0.999938 8.488578 -0.999938 -0 0.011111 -5.032661 0 0 0 1 0.999938 0.000191 0.011106 5.302608 -0.000191 1 0 1.515383 -0.011106 -0.000003 0.999938 -8.098288 0 0 0 1 -0 -0.016841 -0.999858 11.221406 -0.000191 -0.999858 0.016841 -1.889019 -1 0.000191 -0.000003 4.937818 0 0 0 1 0.000192 1 0 1.745375 0.000003 0 -1 8.543945 -1 0.000192 -0.000003 4.937819 0 0 0 1 0.000004 1 0.000001 -1.278764 -0.000001 0.000001 -1 8.543962 -1 0.000004 0.000001 4.938029 0 0 0 1 1 -0.000195 0.000003 -4.877823 0.000195 1 0.000002 1.695347 -0.000003 -0.000002 1 -8.533949 0 0 0 1 -0.003118 -0.652256 -0.757993 6.335854 0.003049 0.757987 -0.652263 5.435551 0.999990 -0.004345 -0.000375 -2.881985 0 0 0 1 0.002098 0.554769 -0.832002 6.002367 0.003823 0.831993 0.554773 -1.286910 0.999990 -0.004345 -0.000375 -2.881984 0 0 0 1 0 0 -1 1.400005 0 1 0 -0.600001 1 -0 0 -2.885144 0 0 0 1 0.999961 -0.008299 -0.003011 -3.075839 0.008649 0.989305 0.145604 1.091651 0.001771 -0.145625 0.989338 -5.711909 0 0 0 1 1 -0 -0 -2.885144 0 1 0 -0.600001 0 -0 1 -0.000008 0 0 0 1 -0.256676 0.957929 -0.128408 -0.833235 -0.011016 0.129951 0.991459 -0.704093 0.966435 0.255898 -0.022803 -2.107132 0 0 0 1 0.256594 0.957623 -0.130835 -2.347206 -0.011004 0.138253 0.990336 -0.691449 0.966456 -0.252675 0.046013 -3.623798 0 0 0 1 -0 -0.972471 -0.233025 -0.390614 -0 -0.233025 0.972471 -0.564074 -1 0 -0 2.885144 0 0 0 1 0 0.959551 -0.281533 -1.044434 -0.010661 0.281517 0.959497 -0.880024 0.999943 0.003001 0.010230 -2.894692 0 0 0 1 -0.257574 0.957690 -0.128398 -1.369879 -0.034420 0.123703 0.991722 -0.652829 0.965645 0.259861 0.001101 -2.124844 0 0 0 1 -0.225536 0.838453 -0.496115 -1.156751 -0.031134 0.502773 0.863858 -1.392009 0.973737 0.210277 -0.087289 -1.994333 0 0 0 1 -0.225536 0.838453 -0.496115 -2.099227 -0.031134 0.502773 0.863858 -1.392009 0.973737 0.210277 -0.087289 -1.994334 0 0 0 1 0.257518 0.957376 -0.130826 -2.893460 0.012854 0.131986 0.991168 -0.780703 0.966188 -0.256925 0.021683 -3.602867 0 0 0 1 0.225086 0.836690 -0.499286 -2.485926 0.011561 0.510106 0.860034 -1.506640 0.974270 -0.199354 0.105144 -3.795710 0 0 0 1 0.225086 0.836690 -0.499286 -3.424798 0.011561 0.510106 0.860034 -1.506639 0.974270 -0.199354 0.105144 -3.795709 0 0 0 1 -0 -0.972471 -0.233025 -1.168550 -0 -0.233025 0.972471 -0.564073 -1 0.000001 -0 2.885144 0 0 0 1 0 0.959552 -0.281533 -2.961374 -0.010661 0.281517 0.959497 -0.880024 0.999943 0.003001 0.010230 -2.894693 0 0 0 1 1 -0.000001 0.000001 -2.885145 0.000001 1 -0.000005 -3.098022 -0.000001 0.000005 1 -0.000021 0 0 0 1";
-        Assert.IsTrue(controllerBindPose.Float_Array.Value_As_String.StartsWith(bindPoseArray));
-        Assert.AreEqual(1024, controllerBindPose.Float_Array.Count);
-        Assert.IsTrue(controllerBindPose.Float_Array.Value_As_String.StartsWith(bindPoseArray)); ;
-
-        testUtils.ValidateColladaXml(colladaData);
-    }
-
-    [TestMethod]
-    public void Candycane_a_MaterialFileNotAvailable()
-    {
-        var args = new string[] { $@"{userHome}\OneDrive\ResourceFiles\MWO\NoMats\candycane_a.chr", "-dds", "-dae" };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-        CryEngine cryData = new(args[0], testUtils.argsHandler.Args.PackFileSystem);
-        cryData.ProcessCryengineFiles();
-
-        var colladaData = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
-        var daeObject = colladaData.DaeObject;
-        colladaData.GenerateDaeObject();
-
-        // Controller check
-        var controller = daeObject.Library_Controllers.Controller[0];
-        Assert.AreEqual("Controller", controller.ID);
-        var skin = controller.Skin;
-        Assert.AreEqual("#candycane_a-mesh", skin.source);
-        Assert.AreEqual("1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1", skin.Bind_Shape_Matrix.Value_As_String);
-        Assert.AreEqual(3, skin.Source.Length);
-        var controllerJoints = skin.Source.Where(a => a.ID == "Controller-joints").First();
-        var controllerBindPose = skin.Source.Where(a => a.ID == "Controller-bind_poses").First();
-        var controllerWeights = skin.Source.Where(a => a.ID == "Controller-weights").First();
-        var joints = skin.Joints;
-        Assert.AreEqual(8, controllerJoints.Name_Array.Count);
-        Assert.AreEqual("Controller-joints-array", controllerJoints.Name_Array.ID);
-
-        var bindPoseArray = "0 0 -1 0.023305 1 0 0 0 0 -1 0 0 0 0 0 1 -0.000089 0 -1 -0.000092 1 0.000008 -0.000089 0 0.000008 -1 0 0 0 0 0 1 -0.000091 0 -1 -0.026455 1 0.000008 -0.000091 0 0.000008";
-        var bindPoseArrayNegZeros = "-0 -0 -1 0.023305 1 -0 -0 -0 -0 -1 0 -0 0 0 0 1 -0.000089 -0 -1 -0.000092 1 0.000008 -0.000089 -0 0.000008 -1 0 -0 0 0 0 1 -0.000091 -0 -1 -0.026455 1 0.000008";
-        Assert.AreEqual(128, controllerBindPose.Float_Array.Count);
-        var bp = controllerBindPose.Float_Array.Value_As_String;
-        Assert.IsTrue(controllerBindPose.Float_Array.Value_As_String.StartsWith(bindPoseArray) || controllerBindPose.Float_Array.Value_As_String.StartsWith(bindPoseArrayNegZeros));
-        int actualMaterialsCount = colladaData.DaeObject.Library_Materials.Material.Count();
-        Assert.AreEqual(2, actualMaterialsCount);
-
-        // VisualScene
-        var scene = daeObject.Library_Visual_Scene.Visual_Scene[0];
-        Assert.AreEqual(2, scene.Node.Length);
-        var armature = scene.Node[0];
-        var instance = scene.Node[1];
-        Assert.AreEqual("Bip01", armature.ID);
-        Assert.AreEqual("Bip01", armature.Name);
-        Assert.AreEqual("-0 -0 -1 0.023305 1 -0 -0 -0 -0 -1 0 -0 0 0 0 1", armature.Matrix[0].Value_As_String);
-        Assert.AreEqual("hang_seg1", armature.node[0].ID);
-        Assert.AreEqual("hang_seg1", armature.node[0].Name);
-        Assert.AreEqual("-0.000089 -0 -1 -0.000092 1 0.000008 -0.000089 -0 0.000008 -1 0 -0 0 0 0 1", armature.node[0].Matrix[0].Value_As_String);
-        Assert.AreEqual("hang_seg2", armature.node[0].node[0].ID);
-        Assert.AreEqual("hang_seg2", armature.node[0].node[0].Name);
-        Assert.AreEqual("-0.000091 -0 -1 -0.026455 1 0.000008 -0.000091 -0 0.000008 -1 0 -0 0 0 0 1", armature.node[0].node[0].Matrix[0].Value_As_String);
-
-        Assert.AreEqual(2, instance.Instance_Controller[0].Bind_Material[0].Technique_Common.Instance_Material.Length);
-
-        testUtils.ValidateColladaXml(colladaData);
-    }
-
-    [TestMethod]
-    public void Candycane_a_WithMaterialFile()
-    {
-        var args = new string[] { $@"{userHome}\OneDrive\ResourceFiles\MWO\candycane_a.chr", objectDir };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-        var cryData = new CryEngine(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir));
-        cryData.ProcessCryengineFiles();
-
-        var colladaData = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
-        var daeObject = colladaData.DaeObject;
-        colladaData.GenerateDaeObject();
-
-        // Controller check
-        var controller = daeObject.Library_Controllers.Controller[0];
-        Assert.AreEqual("Controller", controller.ID);
-        var skin = controller.Skin;
-        Assert.AreEqual("#candycane_a-mesh", skin.source);
-        Assert.AreEqual("1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1", skin.Bind_Shape_Matrix.Value_As_String);
-        Assert.AreEqual(3, skin.Source.Length);
-        var controllerJoints = skin.Source.Where(a => a.ID == "Controller-joints").First();
-        var controllerBindPose = skin.Source.Where(a => a.ID == "Controller-bind_poses").First();
-        var controllerWeights = skin.Source.Where(a => a.ID == "Controller-weights").First();
-        var joints = skin.Joints;
-        Assert.AreEqual(8, controllerJoints.Name_Array.Count);
-        Assert.AreEqual("Controller-joints-array", controllerJoints.Name_Array.ID);
-
-        var bindPoseArray = "0 0 -1 0.023305 1 0 0 0 0 -1 0 0 0 0 0 1 -0.000089 0 -1 -0.000092 1 0.000008 -0.000089 0 0.000008 -1 0 0 0 0 0 1 -0.000091 0 -1 -0.026455 1 0.000008 -0.000091 0 0.000008";
-        var bindPoseArrayNegZeros = "-0 -0 -1 0.023305 1 -0 -0 -0 -0 -1 0 -0 0 0 0 1 -0.000089 -0 -1 -0.000092 1 0.000008 -0.000089 -0 0.000008 -1 0 -0 0 0 0 1 -0.000091 -0 -1 -0.026455 1 0.000008";
-        Assert.AreEqual(128, controllerBindPose.Float_Array.Count);
-        Assert.IsTrue(controllerBindPose.Float_Array.Value_As_String.StartsWith(bindPoseArray) || controllerBindPose.Float_Array.Value_As_String.StartsWith(bindPoseArrayNegZeros));
-        int actualMaterialsCount = colladaData.DaeObject.Library_Materials.Material.Count();
-        Assert.AreEqual(2, actualMaterialsCount);
-
-        // VisualScene
-        var scene = daeObject.Library_Visual_Scene.Visual_Scene[0];
-        Assert.AreEqual(2, scene.Node.Length);
-        var armature = scene.Node[0];
-        var geometryNode = scene.Node[1];
-        Assert.AreEqual("Bip01", armature.ID);
-        Assert.AreEqual("Bip01", armature.Name);
-        Assert.AreEqual(2, geometryNode.Instance_Controller[0].Bind_Material[0].Technique_Common.Instance_Material.Length);
-
-        testUtils.ValidateColladaXml(colladaData);
-    }
-
-    [TestMethod]
-    public void Hbr_right_torso_uac5_bh1_cga()
-    {
-        var args = new string[] { $@"d:\depot\mwo\objects\mechs\hellbringer\body\hbr_right_torso.cga", "-dds", "-dae", "-objectdir", objectDir };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-        CryEngine cryData = new(args[0], testUtils.argsHandler.Args.PackFileSystem);
-        cryData.ProcessCryengineFiles();
-
-        ColladaModelRenderer colladaData = new(testUtils.argsHandler.Args, cryData);
-        colladaData.GenerateDaeObject();
-
-        testUtils.ValidateColladaXml(colladaData);
-    }
-
-    [TestMethod]
-    public void Hbr_right_torso_cga()
-    {
-        // No mtl file provided, so it creates generic mats
-        var args = new string[] { $@"d:\depot\mwo\objects\mechs\hellbringer\body\hbr_right_torso.cga", "-dds", "-dae", "-objectdir", objectDir };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-        CryEngine cryData = new(args[0], testUtils.argsHandler.Args.PackFileSystem);
-        cryData.ProcessCryengineFiles();
-
-        var colladaData = new ColladaModelRenderer(testUtils.argsHandler.Args, cryData);
-        var daeObject = colladaData.DaeObject;
-        colladaData.GenerateDaeObject();
-
-        Assert.AreEqual("Scene", daeObject.Scene.Visual_Scene.Name);
-        Assert.AreEqual("#Scene", daeObject.Scene.Visual_Scene.URL);
-        // Visual Scene Check
-        Assert.AreEqual(1, daeObject.Library_Visual_Scene.Visual_Scene.Length);
-        Assert.AreEqual("Scene", daeObject.Library_Visual_Scene.Visual_Scene[0].ID);
-        Assert.AreEqual(1, daeObject.Library_Visual_Scene.Visual_Scene[0].Node.Length);
-        // Node Matrix check
-        var node = daeObject.Library_Visual_Scene.Visual_Scene[0].Node[0];
-        const string matrix = "1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 0";
-        Assert.AreEqual(matrix, node.Matrix[0].Value_As_String);
-        Assert.AreEqual("transform", node.Matrix[0].sID);
-        // Instance Geometry check
-        Assert.AreEqual("hbr_right_torso", node.Instance_Geometry[0].Name);
-        Assert.AreEqual("#hbr_right_torso-mesh", node.Instance_Geometry[0].URL);
-        Assert.AreEqual(1, node.Instance_Geometry[0].Bind_Material.Length);
-        Assert.AreEqual(1, node.Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material.Length);
-        Assert.AreEqual("mechDefault_mtl_material0-material", node.Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[0].Symbol);
-        Assert.AreEqual("#mechDefault_mtl_material0-material", node.Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[0].Target);
-
-        // library_geometries check
-        Assert.AreEqual(1, colladaData.DaeObject.Library_Geometries.Geometry.Length);
-        var geometry = colladaData.DaeObject.Library_Geometries.Geometry[0];
-        Assert.AreEqual("hbr_right_torso-mesh", geometry.ID);
-        Assert.AreEqual("hbr_right_torso", geometry.Name);
-        Assert.AreEqual(4, geometry.Mesh.Source.Length);
-        Assert.AreEqual("hbr_right_torso-vertices", geometry.Mesh.Vertices.ID);
-        Assert.AreEqual(1, geometry.Mesh.Triangles.Length);
-        Assert.AreEqual(1908, geometry.Mesh.Triangles[0].Count);
-        var source = geometry.Mesh.Source;
-        var vertices = geometry.Mesh.Vertices;
-        var triangles = geometry.Mesh.Triangles;
-        // Triangles check
-        Assert.AreEqual("mechDefault_mtl_material0-material", triangles[0].Material);
-        Assert.AreEqual("#hbr_right_torso-mesh-pos", vertices.Input[0].source);
-        Assert.IsTrue(triangles[0].P.Value_As_String.StartsWith("0 0 0 1 1 1 2 2 2 3 3 3 4 4 4 5 5 5 5 5 5 6 6 6 3 3 3 7 7 7 8 8 8 9 9 9 9 9 9"));
-        // Source check
-        Assert.AreEqual("hbr_right_torso-mesh-pos", source[0].ID);
-        Assert.AreEqual("hbr_right_torso-pos", source[0].Name);
-        Assert.AreEqual("hbr_right_torso-mesh-pos-array", source[0].Float_Array.ID);
-        Assert.AreEqual(7035, source[0].Float_Array.Count);
-        var floatArray = source[0].Float_Array.Value_As_String;
-        Assert.IsTrue(floatArray.StartsWith("2.525999 -1.729837 -1.258107 2.526004 -1.863573 -1.080200 2.525999 -1.993050 -1.255200 2.740049 -0.917271 0.684382 2.740053 -0.917271 0.840976 2.793932"));
-        Assert.IsTrue(floatArray.EndsWith("-3.263152 2.340879 -1.480840 -3.231119 2.352005 -1.494859 -3.268093 2.329598 -1.478497 -3.234514 2.335588 -1.491449 -3.273033 2.320036 -1.471824 -3.237391"));
-        Assert.AreEqual((uint)2345, source[0].Technique_Common.Accessor.Count);
-        Assert.AreEqual((uint)0, source[0].Technique_Common.Accessor.Offset);
-        Assert.AreEqual(3, source[0].Technique_Common.Accessor.Param.Length);
-        Assert.AreEqual("X", source[0].Technique_Common.Accessor.Param[0].Name);
-        Assert.AreEqual("float", source[0].Technique_Common.Accessor.Param[0].Type);
-
-        Assert.AreEqual("hbr_right_torso", daeObject.Library_Visual_Scene.Visual_Scene[0].Node[0].ID);
-        Assert.AreEqual(1, daeObject.Library_Visual_Scene.Visual_Scene[0].Node[0].Instance_Geometry.Length);
-        testUtils.ValidateColladaXml(colladaData);
-    }
-
-    [TestMethod]
-    public void HulaGirl_ColladaFormat()
-    {
-        var args = new string[] { @"d:\depot\MWO\objects\purchasable\cockpit_standing\hulagirl\hulagirl__gold_a.cga" };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-        CryEngine cryData = new(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir));
-        cryData.ProcessCryengineFiles();
-
-        ColladaModelRenderer colladaData = new(testUtils.argsHandler.Args, cryData);
-        colladaData.GenerateDaeObject();
-
-        int actualMaterialsCount = colladaData.DaeObject.Library_Materials.Material.Length;
-        Assert.AreEqual(1, actualMaterialsCount);
-        var libraryGeometry = colladaData.DaeObject.Library_Geometries;
-        Assert.AreEqual(2, libraryGeometry.Geometry.Length);
-        var nodes = colladaData.DaeObject.Library_Visual_Scene.Visual_Scene[0].Node;
-        var baseNode = nodes[0];
-        Assert.AreEqual("hulagirl_a", baseNode.ID);
-        Assert.AreEqual("hulagirl_a", baseNode.Name);
-        Assert.AreEqual(2, baseNode.node.Length);
-        Assert.IsNull(baseNode.Instance_Geometry);
-        Assert.AreEqual("1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 0", baseNode.Matrix[0].Value_As_String);
-
-        // Serialize the object to XML
-        XmlSerializer serializer = new(typeof(ColladaDoc));
-        StringWriter writer = new();
-        serializer.Serialize(writer, colladaData.DaeObject);
-
-        // Load the serialized XML into an XDocument for LINQ querying
-        XDocument doc = XDocument.Parse(writer.ToString());
-
-        // Find nodes under visual_scene node
-        var visualSceneNodes = doc.Descendants("visual_scene").Elements("node");
-
-        foreach (var node in visualSceneNodes)
-        {
-            // Ensure the translate comes before rotate for each "node" element
-            var translateElement = node.Elements("translate").FirstOrDefault();
-            var rotateElement = node.Elements("rotate").FirstOrDefault();
-
-            Assert.IsNotNull(translateElement, "Translate element not found");
-            Assert.IsNotNull(rotateElement, "Rotate element not found");
-
-            // Assert the order is correct
-            int translateIndex = translateElement.ElementsBeforeSelf().Count();
-            int rotateIndex = rotateElement.ElementsBeforeSelf().Count();
-
-            Assert.IsTrue(translateIndex < rotateIndex, "Translate should come before Rotate");
-
-            // Assert the values are correct
-            string translateValues = translateElement.Value;
-            string rotateValues = rotateElement.Value;
-
-            Assert.AreEqual("0.000101 0 0.064078", translateValues, "Translate values are not as expected");
-            Assert.AreEqual("-0.908837 0.415754 0.034101 12.949439", rotateValues, "Rotate values are not as expected");
-        }
-    }
-
-    [TestMethod]
-    public void HulaGirl_GltfFormat()
-    {
-        var args = new string[]
-        {
-            $@"D:\depot\MWO\Objects\purchasable\cockpit_standing\hulagirl\hulagirl__gold_a.cga",
-            "-objectdir", objectDir,
-            "-mat", "hulagirl_a.mtl"
-        };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-        CryEngine cryData = new(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(args[4]));
-        cryData.ProcessCryengineFiles();
-
-        GltfModelRenderer gltfRenderer = new(testUtils.argsHandler.Args, cryData);
-        var gltfData = gltfRenderer.GenerateGltfObject();
-
-        Assert.AreEqual(1, gltfData.Materials.Count);
-        Assert.AreEqual(2, gltfData.Meshes.Count);
-
-        // Nodes check
-        Assert.AreEqual(3, gltfData.Nodes.Count);
-        Assert.AreEqual("HulaGirl_UpperBody", gltfData.Nodes[0].Name);
-        Assert.AreEqual("HulaGirl_LowerBody", gltfData.Nodes[1].Name);
-        Assert.AreEqual("hulagirl_a", gltfData.Nodes[2].Name);
-
-        var rotationMatrix = cryData.RootNode.Children.First().Rot.ConvertToRotationMatrix();
-        AssertExtensions.AreEqual([0, 0, 0, 1], gltfData.Nodes[1].Rotation, TestUtils.delta);
-        AssertExtensions.AreEqual([-0.10248467f, 0.00384537f, -0.04688235744833946f, 0.9936217f], gltfData.Nodes[0].Rotation, TestUtils.delta);
-        AssertExtensions.AreEqual([0, 0, 0, 1], gltfData.Nodes[2].Rotation, TestUtils.delta);
-
-        AssertExtensions.AreEqual([0, 0, 0], gltfData.Nodes[1].Translation, TestUtils.delta);
-        AssertExtensions.AreEqual([-0.000101296f, 0.0640777f, 0f], gltfData.Nodes[0].Translation, TestUtils.delta);
-        AssertExtensions.AreEqual([0, 0, 0], gltfData.Nodes[2].Translation, TestUtils.delta);
-
-        Assert.AreEqual(2, gltfData.Nodes[2].Children.Count);
-        Assert.AreEqual(0, gltfData.Nodes[1].Children.Count);
-        Assert.AreEqual(0, gltfData.Nodes[0].Children.Count);
-
-        // Accessors check
-        Assert.AreEqual(10, gltfData.Accessors.Count);
-    }
-
-    [TestMethod]
-    public void HulaGirl_UsdFormat()
-    {
-        var args = new string[]
-        {
-            $@"{objectDir}\Objects\purchasable\cockpit_standing\hulagirl\hulagirl__gold_a.cga",
-            "-objectdir", objectDir
-        };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-        CryEngine cryData = new(args[0], testUtils.argsHandler.Args.PackFileSystem);
-        cryData.ProcessCryengineFiles();
-
-        UsdRenderer usdRenderer = new(testUtils.argsHandler.Args, cryData);
-        var usdDoc = usdRenderer.GenerateUsdObject();
-        usdRenderer.WriteUsdToFile(usdDoc);
-        Assert.IsNotNull(usdDoc);
-        usdDoc.Prims[0].Name = "root";
-        usdDoc.Prims[0].Children[0].Name = "hulagirl_a";
-        usdDoc.Prims[0].Children[0].Children[0].Name = "HulaGirl_UpperBody";
-        usdDoc.Prims[0].Children[0].Children[1].Name = "HulaGirl_LowerBody";
-    }
-
-    [TestMethod]
-    public void Adder_Cockpit_UsdFormat()
-    {
-        var args = new string[]
-        {
-            $@"{objectDir}\Objects\mechs\Adder\cockpit_standard\adder_a_cockpit_standard.cga",
-            "-objectdir", objectDir
-        };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-        CryEngine cryData = new(args[0], testUtils.argsHandler.Args.PackFileSystem);
-        cryData.ProcessCryengineFiles();
-
-        UsdRenderer usdRenderer = new(testUtils.argsHandler.Args, cryData);
-        var usdDoc = usdRenderer.GenerateUsdObject();
-        usdRenderer.WriteUsdToFile(usdDoc);
-        Assert.IsNotNull(usdDoc);
-    }
-
-    [TestMethod]
-    public void MechFactory_CratesA_Gltf()
-    {
-        var args = new string[]
-        {
-            $@"d:\depot\mwo\objects\environments\mech_factory\mf_crates\mechfactory_cratesa.cgf",
-            "-objectdir", objectDir,
-            "-mat", "mf_crates.mtl"
-        };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-        CryEngine cryData = new(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(args[4]));
-        cryData.ProcessCryengineFiles();
-
-        GltfModelRenderer gltfRenderer = new(testUtils.argsHandler.Args, cryData);
-        var gltfData = gltfRenderer.GenerateGltfObject();
-        Assert.AreEqual(1, gltfData.Textures.Count);
-        Assert.AreEqual(2, gltfData.Materials.Count);
-    }
-
-    [TestMethod]
-    public void Mechanic_Usd_WithArmature()
-    {
-        var modelFile = $@"{objectDir}\Objects\characters\mechanic\mechanic.chr";
-
-        // Check if file exists
-        if (!File.Exists(modelFile))
-        {
-            Assert.Inconclusive($"Model file not found: {modelFile}");
-            return;
-        }
-
-        var args = new string[] { modelFile, "-objectdir", objectDir };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-
-        // Process CryEngine file with skinning info
-        CryEngine cryData = new(args[0], testUtils.argsHandler.Args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir));
-        cryData.ProcessCryengineFiles();
-
-        // Verify skinning info is present
-        Assert.IsNotNull(cryData.SkinningInfo, "SkinningInfo should not be null");
-        Assert.IsTrue(cryData.SkinningInfo.HasSkinningInfo, "Should have skinning info");
-        Assert.IsTrue(cryData.SkinningInfo.CompiledBones.Count > 0, "Should have bones");
-
-        Console.WriteLine($"Model has {cryData.SkinningInfo.CompiledBones.Count} bones");
-        Console.WriteLine($"Root bone: {cryData.SkinningInfo.RootBone?.BoneName}");
-
-        // Generate USD
-        UsdRenderer usdRenderer = new(testUtils.argsHandler.Args, cryData);
-        var usdDoc = usdRenderer.GenerateUsdObject();
-
-        // Serialize to string for inspection
-        var serializer = new UsdSerializer();
-        using var writer = new StringWriter();
-        serializer.Serialize(usdDoc, writer);
-        var usdOutput = writer.ToString();
-
-        // Verify skeleton structure is in output
-        Assert.IsTrue(usdOutput.Contains("def SkelRoot \"Armature\""), "Should have SkelRoot prim");
-        Assert.IsTrue(usdOutput.Contains("def Skeleton \"Skeleton\""), "Should have Skeleton prim");
-        Assert.IsTrue(usdOutput.Contains("prepend apiSchemas = [\"SkelBindingAPI\"]"), "Skeleton should have SkelBindingAPI");
-
-        // Verify skeleton data arrays
-        Assert.IsTrue(usdOutput.Contains("uniform token[] joints"), "Should have joints array");
-        Assert.IsTrue(usdOutput.Contains("uniform matrix4d[] bindTransforms"), "Should have bindTransforms");
-        Assert.IsTrue(usdOutput.Contains("uniform matrix4d[] restTransforms"), "Should have restTransforms");
-
-        // Verify mesh skinning attributes
-        Assert.IsTrue(usdOutput.Contains("primvars:skel:geomBindTransform"), "Should have geomBindTransform");
-        Assert.IsTrue(usdOutput.Contains("primvars:skel:jointIndices"), "Should have jointIndices");
-        Assert.IsTrue(usdOutput.Contains("primvars:skel:jointWeights"), "Should have jointWeights");
-        Assert.IsTrue(usdOutput.Contains("rel skel:skeleton"), "Should have skeleton relationship");
-        Assert.IsTrue(usdOutput.Contains("</root/Armature/Skeleton>"), "Should reference skeleton path");
-
-        // Verify some expected bone names in joint hierarchy
-        Assert.IsTrue(usdOutput.Contains("Bip01"), "Should contain root bone Bip01");
-
-        // Test specific bone transforms against expected values
-        // These values are from the raw bone data and Collada comparison
-
-        var bip01Bone = cryData.SkinningInfo.CompiledBones.FirstOrDefault(b => b.BoneName == "Bip01");
-        var bip01Pelvis = cryData.SkinningInfo.CompiledBones.FirstOrDefault(b => b.BoneName == "bip_01_Pelvis");
-        var bip01LThigh = cryData.SkinningInfo.CompiledBones.FirstOrDefault(b => b.BoneName == "bip_01_L_Thigh");
-
-        Assert.IsNotNull(bip01Bone, $"Should find Bip01 bone. Found {cryData.SkinningInfo.CompiledBones.Count} bones total.");
-        Assert.IsNotNull(bip01Pelvis, $"Should find bip_01_Pelvis bone");
-        Assert.IsNotNull(bip01LThigh, $"Should find bip_01_L_Thigh bone");
-
-        // Expected values from Collada output (both bind and rest use same values)
-        // Bip01: Translation should be near (0, 0, 0) - root bone
-        // Bip01 Pelvis: Translation should be near (0, 0.950611, 0) in Z-up
-        // These are in LocalTransformMatrix (worldToBone / inverse bind)
-
-        Console.WriteLine($"\nBip01 LocalTransformMatrix (worldToBone):");
-        Console.WriteLine($"  Translation: ({bip01Bone.LocalTransformMatrix.M14:F6}, {bip01Bone.LocalTransformMatrix.M24:F6}, {bip01Bone.LocalTransformMatrix.M34:F6})");
-
-        Console.WriteLine($"\nBip01 Pelvis LocalTransformMatrix (worldToBone):");
-        Console.WriteLine($"  Translation: ({bip01Pelvis.LocalTransformMatrix.M14:F6}, {bip01Pelvis.LocalTransformMatrix.M24:F6}, {bip01Pelvis.LocalTransformMatrix.M34:F6})");
-        Console.WriteLine($"  Expected: (0.000000, 0.000000, -0.950611) [inverted Z from world]");
-
-        Console.WriteLine($"\nBip01 Pelvis WorldTransformMatrix (boneToWorld):");
-        Console.WriteLine($"  Translation: ({bip01Pelvis.WorldTransformMatrix.M14:F6}, {bip01Pelvis.WorldTransformMatrix.M24:F6}, {bip01Pelvis.WorldTransformMatrix.M34:F6})");
-        Console.WriteLine($"  Expected: (0.000000, 0.000000, 0.950611) [Z-up position]");
-
-        // Verify Bip01 Pelvis world translation matches expected (from your raw data)
-        Assert.AreEqual(0.0, bip01Pelvis.WorldTransformMatrix.M14, 0.001, "Bip01 Pelvis X should be ~0");
-        Assert.AreEqual(0.0, bip01Pelvis.WorldTransformMatrix.M24, 0.001, "Bip01 Pelvis Y should be ~0");
-        Assert.AreEqual(0.950611, bip01Pelvis.WorldTransformMatrix.M34, 0.001, "Bip01 Pelvis Z should be ~0.950611");
-
-        // Find skeleton recursively
-        UsdSkeleton? skeleton = null;
-        foreach (var prim in usdDoc.Prims)
-        {
-            skeleton = FindSkeleton(prim);
-            if (skeleton is not null) break;
-        }
-
-        if (skeleton == null)
-        {
-            Console.WriteLine("ERROR: No Skeleton prim found in USD output!");
-            Assert.Fail("Skeleton prim not found");
-            return;
-        }
-
-        var restTransformsAttr = skeleton.Attributes.FirstOrDefault(a => a.Name == "restTransforms") as UsdMatrix4dArray;
-        if (restTransformsAttr == null)
-        {
-            Console.WriteLine("ERROR: No restTransforms attribute found!");
-            Console.WriteLine($"Found {skeleton.Attributes.Count} attributes:");
-            foreach (var attr in skeleton.Attributes)
-            {
-                Console.WriteLine($"  - {attr.Name}");
-            }
-            Assert.Fail("restTransforms attribute not found");
-            return;
-        }
-
-        var restTransforms = restTransformsAttr.Matrices;
-        Assert.IsTrue(restTransforms.Count >= 3, "Should have at least 3 bones");
-
-        // Optional: write to file for manual inspection
-        // usdRenderer.WriteUsdToFile(usdDoc);
-    }
-
-    private void PrintMatrix(Matrix4x4 m)
-    {
-        Console.WriteLine($"  ( ({m.M11:F6}, {m.M12:F6}, {m.M13:F6}, {m.M14:F6}), ({m.M21:F6}, {m.M22:F6}, {m.M23:F6}, {m.M24:F6}), ({m.M31:F6}, {m.M32:F6}, {m.M33:F6}, {m.M34:F6}), ({m.M41:F6}, {m.M42:F6}, {m.M43:F6}, {m.M44:F6}) )");
-    }
-
-    private UsdSkeleton? FindSkeleton(UsdPrim prim)
+    private static UsdSkeleton? FindSkeleton(UsdPrim prim)
     {
         if (prim is UsdSkeleton skel)
             return skel;
@@ -1432,36 +93,461 @@ public class MWOIntegrationTests
         foreach (var child in prim.Children)
         {
             var found = FindSkeleton(child);
-            if (found != null)
+            if (found is not null)
                 return found;
         }
 
         return null;
     }
 
-    [TestMethod]
-    public void MechFactory_CratesA_Collada()
-    {
-        var args = new string[] { $@"d:\depot\mwo\objects\environments\mech_factory\mf_crates\mechfactory_cratesa.cgf" };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-        CryEngine cryData = new(args[0], testUtils.argsHandler.Args.PackFileSystem);
-        cryData.ProcessCryengineFiles();
+    #endregion
 
-        ColladaModelRenderer colladaData = new(testUtils.argsHandler.Args, cryData);
-        colladaData.GenerateDaeObject();
+    #region .cgf Static Geometry
+
+    [TestMethod]
+    public void Box_Collada_GeometryAndMaterials()
+    {
+        var cryData = ProcessCryEngineFile($@"{objectDir}\Objects\default\box.cgf");
+        var dae = GenerateCollada(cryData);
+
+        // Geometry
+        Assert.AreEqual(1, dae.Library_Geometries.Geometry.Length);
+        Assert.AreEqual("box-mesh", dae.Library_Geometries.Geometry[0].ID);
+        Assert.AreEqual(4, dae.Library_Geometries.Geometry[0].Mesh.Source.Length);
+        Assert.AreEqual(2, dae.Library_Geometries.Geometry[0].Mesh.Triangles.Length);
+        Assert.AreEqual(12, dae.Library_Geometries.Geometry[0].Mesh.Triangles[0].Count);
+
+        // Materials (resolved via model-name fallback: box.mtl loaded for library "helper")
+        Assert.AreEqual(2, dae.Library_Materials.Material.Length);
+        Assert.AreEqual("helper_mtl_Material_#25", dae.Library_Materials.Material[0].Name);
+
+        // Visual scene node
+        var boxNode = dae.Library_Visual_Scene.Visual_Scene[0].Node[0];
+        Assert.AreEqual("box", boxNode.ID);
+        Assert.AreEqual(ColladaNodeType.NODE, boxNode.Type);
+        Assert.AreEqual("1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 0", boxNode.Matrix[0].Value_As_String);
+
+        // Material binding
+        Assert.AreEqual("#helper_mtl_Material_#25-material", boxNode.Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[0].Target);
+        Assert.AreEqual("helper_mtl_Material_#25-material", boxNode.Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[0].Symbol);
     }
 
     [TestMethod]
-    public void Mf_Bldg_A_Corner_Slope_Gltf()
+    public void Box_Gltf_GeometryAndMaterials()
     {
-        var args = new string[] { $@"D:\depot\mwo\objects\environments\mech_factory\building_blocks\mf_bldg_a_corner_slope_01.cgf", "-objectdir", "d:\\depot\\mwo" };
-        int result = testUtils.argsHandler.ProcessArgs(args);
-        Assert.AreEqual(0, result);
-        CryEngine cryData = new(args[0], testUtils.argsHandler.Args.PackFileSystem);
-        cryData.ProcessCryengineFiles();
+        var cryData = ProcessCryEngineFile($@"{objectDir}\Objects\default\box.cgf");
+        var gltf = GenerateGltf(cryData);
 
-        GltfModelRenderer gltfRenderer = new(testUtils.argsHandler.Args, cryData);
-        var gltfData = gltfRenderer.GenerateGltfObject();
+        Assert.AreEqual(2, gltf.Materials.Count);
+        Assert.AreEqual(1, gltf.Meshes.Count);
+        Assert.AreEqual(1, gltf.Meshes[0].Primitives.Count); // Second subset has 0 indices/vertices
+        Assert.AreEqual("box", gltf.Nodes[0].Name);
     }
+
+    [TestMethod]
+    public void Box_Usd_MaterialProperties()
+    {
+        var matFile = $@"{objectDir}\Objects\default\box.mtl";
+        var cryData = ProcessCryEngineFile($@"{objectDir}\Objects\default\box.cgf", matFile);
+        var usdOutput = GenerateUsdString(cryData);
+
+        // Material shader properties
+        Assert.IsTrue(usdOutput.Contains("inputs:diffuseColor"), "Should have diffuseColor");
+        Assert.IsTrue(usdOutput.Contains("inputs:opacity"), "Should have opacity");
+        Assert.IsTrue(usdOutput.Contains("inputs:roughness"), "Should have roughness");
+        Assert.IsTrue(usdOutput.Contains("inputs:metallic"), "Should have metallic");
+
+        // Color format uses parentheses
+        Assert.IsTrue(usdOutput.Contains("inputs:diffuseColor = ("), "Color values should use parentheses");
+
+        // Face-based GeomSubsets
+        Assert.IsTrue(usdOutput.Contains("elementType = \"face\""), "GeomSubset should use face element type");
+
+        // Material names cleaned
+        Assert.IsTrue(usdOutput.Contains("Material__25"), "Material #25 should be cleaned");
+        Assert.IsTrue(usdOutput.Contains("Material__26"), "Material #26 should be cleaned");
+    }
+
+    [TestMethod]
+    public void WetLamp_Collada_MissingMaterialFile()
+    {
+        var cryData = ProcessCryEngineFile($@"{objectDir}\Objects\environments\frontend\mechlab_a\lights\industrial_wetlamp_a.cgf");
+        var dae = GenerateCollada(cryData);
+
+        Assert.IsTrue(dae.Library_Materials.Material.Length >= 1, "Should have at least 1 material");
+    }
+
+    [TestMethod]
+    public void MechFactory_Crates_Gltf_ExplicitMtl()
+    {
+        var cryData = ProcessCryEngineFile(
+            $@"{objectDir}\objects\environments\mech_factory\mf_crates\mechfactory_cratesa.cgf",
+            "mf_crates.mtl");
+        var gltf = GenerateGltf(cryData);
+
+        Assert.AreEqual(1, gltf.Textures.Count);
+        Assert.AreEqual(2, gltf.Materials.Count);
+    }
+
+    #endregion
+
+    #region .cga Animated Geometry
+
+    [TestMethod]
+    public void AdrRightTorso_Collada_DefaultMaterials()
+    {
+        var cryData = ProcessCryEngineFile($@"{objectDir}\objects\mechs\adder\body\adr_right_torso_uac20_bh1.cga");
+        var dae = GenerateCollada(cryData);
+
+        // Default materials (no mtl file)
+        Assert.AreEqual(0, dae.Library_Images.Image.Length);
+        Assert.AreEqual(22, dae.Library_Materials.Material.Length);
+        Assert.AreEqual("mechDefault_mtl_material0", dae.Library_Materials.Material[0].Name);
+
+        // Geometry (multiple meshes from node hierarchy)
+        Assert.IsTrue(dae.Library_Geometries.Geometry.Length >= 3, "Should have at least 3 geometries");
+
+        // Root visual scene node
+        var rootNode = dae.Library_Visual_Scene.Visual_Scene[0].Node[0];
+        Assert.AreEqual("adr_right_torso_uac20_bh1", rootNode.Name);
+
+        // Animation node has no geometry
+        Assert.AreEqual("animation068", rootNode.node[0].Name);
+        Assert.IsNull(rootNode.node[0].Instance_Geometry);
+    }
+
+    [TestMethod]
+    public void AdrRightTorso_Collada_ProvidedMtlFile()
+    {
+        var matFile = $@"{objectDir}\Objects\mechs\adder\body\adder_body.mtl";
+        var cryData = ProcessCryEngineFile(
+            $@"{objectDir}\objects\mechs\adder\body\adr_right_torso_uac20_bh1.cga", matFile);
+        var dae = GenerateCollada(cryData);
+
+        Assert.AreEqual(28, dae.Library_Images.Image.Length);
+        Assert.AreEqual(5, dae.Library_Materials.Material.Length);
+        Assert.AreEqual("adder_body_mtl_adder_body", dae.Library_Materials.Material[0].Name);
+
+        // Material binding on root node
+        var rootNode = dae.Library_Visual_Scene.Visual_Scene[0].Node[0];
+        Assert.AreEqual("adder_body_mtl_generic-material",
+            rootNode.Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[0].Symbol);
+        Assert.AreEqual("#adder_body_mtl_generic-material",
+            rootNode.Instance_Geometry[0].Bind_Material[0].Technique_Common.Instance_Material[0].Target);
+    }
+
+    [TestMethod]
+    public void ClanBanner_Collada_MaterialAutoDiscovery()
+    {
+        var cryData = ProcessCryEngineFile(
+            $@"{objectDir}\Objects\purchasable\cockpit_mounted\clanbanner\clanbanner_a_adder.cga");
+
+        // Verify MtlName chunk metadata
+        var mtlChunks = cryData.Chunks.Where(a => a.ChunkType == ChunkType.MtlName).ToList();
+        Assert.AreEqual(1, (int)((ChunkMtlName)mtlChunks[0]).NumChildren);
+        Assert.AreEqual(MtlNameType.Library, ((ChunkMtlName)mtlChunks[0]).MatType);
+
+        var dae = GenerateCollada(cryData);
+
+        Assert.AreEqual(1, dae.Library_Materials.Material.Length);
+        Assert.AreEqual(1, dae.Library_Effects.Effect.Length);
+        Assert.AreEqual(2, dae.Library_Images.Image.Length);
+        Assert.AreEqual("clanbanner_a_mtl_clanbanner_a", dae.Library_Materials.Material[0].Name);
+    }
+
+    [TestMethod]
+    public void ClanBanner_Collada_ExplicitMtlFile()
+    {
+        var matFile = $@"{objectDir}\Objects\purchasable\cockpit_mounted\clanbanner\clanbanner_a.mtl";
+        var cryData = ProcessCryEngineFile(
+            $@"{objectDir}\Objects\purchasable\cockpit_mounted\clanbanner\clanbanner_a_adder.cga", matFile);
+        var dae = GenerateCollada(cryData);
+
+        // Should produce same results as auto-discovery
+        Assert.AreEqual(1, dae.Library_Materials.Material.Length);
+        Assert.AreEqual(1, dae.Library_Effects.Effect.Length);
+        Assert.AreEqual(2, dae.Library_Images.Image.Length);
+        Assert.AreEqual("clanbanner_a_mtl_clanbanner_a", dae.Library_Materials.Material[0].Name);
+    }
+
+    [TestMethod]
+    public void HulaGirl_Collada_ChildNodesAndTransforms()
+    {
+        var cryData = ProcessCryEngineFile(
+            $@"{objectDir}\objects\purchasable\cockpit_standing\hulagirl\hulagirl__gold_a.cga");
+        var dae = GenerateCollada(cryData);
+
+        Assert.AreEqual(1, dae.Library_Materials.Material.Length);
+        Assert.AreEqual(2, dae.Library_Geometries.Geometry.Length);
+
+        // Root node has children but no geometry itself
+        var rootNode = dae.Library_Visual_Scene.Visual_Scene[0].Node[0];
+        Assert.AreEqual("hulagirl_a", rootNode.ID);
+        Assert.AreEqual(2, rootNode.node.Length);
+        Assert.IsNull(rootNode.Instance_Geometry);
+        Assert.AreEqual("1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 0", rootNode.Matrix[0].Value_As_String);
+    }
+
+    [TestMethod]
+    public void HulaGirl_Gltf_ChildNodesAndTransforms()
+    {
+        var cryData = ProcessCryEngineFile(
+            $@"{objectDir}\Objects\purchasable\cockpit_standing\hulagirl\hulagirl__gold_a.cga");
+        var gltf = GenerateGltf(cryData);
+
+        Assert.AreEqual(1, gltf.Materials.Count);
+        Assert.AreEqual(2, gltf.Meshes.Count);
+        Assert.AreEqual(3, gltf.Nodes.Count);
+
+        // Node names
+        Assert.AreEqual("HulaGirl_UpperBody", gltf.Nodes[0].Name);
+        Assert.AreEqual("HulaGirl_LowerBody", gltf.Nodes[1].Name);
+        Assert.AreEqual("hulagirl_a", gltf.Nodes[2].Name);
+
+        // Root children count
+        Assert.AreEqual(2, gltf.Nodes[2].Children.Count);
+
+        // Rotation/translation spot-checks on UpperBody
+        AssertExtensions.AreEqual(
+            [-0.10248467f, 0.00384537f, -0.04688235744833946f, 0.9936217f],
+            gltf.Nodes[0].Rotation, TestUtils.delta);
+        AssertExtensions.AreEqual(
+            [-0.000101296f, 0.0640777f, 0f],
+            gltf.Nodes[0].Translation, TestUtils.delta);
+    }
+
+    [TestMethod]
+    public void AtlasBodyPart_Collada_MultiSubmaterial()
+    {
+        var matFile = $@"{objectDir}\Objects\mechs\atlas\body\atlas_body.mtl";
+        var cryData = ProcessCryEngineFile(
+            $@"{objectDir}\Objects\mechs\atlas\body\as7_centre_torso.cga", matFile);
+        var dae = GenerateCollada(cryData);
+
+        Assert.AreEqual(5, dae.Library_Materials.Material.Length);
+        Assert.AreEqual(5, dae.Library_Effects.Effect.Length);
+        Assert.AreEqual(31, dae.Library_Images.Image.Length);
+        Assert.AreEqual("atlas_body_mtl_atlas_body", dae.Library_Materials.Material[0].Name);
+    }
+
+    #endregion
+
+    #region .chr Skeleton and Skinning
+
+    [TestMethod]
+    public void Adder_Collada_SkeletonAndAnimations()
+    {
+        var cryData = ProcessCryEngineFile($@"{objectDir}\objects\mechs\adder\body\adder.chr");
+        var dae = GenerateCollada(cryData);
+
+        // Materials (default, no textures)
+        Assert.AreEqual(11, dae.Library_Materials.Material.Length);
+        Assert.AreEqual(0, dae.Library_Images.Image.Length);
+
+        // Geometry
+        Assert.AreEqual(1, dae.Library_Geometries.Geometry.Length);
+        Assert.AreEqual("adder-mesh", dae.Library_Geometries.Geometry[0].ID);
+
+        // Controller (skinning)
+        Assert.AreEqual(1, dae.Library_Controllers.Controller.Length);
+        var skin = dae.Library_Controllers.Controller[0].Skin;
+        var jointsSource = skin.Source.First(s => s.ID == "Controller-joints");
+        Assert.AreEqual(73, jointsSource.Name_Array.Count);
+        Assert.AreEqual("Bip01", jointsSource.Name_Array.Value()[0]);
+
+        // Bind poses
+        var bindPosesSource = skin.Source.First(s => s.ID == "Controller-bind_poses");
+        Assert.AreEqual(1168, bindPosesSource.Float_Array.Count); // 73 joints * 16 floats
+
+        // Armature root node
+        var rootNode = dae.Library_Visual_Scene.Visual_Scene[0].Node[0];
+        Assert.AreEqual("Bip01", rootNode.ID);
+        Assert.AreEqual(ColladaNodeType.JOINT, rootNode.Type);
+
+        // Pelvis has 3 children (L_Hip, Pitch, R_Hip)
+        var pelvisNode = rootNode.node[0];
+        Assert.AreEqual("Bip01_Pelvis", pelvisNode.ID);
+        Assert.AreEqual(3, pelvisNode.node.Length);
+        Assert.IsNotNull(pelvisNode.node.FirstOrDefault(n => n.ID == "Bip01_L_Hip"));
+        Assert.IsNotNull(pelvisNode.node.FirstOrDefault(n => n.ID == "Bip01_Pitch"));
+        Assert.IsNotNull(pelvisNode.node.FirstOrDefault(n => n.ID == "Bip01_R_Hip"));
+
+        // Geometry node uses Instance_Controller, not Instance_Geometry
+        var geometryNode = dae.Library_Visual_Scene.Visual_Scene[0].Node[1];
+        Assert.AreEqual("adder", geometryNode.ID);
+        Assert.IsNull(geometryNode.Instance_Geometry);
+        Assert.AreEqual(1, geometryNode.Instance_Controller.Length);
+        Assert.AreEqual("#Controller", geometryNode.Instance_Controller[0].URL);
+
+        // Animations present
+        Assert.IsNotNull(dae.Library_Animations);
+        Assert.IsTrue(dae.Library_Animations.Animation.Length > 0, "Should have animations from DBA files");
+    }
+
+    [TestMethod]
+    public void Adder_Gltf_SkeletonAndAnimations()
+    {
+        var cryData = ProcessCryEngineFile($@"{objectDir}\objects\mechs\adder\body\adder.chr");
+        var gltf = GenerateGltf(cryData);
+
+        Assert.AreEqual(11, gltf.Materials.Count);
+        Assert.AreEqual(1, gltf.Meshes.Count);
+        Assert.IsTrue(gltf.Nodes.Count >= 73, "Should have at least 73 bone nodes");
+
+        // Root bone
+        Assert.AreEqual("Bip01", gltf.Nodes[0].Name);
+        AssertExtensions.AreEqual(
+            [0.0f, 0.70710677f, 0.0f, 0.70710677f],
+            gltf.Nodes[0].Rotation, 1e-5f);
+
+        // Skin
+        Assert.AreEqual(1, gltf.Skins.Count);
+        Assert.AreEqual(73, gltf.Skins[0].Joints.Count);
+
+        // Animations
+        Assert.IsTrue(gltf.Animations.Count > 0, "Should have animations from DBA files");
+    }
+
+    [TestMethod]
+    public void Adder_Usd_SkeletonAndAnimations()
+    {
+        var cryData = ProcessCryEngineFile($@"{objectDir}\objects\mechs\adder\body\adder.chr");
+        var usdOutput = GenerateUsdString(cryData);
+
+        // Root and skeleton prims
+        Assert.IsTrue(usdOutput.Contains("def Xform \"adder\"") || usdOutput.Contains("def SkelRoot"), "Should have root prim");
+        Assert.IsTrue(usdOutput.Contains("def Skeleton \"Skeleton\""), "Should have skeleton");
+
+        // Key bone names
+        Assert.IsTrue(usdOutput.Contains("Bip01"), "Should include Bip01");
+        Assert.IsTrue(usdOutput.Contains("Bip01_Pelvis"), "Should include Bip01_Pelvis");
+
+        // Geometry present
+        Assert.IsTrue(usdOutput.Contains("point3f[] points"), "Should have geometry points");
+        Assert.IsTrue(usdOutput.Contains("normal3f[] normals"), "Should have normals");
+    }
+
+    [TestMethod]
+    public void FiftyCal_Collada_SmallSkeleton()
+    {
+        var cryData = ProcessCryEngineFile(
+            $@"{objectDir}\objects\purchasable\cockpit_hanging\50calnecklace\50calnecklace_a.chr");
+        var dae = GenerateCollada(cryData);
+
+        Assert.AreEqual(1, dae.Library_Materials.Material.Length);
+        Assert.AreEqual(1, dae.Library_Effects.Effect.Length);
+        Assert.AreEqual(4, dae.Library_Images.Image.Length);
+    }
+
+    [TestMethod]
+    public void FiftyCal_Gltf_SmallSkeleton()
+    {
+        var cryData = ProcessCryEngineFile(
+            $@"{objectDir}\objects\purchasable\cockpit_hanging\50calnecklace\50calnecklace_a.chr");
+        var gltf = GenerateGltf(cryData);
+
+        Assert.AreEqual(1, gltf.Materials.Count);
+        Assert.AreEqual(1, gltf.Meshes.Count);
+        Assert.AreEqual(9, gltf.Nodes.Count);
+
+        // Root bone
+        Assert.AreEqual("Bip01", gltf.Nodes[0].Name);
+        AssertExtensions.AreEqual(
+            [-0.4963841f, -0.5035906f, 0.491474152f, 0.5083822f],
+            gltf.Nodes[0].Rotation, TestUtils.delta);
+
+        // Skin
+        Assert.AreEqual(1, gltf.Skins.Count);
+        Assert.AreEqual(8, gltf.Skins[0].Joints.Count);
+
+        // Accessors
+        Assert.AreEqual(7, gltf.Accessors.Count);
+    }
+
+    [TestMethod]
+    public void Mechanic_Usd_SkeletonAndSkinning()
+    {
+        var cryData = ProcessCryEngineFile($@"{objectDir}\Objects\characters\mechanic\mechanic.chr");
+
+        // Verify skinning info at CryEngine level
+        Assert.IsNotNull(cryData.SkinningInfo, "SkinningInfo should not be null");
+        Assert.IsTrue(cryData.SkinningInfo.HasSkinningInfo, "Should have skinning info");
+        Assert.IsTrue(cryData.SkinningInfo.CompiledBones.Count > 0, "Should have bones");
+
+        // Key bones exist
+        var bip01 = cryData.SkinningInfo.CompiledBones.FirstOrDefault(b => b.BoneName == "Bip01");
+        var pelvis = cryData.SkinningInfo.CompiledBones.FirstOrDefault(b => b.BoneName == "bip_01_Pelvis");
+        Assert.IsNotNull(bip01, "Should find Bip01 bone");
+        Assert.IsNotNull(pelvis, "Should find bip_01_Pelvis bone");
+
+        // Pelvis world position
+        Assert.AreEqual(0.950611, pelvis.WorldTransformMatrix.M34, 0.001, "Pelvis Z should be ~0.951");
+
+        // Generate USD and verify structure
+        var (usdOutput, usdDoc) = GenerateUsd(cryData);
+
+        Assert.IsTrue(usdOutput.Contains("def SkelRoot \"Armature\""), "Should have SkelRoot");
+        Assert.IsTrue(usdOutput.Contains("def Skeleton \"Skeleton\""), "Should have Skeleton");
+        Assert.IsTrue(usdOutput.Contains("uniform token[] joints"), "Should have joints array");
+        Assert.IsTrue(usdOutput.Contains("uniform matrix4d[] bindTransforms"), "Should have bindTransforms");
+        Assert.IsTrue(usdOutput.Contains("uniform matrix4d[] restTransforms"), "Should have restTransforms");
+        Assert.IsTrue(usdOutput.Contains("primvars:skel:jointIndices"), "Should have jointIndices");
+        Assert.IsTrue(usdOutput.Contains("primvars:skel:jointWeights"), "Should have jointWeights");
+        Assert.IsTrue(usdOutput.Contains("Bip01"), "Should contain Bip01");
+
+        // Find Skeleton prim and verify restTransforms
+        UsdSkeleton? skeleton = null;
+        foreach (var prim in usdDoc.Prims)
+        {
+            skeleton = FindSkeleton(prim);
+            if (skeleton is not null) break;
+        }
+        Assert.IsNotNull(skeleton, "Skeleton prim should be findable");
+
+        var restTransforms = skeleton.Attributes.FirstOrDefault(a => a.Name == "restTransforms") as UsdMatrix4dArray;
+        Assert.IsNotNull(restTransforms, "Should have restTransforms attribute");
+        Assert.IsTrue(restTransforms.Matrices.Count >= 3, "Should have at least 3 bones");
+    }
+
+    #endregion
+
+    #region Supplementary Renderer Coverage
+
+    [TestMethod]
+    public void HulaGirl_Usd_NodeHierarchy()
+    {
+        var cryData = ProcessCryEngineFile(
+            $@"{objectDir}\Objects\purchasable\cockpit_standing\hulagirl\hulagirl__gold_a.cga");
+        var usdOutput = GenerateUsdString(cryData);
+
+        Assert.IsNotNull(usdOutput);
+        Assert.IsTrue(usdOutput.Contains("hulagirl"), "Should contain hulagirl");
+        Assert.IsTrue(usdOutput.Contains("HulaGirl_UpperBody"), "Should contain UpperBody node");
+        Assert.IsTrue(usdOutput.Contains("HulaGirl_LowerBody"), "Should contain LowerBody node");
+    }
+
+    [TestMethod]
+    public void AdrRightTorso_Usd_DefaultMaterials()
+    {
+        var cryData = ProcessCryEngineFile(
+            $@"{objectDir}\objects\mechs\adder\body\adr_right_torso_uac20_bh1.cga");
+        var usdOutput = GenerateUsdString(cryData);
+
+        Assert.IsNotNull(usdOutput);
+        Assert.IsTrue(usdOutput.Contains("mechDefault"), "Should have default materials");
+        Assert.IsTrue(usdOutput.Contains("point3f[] points"), "Should have geometry points");
+    }
+
+    [TestMethod]
+    public void FiftyCal_Usd_SmallSkeleton()
+    {
+        var cryData = ProcessCryEngineFile(
+            $@"{objectDir}\objects\purchasable\cockpit_hanging\50calnecklace\50calnecklace_a.chr");
+        var usdOutput = GenerateUsdString(cryData);
+
+        Assert.IsTrue(usdOutput.Contains("Skeleton"), "Should contain Skeleton");
+        Assert.IsTrue(usdOutput.Contains("Bip01"), "Should contain Bip01");
+    }
+
+    #endregion
 }

--- a/CgfConverterIntegrationTests/IntegrationTests/MWO/MWOIntegrationTests.cs
+++ b/CgfConverterIntegrationTests/IntegrationTests/MWO/MWOIntegrationTests.cs
@@ -307,13 +307,25 @@ public class MWOIntegrationTests
         // Root children count
         Assert.AreEqual(2, gltf.Nodes[2].Children.Count);
 
-        // Rotation/translation spot-checks on UpperBody
+        // Transform matrices (column-major, per glTF spec)
         AssertExtensions.AreEqual(
-            [-0.10248467f, 0.00384537f, -0.04688235744833946f, 0.9936217f],
-            gltf.Nodes[0].Rotation, TestUtils.delta);
+            [0.9955745f, -0.093954846f, 0.0019677456f, 0.0f,
+             0.092378475f, 0.9745979f, -0.20402257f, 0.0f,
+             0.017251149f, 0.20330146f, 0.9789642f, 0.0f,
+             0.000101296144f, 0.06407773f, 0.0f, 0.0f],
+            gltf.Nodes[0].Matrix, TestUtils.delta);
         AssertExtensions.AreEqual(
-            [-0.000101296f, 0.0640777f, 0f],
-            gltf.Nodes[0].Translation, TestUtils.delta);
+            [1.0f, 0.0f, 0.0f, 0.0f,
+             0.0f, 1.0f, 0.0f, 0.0f,
+             0.0f, 0.0f, 1.0f, 0.0f,
+             0.0f, 0.0f, 0.0f, 0.0f],
+            gltf.Nodes[1].Matrix, TestUtils.delta);
+        AssertExtensions.AreEqual(
+            [1.0f, 0.0f, 0.0f, 0.0f,
+             0.0f, 1.0f, 0.0f, 0.0f,
+             0.0f, 0.0f, 1.0f, 0.0f,
+             0.0f, 0.0f, 0.0f, 0.0f],
+            gltf.Nodes[2].Matrix, TestUtils.delta);
     }
 
     [TestMethod]
@@ -452,7 +464,7 @@ public class MWOIntegrationTests
         // Root bone
         Assert.AreEqual("Bip01", gltf.Nodes[0].Name);
         AssertExtensions.AreEqual(
-            [-0.4963841f, -0.5035906f, 0.491474152f, 0.5083822f],
+            [0.4963841f, -0.5035906f, -0.491474152f, 0.5083822f],
             gltf.Nodes[0].Rotation, TestUtils.delta);
 
         // Skin

--- a/CgfConverterIntegrationTests/ManualTests/ManualRenderTests.cs
+++ b/CgfConverterIntegrationTests/ManualTests/ManualRenderTests.cs
@@ -68,6 +68,36 @@ public class ManualRenderTests
         RenderToGltf($@"{archeageObjectDir}\game\objects\characters\animals\chicken\chicken.chr", archeageObjectDir);
     }
 
+    [TestMethod]
+    public void ArcheAge_Bird_Collada()
+    {
+        RenderToCollada($@"{archeageObjectDir}\game\objects\characters\animals\bird\bird_a.chr", archeageObjectDir);
+    }
+
+    [TestMethod]
+    public void ArcheAge_Bird_Gltf()
+    {
+        RenderToGltf($@"{archeageObjectDir}\game\objects\characters\animals\bird\bird_a.chr", archeageObjectDir);
+    }
+
+    [TestMethod]
+    public void ArcheAge_Bird_USD()
+    {
+        RenderToUsd($@"{archeageObjectDir}\game\objects\characters\animals\bird\bird_a.chr", archeageObjectDir);
+    }
+
+    [TestMethod]
+    public void ArcheAge_Fishboat_Gltf() // 0x828 controller edge case
+    {
+        RenderToGltf($@"{archeageObjectDir}\game\objects\env\06_unit\01_ship\fishboat\fishboat.chr", archeageObjectDir);
+    }
+
+    [TestMethod]
+    public void ArcheAge_Fishboat_USD() // 0x828 controller edge case
+    {
+        RenderToUsd($@"{archeageObjectDir}\game\objects\env\06_unit\01_ship\fishboat\fishboat.chr", archeageObjectDir);
+    }
+
     #endregion
 
     #region Armored Warfare Test Files

--- a/CgfConverterIntegrationTests/ManualTests/ManualRenderTests.cs
+++ b/CgfConverterIntegrationTests/ManualTests/ManualRenderTests.cs
@@ -365,7 +365,7 @@ public class ManualRenderTests
         var cliArgs = new string[] { inputFile, "-usd", "-objectdir", objectDir };
         argsHandler.ProcessArgs(cliArgs);
 
-        var cryData = new CryEngine(inputFile, args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir));
+        var cryData = new CryEngine(inputFile, args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir, IncludeAnimations: true));
         cryData.ProcessCryengineFiles();
 
         var renderer = new UsdRenderer(args, cryData);
@@ -395,7 +395,7 @@ public class ManualRenderTests
         var cliArgs = new string[] { inputFile, "-gltf", "-objectdir", objectDir };
         argsHandler.ProcessArgs(cliArgs);
 
-        var cryData = new CryEngine(inputFile, args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir));
+        var cryData = new CryEngine(inputFile, args.PackFileSystem, new CryEngineOptions(ObjectDir: objectDir, IncludeAnimations: true));
         cryData.ProcessCryengineFiles();
 
         var renderer = new GltfModelRenderer(args, cryData);

--- a/CgfConverterIntegrationTests/ManualTests/ManualRenderTests.cs
+++ b/CgfConverterIntegrationTests/ManualTests/ManualRenderTests.cs
@@ -123,6 +123,24 @@ public class ManualRenderTests
     }
 
     [TestMethod]
+    public void _50Cal_Necklace_Gltf()
+    {
+        RenderToGltf($@"{mwoObjectDir}\Objects\purchasable\cockpit_hanging\50calnecklace\50calnecklace_a.chr", mwoObjectDir);
+    }
+
+    [TestMethod]
+    public void HulaGirl_USD()
+    {
+        RenderToUsd($@"{mwoObjectDir}\Objects\purchasable\cockpit_standing\hulagirl\hulagirl_a.cga", mwoObjectDir);
+    }
+
+    [TestMethod]
+    public void HulaGirl_Gltf()
+    {
+        RenderToGltf($@"{mwoObjectDir}\Objects\purchasable\cockpit_standing\hulagirl\hulagirl_a.cga", mwoObjectDir);
+    }
+
+    [TestMethod]
     public void MWO_Box_USD()
     {
         RenderToUsd($@"{mwoObjectDir}\Objects\default\box.cgf", mwoObjectDir);


### PR DESCRIPTION
## Summary

- Fix `NumChunks` computation for 0x744 CAF files (header field is unreliable in animation files; compute actual count from available bytes)
- Implement `ChunkController_827`: uncompressed CryKeyPQLog format used in legacy ArcheAge CAF files — identical layout to 0x830 but without the `Flags` field and without an embedded local chunk header
- Implement `ChunkController_828`: graceful no-op (empty struct in CryEngine/Lumberyard source; previously threw `NotSupportedException` — resolves #230)
- Wire `ChunkController_827` into `ParseCafModel` so ArcheAge CAF animations are exported correctly
- Refactor `ArcheAgeTests` to use shared helpers (`ProcessCryEngineFile`, `GenerateCollada`, `GenerateGltf`, `GenerateUsdString`) matching the MWO test pattern; add glTF and USD test variants for all assets including fishboat
- Fix material resolution pipeline with model-name fallback
- Fix animation flags and test assertions for Adder, HulaGirl, and ManualRenderTests

## Test plan

- [ ] Run `dotnet test --filter TestCategory=unit` — all pass
- [ ] Run `dotnet test --filter "FullyQualifiedName~ArcheAge"` — all pass including new Fishboat tests
- [ ] Run manual render tests for ArcheAge bird and fishboat (Collada/glTF/USD) and verify output files are generated without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)