### PR TITLE
Use input filename as USD root prim name

### DIFF
--- a/CgfConverter/Renderers/USD/UsdRenderer.Animation.cs
+++ b/CgfConverter/Renderers/USD/UsdRenderer.Animation.cs
@@ -1212,6 +1212,7 @@ public partial class UsdRenderer
         {
             Header = new UsdHeader
             {
+                DefaultPrim = _rootPrimName,
                 TimeCodesPerSecond = 30,
                 StartTimeCode = 0,
                 EndTimeCode = endFrame
@@ -1219,7 +1220,7 @@ public partial class UsdRenderer
         };
 
         // Create root
-        usdDoc.Prims.Add(new UsdXform("root", "/"));
+        usdDoc.Prims.Add(new UsdXform(_rootPrimName, "/"));
         var rootPrim = usdDoc.Prims[0];
 
         // Create skeleton structure (same as main export but without mesh)
@@ -1238,7 +1239,7 @@ public partial class UsdRenderer
         skeleton.Attributes.Add(new UsdMatrix4dArray("restTransforms", restTransforms, isUniform: true));
 
         // Bind this animation to the skeleton
-        var animPath = $"</root/Armature/{skelAnim.Name}>";
+        var animPath = $"</{_rootPrimName}/Armature/{skelAnim.Name}>";
         skeleton.Attributes.Add(new UsdRelationship("skel:animationSource", animPath));
 
         skelRoot.Children.Add(skeleton);

--- a/CgfConverter/Renderers/USD/UsdRenderer.Geometry.cs
+++ b/CgfConverter/Renderers/USD/UsdRenderer.Geometry.cs
@@ -302,7 +302,7 @@ public partial class UsdRenderer
                 submeshPrim.Attributes.Add(
                     new UsdRelativePath(
                         "material:binding",
-                        $"/root/_materials/{cleanMatName}"));
+                        $"/{_rootPrimName}/_materials/{cleanMatName}"));
             }
 
             // Skinning attributes are added by CreateSkinnedMeshes()/CreateIvoSkinnedMeshes(),
@@ -471,7 +471,7 @@ public partial class UsdRenderer
                 submeshPrim.Attributes.Add(
                     new UsdRelativePath(
                         "material:binding",
-                        $"/root/_materials/{cleanMatName}"));
+                        $"/{_rootPrimName}/_materials/{cleanMatName}"));
             }
 
             // Skinning attributes are added by CreateIvoSkinnedMeshes() after mesh creation,

--- a/CgfConverter/Renderers/USD/UsdRenderer.Materials.cs
+++ b/CgfConverter/Renderers/USD/UsdRenderer.Materials.cs
@@ -47,7 +47,7 @@ public partial class UsdRenderer
                 var usdMat = new UsdMaterial(cleanMatName);
                 usdMat.Attributes.Add(new UsdToken<string>(
                     "outputs:surface.connect",
-                    $"</root/_materials/{cleanMatName}/Principled_BSDF.outputs:surface>"));
+                    $"</{_rootPrimName}/_materials/{cleanMatName}/Principled_BSDF.outputs:surface>"));
                 usdMat.Children.AddRange(CreateShaders(submat, matKey, cleanMatName));
                 matList.Add(usdMat);
             }
@@ -205,7 +205,7 @@ public partial class UsdRenderer
                 // Connect RGB to diffuse color
                 principleBSDF.Attributes.Add(new UsdColor3f(
                     $"inputs:diffuseColor.connect",
-                    $"</root/_materials/{matName}/{imageTexture.Name}.outputs:rgb>"));
+                    $"</{_rootPrimName}/_materials/{matName}/{imageTexture.Name}.outputs:rgb>"));
 
                 // Check shader rules for alpha channel routing
                 var alphaTarget = _shaderRules.GetChannelTarget(rules, "Diffuse", "alpha");
@@ -227,7 +227,7 @@ public partial class UsdRenderer
                     {
                         principleBSDF.Attributes.Add(new UsdFloat(
                             $"inputs:opacity.connect",
-                            $"</root/_materials/{matName}/{imageTexture.Name}.outputs:a>"));
+                            $"</{_rootPrimName}/_materials/{matName}/{imageTexture.Name}.outputs:a>"));
                     }
                 }
                 break;
@@ -237,7 +237,7 @@ public partial class UsdRenderer
                 imageTexture.Attributes.Add(new UsdFloat3f("outputs:rgb"));
                 principleBSDF.Attributes.Add(new UsdFloat3f(
                     $"inputs:normal.connect",
-                    $"</root/_materials/{matName}/{imageTexture.Name}.outputs:rgb>"));
+                    $"</{_rootPrimName}/_materials/{matName}/{imageTexture.Name}.outputs:rgb>"));
                 break;
 
             case Texture.MapTypeEnum.Specular:
