### PR TITLE
Implemented correct IVO Normals decoding

### DIFF
--- a/CgfConverter/CryEngineCore/Chunks/ChunkIvoSkinMesh_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkIvoSkinMesh_900.cs
@@ -11,6 +11,30 @@ namespace CgfConverter.CryEngineCore.Chunks;
 
 internal sealed class ChunkIvoSkinMesh_900 : ChunkIvoSkinMesh
 {
+    /// <summary>
+    /// Decode a packed unit vector from a u32 using 15-15-1-1 bit layout.
+    /// Bits 0-14: X biased by 0x3FFF, bits 15-29: Y biased by 0x3FFF,
+    /// bit 30: Z sign, bit 31: reserved (bitangent sign in caller).
+    /// </summary>
+    private static Vector3 DecodePackedUnitVector(uint val)
+    {
+        const float scale = 1.0f / 16383.0f;
+
+        int xRaw = (int)(val & 0x7FFF) - 0x3FFF;
+        int yRaw = (int)((val >> 15) & 0x7FFF) - 0x3FFF;
+        float x = xRaw * scale;
+        float y = yRaw * scale;
+
+        float zSq = MathF.Max(0, 1.0f - x * x - y * y);
+        float zUnsigned = MathF.Sqrt(zSq);
+        float z = ((val >> 30) & 1) != 0 ? -zUnsigned : zUnsigned;
+
+        float len = MathF.Sqrt(x * x + y * y + z * z);
+        return len > 1e-8f
+            ? new Vector3(x / len, y / len, z / len)
+            : new Vector3(0, 0, 1);
+    }
+
     public override void Read(BinaryReader b)
     {
         base.Read(b);
@@ -141,7 +165,8 @@ internal sealed class ChunkIvoSkinMesh_900 : ChunkIvoSkinMesh
                     bytesPerElement = b.ReadUInt32();
                     if (bytesPerElement == 8)
                     {
-                        // 8-byte format uses smallest-three quaternion encoding for TBN matrix
+                        // 8-byte format: 4× i16 SNorm quaternion (XYZW / 32767.0)
+                        // Normal = rotation matrix column 2, negated if w < 0.
                         Datastream<Vector3> tangentNormals = new(
                             DatastreamType.NORMALS,
                             meshDetails.NumberOfVertices,
@@ -150,9 +175,28 @@ internal sealed class ChunkIvoSkinMesh_900 : ChunkIvoSkinMesh
 
                         for (int i = 0; i < meshDetails.NumberOfVertices; i++)
                         {
-                            var frame = b.ReadIvoTangentFrame();
-                            var (normal, _, _) = frame.Decode();
-                            tangentNormals.Data[i] = normal;
+                            float qx = b.ReadInt16() / 32767.0f;
+                            float qy = b.ReadInt16() / 32767.0f;
+                            float qz = b.ReadInt16() / 32767.0f;
+                            float qw = b.ReadInt16() / 32767.0f;
+
+                            // Column 2 of rotation matrix = normal direction
+                            float nx = 2.0f * (qx * qz + qw * qy);
+                            float ny = 2.0f * (qy * qz - qw * qx);
+                            float nz = 1.0f - 2.0f * (qx * qx + qy * qy);
+
+                            // CryEngine convention: negate normal if w < 0
+                            if (qw < 0.0f)
+                            {
+                                nx = -nx;
+                                ny = -ny;
+                                nz = -nz;
+                            }
+
+                            float len = MathF.Sqrt(nx * nx + ny * ny + nz * nz);
+                            tangentNormals.Data[i] = len > 1e-8f
+                                ? new Vector3(nx / len, ny / len, nz / len)
+                                : new Vector3(0, 0, 1);
                         }
                         Normals = tangentNormals;
                     }
@@ -182,7 +226,9 @@ internal sealed class ChunkIvoSkinMesh_900 : ChunkIvoSkinMesh
                     b.AlignTo(8);
                     break;
                 case DatastreamType.IVOQTANGENTS:
-                    // IVOQTANGENTS uses the same smallest-three format as IVOTANGENTS when 8 bytes
+                    // IVOQTANGENTS 8-byte format: 2× u32 packed unit vectors (15-15-1-1 bit layout).
+                    // Despite the name, these are NOT quaternions — they are compressed tangent/bitangent vectors.
+                    // Normal = cross(tangent, bitangent) × bitangent_sign.
                     bytesPerElement = b.ReadUInt32();
                     Datastream<Quaternion> qtangents = new(
                         DatastreamType.IVOTANGENTS,
@@ -196,12 +242,23 @@ internal sealed class ChunkIvoSkinMesh_900 : ChunkIvoSkinMesh
                         new Vector3[meshDetails.NumberOfVertices]);
                     if (qtangents.BytesPerElement == 8)
                     {
-                        // Use IvoTangentFrame for 8-byte format (smallest-three encoding)
                         for (int i = 0; i < meshDetails.NumberOfVertices; i++)
                         {
-                            var frame = b.ReadIvoTangentFrame();
-                            var (normal, _, _) = frame.Decode();
-                            normals2.Data[i] = normal;
+                            uint value1 = b.ReadUInt16() | ((uint)b.ReadUInt16() << 16);
+                            uint value2 = b.ReadUInt16() | ((uint)b.ReadUInt16() << 16);
+
+                            Vector3 tangent = DecodePackedUnitVector(value1);
+                            Vector3 bitangent = DecodePackedUnitVector(value2);
+
+                            // Bitangent sign from bit 31 of first u32
+                            float bitanSign = (value1 & 0x80000000) != 0 ? -1.0f : 1.0f;
+
+                            // Normal = cross(tangent, bitangent) × bitangent_sign
+                            Vector3 cross = Vector3.Cross(tangent, bitangent) * bitanSign;
+                            float len = cross.Length();
+                            normals2.Data[i] = len > 1e-8f
+                                ? cross / len
+                                : new Vector3(0, 0, 1);
                         }
                     }
                     else if (qtangents.BytesPerElement == 16)

--- a/CgfConverter/CryEngineCore/Chunks/ChunkIvoSkinMesh_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkIvoSkinMesh_900.cs
@@ -126,39 +126,39 @@ internal sealed class ChunkIvoSkinMesh_900 : ChunkIvoSkinMesh
                 case DatastreamType.IVONORMALS:
                 case DatastreamType.IVONORMALS2:
                     bytesPerElement = b.ReadUInt32();
-                    Datastream<Vector3> normals = new(
-                        DatastreamType.IVONORMALS2,
-                        meshDetails.NumberOfVertices,
-                        bytesPerElement,
-                        new Vector3[meshDetails.NumberOfVertices]);
-                    if (normals.BytesPerElement == 4)
+                    if (bytesPerElement == 4)
                     {
+                        // 4-byte format: single u32 packed unit vector (15-15-1-1 bit layout).
+                        // Same encoding as IVOQTANGENTS individual vectors.
+                        Datastream<Vector3> ivoNormals = new(
+                            DatastreamType.IVONORMALS2,
+                            meshDetails.NumberOfVertices,
+                            bytesPerElement,
+                            new Vector3[meshDetails.NumberOfVertices]);
                         for (int i = 0; i < meshDetails.NumberOfVertices; i++)
                         {
-                            var x = (float)b.ReadCryHalf();
-                            var y = (float)b.ReadCryHalf();
-
-                            //if (Math.Abs(x) > 1.05f || Math.Abs(y) > 1.05f)
-                            //    throw new InvalidDataException($"Invalid normal components at vertex {i}: ({x}, {y})");
-
-                            //// Check if x²+y² <= 1 (required for valid unit vector)
-                            //float sumSquares = x * x + y * y;
-                            //if (sumSquares > 1.05f)
-                            //    throw new InvalidDataException($"Invalid normal magnitude at vertex {i}: x²+y²={sumSquares}");
-
-                            //float z = (float)Math.Sqrt(1.0f - sumSquares);
-                            //normals.Data[i] = new Vector3(x, y, z);
-                            normals.Data[i] = new Vector3(x, y, 0.0f);
+                            uint val = b.ReadUInt16() | ((uint)b.ReadUInt16() << 16);
+                            ivoNormals.Data[i] = DecodePackedUnitVector(val);
                         }
+                        Normals = ivoNormals;
                     }
-                    else if (normals.BytesPerElement == 12)
+                    else if (bytesPerElement == 12)
                     {
+                        Datastream<Vector3> ivoNormals = new(
+                            DatastreamType.IVONORMALS2,
+                            meshDetails.NumberOfVertices,
+                            bytesPerElement,
+                            new Vector3[meshDetails.NumberOfVertices]);
                         for (int i = 0; i < meshDetails.NumberOfVertices; i++)
                         {
-                            normals.Data[i] = b.ReadVector3();
+                            ivoNormals.Data[i] = b.ReadVector3();
                         }
+                        Normals = ivoNormals;
                     }
-                    Normals = normals;
+                    else
+                    {
+                        SkipBytes(b, bytesPerElement * meshDetails.NumberOfVertices);
+                    }
                     b.AlignTo(8);
                     break;
                 case DatastreamType.IVOTANGENTS:
@@ -198,7 +198,8 @@ internal sealed class ChunkIvoSkinMesh_900 : ChunkIvoSkinMesh
                                 ? new Vector3(nx / len, ny / len, nz / len)
                                 : new Vector3(0, 0, 1);
                         }
-                        Normals = tangentNormals;
+                        // Prefer direct IVONORMALS when available; fall back to tangent-derived
+                        Normals ??= tangentNormals;
                     }
                     else if (bytesPerElement == 16)
                     {
@@ -272,7 +273,8 @@ internal sealed class ChunkIvoSkinMesh_900 : ChunkIvoSkinMesh
                         }
                     }
                     QTangents = qtangents;
-                    Normals = normals2;
+                    // Prefer direct IVONORMALS when available; fall back to tangent-derived
+                    Normals ??= normals2;
                     b.AlignTo(8);
                     break;
                 case DatastreamType.IVOBONEMAP32:


### PR DESCRIPTION
<img width="2559" height="1389" alt="blender_BlhnWmQDUz" src="https://github.com/user-attachments/assets/09db1d13-a8b4-45ef-80be-e507e2421def" />


Hey! I'm in the middle of porting my StarBreaker project to Rust, and along the way I'm adding a significant amount of cryengine-converter functionality to it (star citizen specific, and ignoring everything else)

It's been a great help!

I noticed that normals here seem to be decoded incorrectly, so I had claude code help me and managed to crack the format. The screenshot above is a before and after of this commit.

I'm not sure if this is the correct branch to base off of, but the diff is small and easy to rebase if necessary.