### PR TITLE
Fix #227: Standardize UV and vertex color source names in Collada and USD renderers

### DIFF
--- a/CgfConverter/Renderers/Collada/ColladaModelRenderer.Geometry.cs
+++ b/CgfConverter/Renderers/Collada/ColladaModelRenderer.Geometry.cs
@@ -87,9 +87,9 @@ public partial class ColladaModelRenderer
             normSource.ID = nodeChunk.Name + "-mesh-norm";
             normSource.Name = nodeChunk.Name + "-norm";
             uvSource.ID = nodeChunk.Name + "-mesh-UV";
-            uvSource.Name = nodeChunk.Name + "-UV";
+            uvSource.Name = "UV";
             colorSource.ID = nodeChunk.Name + "-mesh-color";
-            colorSource.Name = nodeChunk.Name + "-color";
+            colorSource.Name = "Col";
 
             ColladaVertices vertices = new() { ID = nodeChunk.Name + "-vertices" };
             geometry.Mesh.Vertices = vertices;

--- a/CgfConverter/Renderers/USD/UsdRenderer.Geometry.cs
+++ b/CgfConverter/Renderers/USD/UsdRenderer.Geometry.cs
@@ -176,11 +176,11 @@ public partial class UsdRenderer
             meshPrim.Attributes.Add(new UsdPointsList("points", [.. verts.Data]));
 
             if (hasColors)
-                meshPrim.Attributes.Add(new UsdColorsList($"{CleanPathString(nodeChunk.Name)}_color", [.. colors.Data]));
+                meshPrim.Attributes.Add(new UsdColorsList("displayColor", [.. colors.Data]));
             if (hasUVs)
-                meshPrim.Attributes.Add(new UsdTexCoordsList($"{CleanPathString(nodeChunk.Name)}_UV", [.. uvs.Data]));
+                meshPrim.Attributes.Add(new UsdTexCoordsList("st", [.. uvs.Data]));
             if (hasUVs2)
-                meshPrim.Attributes.Add(new UsdTexCoordsList($"{CleanPathString(nodeChunk.Name)}_UV2", [.. uvs2.Data]));
+                meshPrim.Attributes.Add(new UsdTexCoordsList("st2", [.. uvs2.Data]));
             if (hasNormals)
             {
                 // For faceVarying normals, expand the normals array to match faceVertexIndices
@@ -343,10 +343,10 @@ public partial class UsdRenderer
             meshPrim.Attributes.Add(new UsdPointsList("points", vertices));
 
             // Add vertex colors from VertUV
-            meshPrim.Attributes.Add(new UsdColorsList($"{CleanPathString(nodeChunk.Name)}_color", colorList));
+            meshPrim.Attributes.Add(new UsdColorsList("displayColor", colorList));
 
             // Add UVs from VertUV
-            meshPrim.Attributes.Add(new UsdTexCoordsList($"{CleanPathString(nodeChunk.Name)}_UV", uvList));
+            meshPrim.Attributes.Add(new UsdTexCoordsList("st", uvList));
 
             if (hasNormals)
             {

--- a/CgfConverterIntegrationTests/IntegrationTests/Hunt/HuntIntegrationTests.cs
+++ b/CgfConverterIntegrationTests/IntegrationTests/Hunt/HuntIntegrationTests.cs
@@ -186,9 +186,9 @@ public class HuntIntegrationTests
         Assert.AreEqual("assassin_body-mesh-norm", normals.ID);
         Assert.AreEqual("assassin_body-norm", normals.Name);
         Assert.AreEqual("assassin_body-mesh-UV", uvs.ID);
-        Assert.AreEqual("assassin_body-UV", uvs.Name);
+        Assert.AreEqual("UV", uvs.Name);
         Assert.AreEqual("assassin_body-mesh-color", colors.ID);
-        Assert.AreEqual("assassin_body-color", colors.Name);
+        Assert.AreEqual("Col", colors.Name);
         Assert.AreEqual(18087, vertices.Float_Array.Count);
         Assert.AreEqual("assassin_body-mesh-pos-array", vertices.Float_Array.ID);
         Assert.IsTrue(vertices.Float_Array.Value_As_String.StartsWith("0.050568 0.100037 2.091797 0.048096 0.124878 2.099609 0.059082 0.102295 2.117188 0.049042 0.124695 2.113281 0.016800 0.109009"));

--- a/CgfConverterIntegrationTests/IntegrationTests/SC/StarCitizenTests.cs
+++ b/CgfConverterIntegrationTests/IntegrationTests/SC/StarCitizenTests.cs
@@ -887,8 +887,8 @@ public class StarCitizenTests
         Assert.IsTrue(meshAttributes.Any(a => a.Name == "normals"), "Mesh should have normals");
 
         // 9. Verify Ivo-specific attributes (UVs and colors from VertUV)
-        Assert.IsTrue(meshAttributes.Any(a => a.Name.Contains("_UV")), "Mesh should have UV coordinates from VertUV");
-        Assert.IsTrue(meshAttributes.Any(a => a.Name.Contains("_color")), "Mesh should have vertex colors from VertUV");
+        Assert.IsTrue(meshAttributes.Any(a => a.Name == "st"), "Mesh should have UV coordinates from VertUV");
+        Assert.IsTrue(meshAttributes.Any(a => a.Name == "displayColor"), "Mesh should have vertex colors from VertUV");
 
         // 10. Verify GeomSubset exists for material assignment
         var geomSubsets = teapotMesh.Children.Where(x => x is UsdGeomSubset).ToList();


### PR DESCRIPTION
## Summary

Fixes #227.

The UV and vertex color source `Name` attributes in Collada exports were dynamically generated from the node name (e.g. `ship_hull-UV`, `ship_hull-color`). This made it impossible to write a single shader node tree that references a consistent UV map or vertex color layer name across objects in an imported scene.

The dynamic naming has been present since colors were first added — it was never a regression from a specific release, but the behavior is incorrect from an interoperability standpoint.

## Changes

### Collada (`ColladaModelRenderer.Geometry.cs`)
- `uvSource.Name` → `"UV"`
- `colorSource.Name` → `"Col"`
- `ID` attributes are unchanged — they retain the node-name prefix since Collada IDs must be document-unique and are used for internal `#fragment` cross-references

### USD (`UsdRenderer.Geometry.cs`)
- UV primvar → `"st"` / `"st2"` per USD specification
- Vertex color primvar → `"displayColor"` per USD specification
- Applied to both the `verts` and `VertsUVs` (Ivo format) code paths

### Tests
- Updated Hunt Collada integration test `Name` assertions
- Updated Star Citizen USD integration test attribute name checks

## Testing
- All 102 unit tests pass
- A build with this fix is available in the [v2.0.0 pre-release](https://github.com/Markemp/Cryengine-Converter/releases/tag/v2.0.0) for community verification