@@ -250,14 +250,14 @@ public partial class UsdRenderer
                 // Connect RGB to specular color
                 principleBSDF.Attributes.Add(new UsdColor3f(
                     $"inputs:specularColor.connect",
-                    $"</root/_materials/{matName}/{imageTexture.Name}.outputs:rgb>"));
+                    $"</{_rootPrimName}/_materials/{matName}/{imageTexture.Name}.outputs:rgb>"));
 
                 // Specular alpha carries glossiness/smoothness data in CryEngine.
                 // Older shaders use %SPECULARPOW_GLOSSALPHA flag; newer shaders (Layer, HardSurface)
                 // treat this as default behavior. Always connect spec alpha → roughness.
                 principleBSDF.Attributes.Add(new UsdFloat(
                     $"inputs:roughness.connect",
-                    $"</root/_materials/{matName}/{imageTexture.Name}.outputs:a>"));
+                    $"</{_rootPrimName}/_materials/{matName}/{imageTexture.Name}.outputs:a>"));
                 break;
 
             case Texture.MapTypeEnum.Opacity:
@@ -272,7 +272,7 @@ public partial class UsdRenderer
                     imageTexture.Attributes.Add(new UsdFloat("outputs:r"));
                     principleBSDF.Attributes.Add(new UsdFloat(
                         $"inputs:opacity.connect",
-                        $"</root/_materials/{matName}/{imageTexture.Name}.outputs:r>"));
+                        $"</{_rootPrimName}/_materials/{matName}/{imageTexture.Name}.outputs:r>"));
                 }
                 else
                 {

--- a/CgfConverter/Renderers/USD/UsdRenderer.Skeleton.cs
+++ b/CgfConverter/Renderers/USD/UsdRenderer.Skeleton.cs
@@ -371,7 +371,7 @@ public partial class UsdRenderer
         meshPrim.Attributes.Add(new UsdFloatArray("primvars:skel:jointWeights", jointWeights, elementSize, "vertex"));
 
         // Add relationship to skeleton
-        meshPrim.Attributes.Add(new UsdRelationship("skel:skeleton", "</root/Armature/Skeleton>"));
+        meshPrim.Attributes.Add(new UsdRelationship("skel:skeleton", $"</{_rootPrimName}/Armature/Skeleton>"));
     }
 
     #endregion

--- a/CgfConverter/Renderers/USD/UsdRenderer.cs
+++ b/CgfConverter/Renderers/USD/UsdRenderer.cs
@@ -23,6 +23,7 @@ public partial class UsdRenderer : IRenderer
     private readonly FileInfo usdOutputFile;
     private UsdSerializer usdSerializer;
     protected readonly TaggedLogger Log;
+    protected readonly string _rootPrimName;
 
     // Shader system
     protected readonly Dictionary<string, ShaderDefinition> _shaderDefinitions;
@@ -35,6 +36,7 @@ public partial class UsdRenderer : IRenderer
         usdOutputFile = _args.FormatOutputFileName(".usda", _cryData.InputFile);
         usdSerializer = new UsdSerializer();
         Log = _cryData.Log;
+        _rootPrimName = CleanPathString(Path.GetFileNameWithoutExtension(_cryData.InputFile));
 
         // Initialize shader system
         _shaderRules = new ShaderRulesEngine(Log);
@@ -117,8 +119,8 @@ public partial class UsdRenderer : IRenderer
         }
 
         // Create the usd doc
-        var usdDoc = new UsdDoc { Header = new UsdHeader() };
-        usdDoc.Prims.Add(new UsdXform("root", "/"));
+        var usdDoc = new UsdDoc { Header = new UsdHeader { DefaultPrim = _rootPrimName } };
+        usdDoc.Prims.Add(new UsdXform(_rootPrimName, "/"));
         var rootPrim = usdDoc.Prims[0];
 
         // Check if this model has skeletal animation


### PR DESCRIPTION
## Summary
- Derives USD root prim name from the input filename (e.g. `adder.chr` → `adder`) instead of hardcoded `root`
- Updates `defaultPrim` header and all rel paths (materials, skeleton, animation) to use the dynamic name
- Cleaned via `CleanPathString` to ensure valid USD prim naming

## Test plan
- [x] Unit tests pass (102/102)
- [ ] Manual render test: verify `.usda` output has correct root prim name matching input file
- [ ] Import into Blender and verify material/skeleton bindings resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)