### PR TITLE
Fix case-sensitive filesystem compatibility for Linux/POSIX (#193)

### DIFF
--- a/CgfConverter/PackFileSystem/RealFileSystem.cs
+++ b/CgfConverter/PackFileSystem/RealFileSystem.cs
@@ -1,16 +1,21 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using Extensions;
 
 namespace CgfConverter.PackFileSystem;
 
 public class RealFileSystem : IPackFileSystem
 {
-    // Object dir
     private readonly string _rootPath;
+
+    // Cache: lowercased directory path → actual entry names in that directory
+    private readonly Dictionary<string, string[]> _dirFileCache = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, string[]> _dirSubdirCache = new(StringComparer.OrdinalIgnoreCase);
+
+    // Cache: lowercased full path → resolved actual path on disk
+    private readonly Dictionary<string, string?> _resolvedPathCache = new(StringComparer.OrdinalIgnoreCase);
 
     public RealFileSystem(string rootPath)
     {
@@ -18,49 +23,44 @@ public class RealFileSystem : IPackFileSystem
         if (!Directory.Exists(rootPath))
             throw new FileNotFoundException();
 
-        _rootPath = FileHandlingExtensions.CombineAndNormalizePath(rootPath) + "\\";
+        _rootPath = FileHandlingExtensions.CombineAndNormalizePath(rootPath) + Path.DirectorySeparatorChar;
     }
 
     public Stream GetStream(string path)
     {
+        var fullPath = ResolvePath(path);
+        if (fullPath is null)
+            throw new FileNotFoundException(path);
+
         try
         {
-            return new FileStream(
-                FileHandlingExtensions.CombineAndNormalizePath(_rootPath, path),
-                FileMode.Open,
-                FileAccess.Read);
+            return new FileStream(fullPath, FileMode.Open, FileAccess.Read);
         }
-        catch (IOException ioe) when (ioe.HResult == unchecked((int) 0x8007007B)) // Path name is invalid
+        catch (IOException ioe) when (ioe.HResult == unchecked((int)0x8007007B))
         {
             throw new FileNotFoundException(path);
         }
     }
 
-    public bool Exists(string path) =>
-        File.Exists(FileHandlingExtensions.CombineAndNormalizePath(_rootPath, path));
+    public bool Exists(string path) => ResolvePath(path) is not null;
 
     public string[] Glob(string pattern)
     {
-        // Simplified glob method that avoids recursive searching
         var normalizedPattern = FileHandlingExtensions.CombineAndNormalizePath(_rootPath, pattern);
-        var directory = Path.GetDirectoryName(normalizedPattern) ?? _rootPath;
         var filePattern = Path.GetFileName(normalizedPattern);
-        var foundPaths = new List<string>();
-        
-        // If it's a direct file reference with no wildcards, just check if it exists
-        if (!filePattern.Contains("*") && !filePattern.Contains("?"))
+
+        // Direct file reference with no wildcards — just check if it exists
+        if (!filePattern.Contains('*') && !filePattern.Contains('?'))
         {
-            var exactPath = FileHandlingExtensions.CombineAndNormalizePath(_rootPath, pattern);
-            if (File.Exists(exactPath))
-                return new[] { exactPath[_rootPath.Length..] };
-            return Array.Empty<string>();
+            var resolved = ResolvePath(pattern);
+            if (resolved is not null)
+                return [resolved[_rootPath.Length..]];
+            return [];
         }
-        
+
         // Special case: Double wildcard
         if (pattern.Contains("**"))
         {
-            // For specific common patterns we can still do a limited search
-            // Example: "**/*.dds" - search for dds files in current dir only
             if (pattern.StartsWith("**"))
             {
                 var fileExtension = Path.GetExtension(pattern);
@@ -68,55 +68,184 @@ public class RealFileSystem : IPackFileSystem
                 {
                     try
                     {
-                        // Only search in the root directory without recursion
                         var files = Directory.GetFiles(_rootPath, "*" + fileExtension, SearchOption.TopDirectoryOnly);
                         return files.Select(f => f[_rootPath.Length..]).ToArray();
                     }
                     catch (Exception)
                     {
-                        return Array.Empty<string>();
+                        return [];
                     }
                 }
             }
-            
-            // Default to empty result for other complex patterns
-            return Array.Empty<string>();
+
+            return [];
         }
 
-        // For simple wildcards, only search in the specified directory, not recursively
+        // For simple wildcards, resolve the directory case-insensitively, then search
+        var directoryPattern = Path.GetDirectoryName(normalizedPattern) ?? _rootPath;
+        var resolvedDir = ResolveDirectoryPath(directoryPattern);
+
+        if (resolvedDir is null)
+            return [];
+
         try
         {
-            if (Directory.Exists(directory))
-            {
-                var files = Directory.GetFiles(directory, filePattern, SearchOption.TopDirectoryOnly);
-                return files.Select(f => f[_rootPath.Length..]).ToArray();
-            }
+            var files = Directory.GetFiles(resolvedDir, filePattern, SearchOption.TopDirectoryOnly);
+            return files.Select(f => f[_rootPath.Length..]).ToArray();
         }
         catch (Exception)
         {
-            // Ignore directory access errors
+            return [];
         }
-        
-        return Array.Empty<string>();
     }
 
     public byte[] ReadAllBytes(string path)
     {
+        var fullPath = ResolvePath(path);
+        if (fullPath is null)
+            throw new FileNotFoundException(path);
+
         try
         {
-            return File.ReadAllBytes(Path.Join(_rootPath, path));
+            return File.ReadAllBytes(fullPath);
         }
-        catch (FileNotFoundException)
+        catch (IOException ioe) when (ioe.HResult == unchecked((int)0x8007007B))
         {
             throw new FileNotFoundException(path);
         }
-        catch (DirectoryNotFoundException)
+    }
+
+    /// <summary>
+    /// Resolves a relative path to an actual path on disk, using case-insensitive matching
+    /// when a direct lookup fails. Returns null if the file cannot be found.
+    /// </summary>
+    private string? ResolvePath(string relativePath)
+    {
+        var directPath = FileHandlingExtensions.CombineAndNormalizePath(_rootPath, relativePath);
+
+        // Fast path: direct lookup (always works on Windows, works on Linux when casing matches)
+        if (File.Exists(directPath))
+            return directPath;
+
+        // Check resolved path cache
+        if (_resolvedPathCache.TryGetValue(directPath, out var cached))
+            return cached;
+
+        // Slow path: walk segments case-insensitively
+        var resolved = ResolvePathCaseInsensitive(directPath);
+        _resolvedPathCache[directPath] = resolved;
+        return resolved;
+    }
+
+    /// <summary>
+    /// Resolves a directory path case-insensitively. Returns null if the directory cannot be found.
+    /// </summary>
+    private string? ResolveDirectoryPath(string fullDirPath)
+    {
+        if (Directory.Exists(fullDirPath))
+            return fullDirPath;
+
+        // Walk segments from root
+        var relativePart = fullDirPath.StartsWith(_rootPath, StringComparison.OrdinalIgnoreCase)
+            ? fullDirPath[_rootPath.Length..]
+            : fullDirPath;
+
+        var segments = relativePart.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar,
+            StringSplitOptions.RemoveEmptyEntries);
+
+        var currentDir = _rootPath.TrimEnd(Path.DirectorySeparatorChar);
+
+        foreach (var segment in segments)
         {
-            throw new FileNotFoundException(path);
+            var subdirs = GetCachedSubdirectories(currentDir);
+            var match = subdirs.FirstOrDefault(d =>
+                string.Equals(Path.GetFileName(d), segment, StringComparison.OrdinalIgnoreCase));
+
+            if (match is null)
+                return null;
+
+            currentDir = match;
         }
-        catch (IOException ioe) when (ioe.HResult == unchecked((int) 0x8007007B)) // Path name is invalid
+
+        return currentDir;
+    }
+
+    /// <summary>
+    /// Walks path segments from root, matching each case-insensitively against the actual
+    /// directory contents. The final segment is matched against files.
+    /// </summary>
+    private string? ResolvePathCaseInsensitive(string fullPath)
+    {
+        // Split into root-relative segments
+        if (!fullPath.StartsWith(_rootPath, StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var relativePart = fullPath[_rootPath.Length..];
+        var segments = relativePart.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar,
+            StringSplitOptions.RemoveEmptyEntries);
+
+        if (segments.Length == 0)
+            return null;
+
+        var currentDir = _rootPath.TrimEnd(Path.DirectorySeparatorChar);
+
+        // Resolve directory segments (all except last)
+        for (int i = 0; i < segments.Length - 1; i++)
         {
-            throw new FileNotFoundException(path);
+            var subdirs = GetCachedSubdirectories(currentDir);
+            var match = subdirs.FirstOrDefault(d =>
+                string.Equals(Path.GetFileName(d), segments[i], StringComparison.OrdinalIgnoreCase));
+
+            if (match is null)
+                return null;
+
+            currentDir = match;
+        }
+
+        // Resolve the final segment (file name)
+        var fileName = segments[^1];
+        var files = GetCachedFiles(currentDir);
+        var fileMatch = files.FirstOrDefault(f =>
+            string.Equals(Path.GetFileName(f), fileName, StringComparison.OrdinalIgnoreCase));
+
+        return fileMatch;
+    }
+
+    private string[] GetCachedSubdirectories(string directory)
+    {
+        if (_dirSubdirCache.TryGetValue(directory, out var cached))
+            return cached;
+
+        try
+        {
+            var subdirs = Directory.GetDirectories(directory);
+            _dirSubdirCache[directory] = subdirs;
+            return subdirs;
+        }
+        catch (Exception)
+        {
+            var empty = Array.Empty<string>();
+            _dirSubdirCache[directory] = empty;
+            return empty;
+        }
+    }
+
+    private string[] GetCachedFiles(string directory)
+    {
+        if (_dirFileCache.TryGetValue(directory, out var cached))
+            return cached;
+
+        try
+        {
+            var files = Directory.GetFiles(directory);
+            _dirFileCache[directory] = files;
+            return files;
+        }
+        catch (Exception)
+        {
+            var empty = Array.Empty<string>();
+            _dirFileCache[directory] = empty;
+            return empty;
         }
     }
 }

--- a/CgfConverter/Utilities/FileHandlingExtensions.cs
+++ b/CgfConverter/Utilities/FileHandlingExtensions.cs
@@ -126,7 +126,7 @@ public static class FileHandlingExtensions
             i++;
         }
 
-        var result = string.Join('\\', parts);
+        var result = string.Join(Path.DirectorySeparatorChar, parts);
 
         // Cache the result if it's a single path component
         if (pathComponents.Length == 1 && pathComponents[0] != null)

--- a/CgfConverterIntegrationTests/ManualTests/ManualRenderTests.cs
+++ b/CgfConverterIntegrationTests/ManualTests/ManualRenderTests.cs
@@ -28,7 +28,6 @@ public class ManualRenderTests
     private readonly string kcd2ObjectDir = @"d:\depot\kcd2";
     private readonly string mwoObjectDir = @"d:\depot\mwo";
     private readonly string sc41ObjectDir = @"d:\depot\sc4.1\data";
-    private readonly string sc44ObjectDir = @"d:\depot\sc4.4\data";
     private readonly string sc46ObjectDir = @"d:\depot\sc4.6\data";
     private readonly string archeageObjectDir = @"d:\depot\archeage";
 
@@ -315,7 +314,7 @@ public class ManualRenderTests
     [TestMethod]
     public void MWO_Pilot_Usd()
     {
-        RenderToUsd($@"{mwoObjectDir}\objects\characters\pilot\pilot.chr", mwoObjectDir);
+        RenderToUsd($@"{mwoObjectDir}\objects\characters\pilot\pilot.chr", mwoObjectDir, includeAnimations: true);
     }
 
     [TestMethod]

--- a/CgfConverterIntegrationTests/UnitTests/FileHandlingExtensionsTests.cs
+++ b/CgfConverterIntegrationTests/UnitTests/FileHandlingExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Extensions.FileHandlingExtensions;
 
 namespace CgfConverterTests.UnitTests;
@@ -7,6 +8,8 @@ namespace CgfConverterTests.UnitTests;
 [TestCategory("unit")]
 public class FileHandlingExtensionsTests
 {
+    private static readonly char S = Path.DirectorySeparatorChar;
+
     [TestMethod]
     public void CombineAndNormalizePath_SingleSimplePath_ReturnsSamePath()
     {
@@ -18,21 +21,21 @@ public class FileHandlingExtensionsTests
     public void CombineAndNormalizePath_MultipleSimplePaths_ReturnsCombinedPath()
     {
         var result = CombineAndNormalizePath("path1", "path2", "path3");
-        Assert.AreEqual("path1\\path2\\path3", result);
+        Assert.AreEqual($"path1{S}path2{S}path3", result);
     }
 
     [TestMethod]
     public void CombineAndNormalizePath_PathsContainingSpaces_ReturnsTrimmedPath()
     {
         var result = CombineAndNormalizePath(" path1 ", " path2 ");
-        Assert.AreEqual("path1\\path2", result);
+        Assert.AreEqual($"path1{S}path2", result);
     }
 
     [TestMethod]
     public void CombineAndNormalizePath_PathsContainingPeriodSymbol_ReturnsNormalizedPath()
     {
         var result = CombineAndNormalizePath("path1", ".", "path2");
-        Assert.AreEqual("path1\\path2", result);
+        Assert.AreEqual($"path1{S}path2", result);
     }
 
     [TestMethod]
@@ -53,13 +56,13 @@ public class FileHandlingExtensionsTests
     public void CombineAndNormalizePath_MixedSeparators_ReturnsNormalizedPath()
     {
         var result = CombineAndNormalizePath("path1/path2", "path3\\path4");
-        Assert.AreEqual("path1\\path2\\path3\\path4", result);
+        Assert.AreEqual($"path1{S}path2{S}path3{S}path4", result);
     }
 
     [TestMethod]
     public void CombineAndNormalizePath_DirAndMaterialFile()
     {
         var result = CombineAndNormalizePath("c:/dir", "material.mtl");
-        Assert.AreEqual("c:\\dir\\material.mtl", result);
+        Assert.AreEqual($"c:{S}dir{S}material.mtl", result);
     }
 }

--- a/CgfConverterIntegrationTests/UnitTests/RealFileSystemTests.cs
+++ b/CgfConverterIntegrationTests/UnitTests/RealFileSystemTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using CgfConverter.PackFileSystem;
+
+namespace CgfConverterTests.UnitTests;
+
+[TestClass]
+[TestCategory("unit")]
+public class RealFileSystemTests
+{
+    private string _tempDir = null!;
+    private RealFileSystem _fs = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "RealFileSystemTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+
+        // Create a directory structure with specific casing:
+        // Objects/Ships/hornet.mtl
+        // Objects/Ships/textures/hull.dds
+        // Objects/Weapons/laser.cgf
+        var shipsDir = Path.Combine(_tempDir, "Objects", "Ships");
+        var texturesDir = Path.Combine(shipsDir, "textures");
+        var weaponsDir = Path.Combine(_tempDir, "Objects", "Weapons");
+
+        Directory.CreateDirectory(shipsDir);
+        Directory.CreateDirectory(texturesDir);
+        Directory.CreateDirectory(weaponsDir);
+
+        File.WriteAllText(Path.Combine(shipsDir, "hornet.mtl"), "test");
+        File.WriteAllText(Path.Combine(texturesDir, "hull.dds"), "test");
+        File.WriteAllText(Path.Combine(weaponsDir, "laser.cgf"), "test");
+
+        _fs = new RealFileSystem(_tempDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [TestMethod]
+    public void Exists_ExactCase_ReturnsTrue()
+    {
+        Assert.IsTrue(_fs.Exists(Path.Combine("Objects", "Ships", "hornet.mtl")));
+    }
+
+    [TestMethod]
+    public void Exists_WrongCase_ReturnsTrue()
+    {
+        Assert.IsTrue(_fs.Exists(Path.Combine("objects", "ships", "Hornet.mtl")));
+    }
+
+    [TestMethod]
+    public void Exists_AllUpperCase_ReturnsTrue()
+    {
+        Assert.IsTrue(_fs.Exists(Path.Combine("OBJECTS", "SHIPS", "HORNET.MTL")));
+    }
+
+    [TestMethod]
+    public void Exists_NonexistentFile_ReturnsFalse()
+    {
+        Assert.IsFalse(_fs.Exists(Path.Combine("Objects", "Ships", "nonexistent.mtl")));
+    }
+
+    [TestMethod]
+    public void Exists_NonexistentDirectory_ReturnsFalse()
+    {
+        Assert.IsFalse(_fs.Exists(Path.Combine("NoSuchDir", "file.mtl")));
+    }
+
+    [TestMethod]
+    public void GetStream_ExactCase_ReturnsStream()
+    {
+        using var stream = _fs.GetStream(Path.Combine("Objects", "Ships", "hornet.mtl"));
+        Assert.IsNotNull(stream);
+        Assert.IsTrue(stream.CanRead);
+    }
+
+    [TestMethod]
+    public void GetStream_WrongCase_ReturnsStream()
+    {
+        using var stream = _fs.GetStream(Path.Combine("objects", "ships", "Hornet.MTL"));
+        Assert.IsNotNull(stream);
+        Assert.IsTrue(stream.CanRead);
+    }
+
+    [TestMethod]
+    public void GetStream_NonexistentFile_ThrowsFileNotFoundException()
+    {
+        Assert.ThrowsException<FileNotFoundException>(
+            () => _fs.GetStream(Path.Combine("Objects", "Ships", "nonexistent.mtl")));
+    }
+
+    [TestMethod]
+    public void ReadAllBytes_WrongCase_ReturnsContent()
+    {
+        var bytes = _fs.ReadAllBytes(Path.Combine("objects", "SHIPS", "hornet.mtl"));
+        Assert.AreEqual("test", System.Text.Encoding.UTF8.GetString(bytes));
+    }
+
+    [TestMethod]
+    public void ReadAllBytes_NonexistentFile_ThrowsFileNotFoundException()
+    {
+        Assert.ThrowsException<FileNotFoundException>(
+            () => _fs.ReadAllBytes(Path.Combine("Objects", "NoFile.mtl")));
+    }
+
+    [TestMethod]
+    public void Glob_WildcardExactCaseDir_FindsFiles()
+    {
+        var results = _fs.Glob(Path.Combine("Objects", "Ships", "*.mtl"));
+        Assert.AreEqual(1, results.Length);
+    }
+
+    [TestMethod]
+    public void Glob_WildcardWrongCaseDir_FindsFiles()
+    {
+        var results = _fs.Glob(Path.Combine("objects", "ships", "*.mtl"));
+        Assert.AreEqual(1, results.Length);
+    }
+
+    [TestMethod]
+    public void Glob_ExactFileWrongCase_FindsFile()
+    {
+        var results = _fs.Glob(Path.Combine("objects", "ships", "HORNET.MTL"));
+        Assert.AreEqual(1, results.Length);
+    }
+
+    [TestMethod]
+    public void Glob_NonexistentDir_ReturnsEmpty()
+    {
+        var results = _fs.Glob(Path.Combine("NoSuchDir", "*.mtl"));
+        Assert.AreEqual(0, results.Length);
+    }
+
+    [TestMethod]
+    public void Exists_NestedPath_WrongCase_ReturnsTrue()
+    {
+        Assert.IsTrue(_fs.Exists(Path.Combine("objects", "ships", "TEXTURES", "Hull.DDS")));
+    }
+
+    [TestMethod]
+    public void GetStream_CachedResolution_SecondCallFaster()
+    {
+        // First call populates the cache
+        using (var stream1 = _fs.GetStream(Path.Combine("objects", "ships", "Hornet.MTL")))
+            Assert.IsNotNull(stream1);
+
+        // Second call should hit the cache
+        using (var stream2 = _fs.GetStream(Path.Combine("objects", "ships", "Hornet.MTL")))
+            Assert.IsNotNull(stream2);
+    }
+}

--- a/TODO
+++ b/TODO
@@ -4,3 +4,17 @@ TODO File
 - Animations
 - USD support
 
+Future
+- .pak file system support (issue #193 related)
+  - CryEngine .pak files are renamed ZIP archives
+  - Add PakFileSystem implementing IPackFileSystem, using ZipArchive for on-demand entry access
+  - Parse ZIP central directory at construction (seek to end of file), decompress entries on demand
+  - For multi-pak games (MWO has 20+), add each to CascadedPackFileSystem (last-added wins, matches CryEngine pak priority)
+  - For huge single paks (Star Citizen 140GB+), ZipArchive handles this since it only reads the directory index, not the whole file
+  - Add IPackFileSystem.EnumerateFiles() for UI browsing of pak contents
+  - Split texture problem: pak files may contain split DDS textures (.dds + .dds.1 etc.)
+    - Recombine at the renderer level (in ResolveTextureFile), not in PakFileSystem
+    - PakFileSystem stays a dumb file accessor, renderer knows output format requirements
+  - UI scenario: point to Steam game root, auto-discover .pak files, browse directory tree to select model
+  - WiiuStreamPackFileSystem is a good implementation template
+


### PR DESCRIPTION
RealFileSystem now resolves paths case-insensitively with per-directory caching when direct lookups fail. CombineAndNormalizePath uses Path.DirectorySeparatorChar instead of hardcoded backslash.