### PR TITLE
Fix Controller_831 animation parsing and chrparams #filepath handling (#175)

### DIFF
--- a/CgfConverter/CgfConverter.csproj
+++ b/CgfConverter/CgfConverter.csproj
@@ -22,4 +22,8 @@
     <!-- Needed for XmlSerializer Source Generator -->
     <SGenTypes>CgfConverter.Renderers.Collada.Collada.ColladaDoc</SGenTypes>
   </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="CgfConverterTests" />
+  </ItemGroup>
 </Project>

--- a/CgfConverter/CryEngine/CryEngine.cs
+++ b/CgfConverter/CryEngine/CryEngine.cs
@@ -754,7 +754,7 @@ public partial class CryEngine
         if (chrparams.Animations is null)
             return;
 
-        var basePath = chrparams.Animations.FirstOrDefault(x => x.Name == "#filepath")?.Path ?? "";
+        var basePath = "";
 
         foreach (var entry in chrparams.Animations)
         {
@@ -763,6 +763,10 @@ public partial class CryEngine
 
             switch (entry.Name)
             {
+                case "#filepath":
+                    basePath = entry.Path;
+                    break;
+
                 case "$TracksDatabase":
                     LoadDbaFromEntry(entry.Path);
                     break;
@@ -776,7 +780,7 @@ public partial class CryEngine
                     break;
 
                 case string s when s.StartsWith('$') || s.StartsWith('#'):
-                    // Other directives ($AnimEventDatabase, $facelib, #filepath, etc.) — skip
+                    // Other directives ($AnimEventDatabase, $facelib, etc.) — skip
                     break;
 
                 default:

--- a/CgfConverter/CryEngineCore/Chunks/ChunkController_831.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkController_831.cs
@@ -73,30 +73,39 @@ internal sealed class ChunkController_831 : ChunkController
         PositionTimeFormat = b.ReadByte();
         TracksAligned = b.ReadByte();
 
+        // C++ sizeof(CONTROLLER_CHUNK_DESC_0831) = 20 bytes due to struct alignment padding.
+        // The 18 bytes of fields are followed by 2 padding bytes. The Lumberyard reader uses
+        // (pCtrlChunk + 1) to get the data pointer, which advances by sizeof = 20.
+        b.ReadUInt16(); // struct alignment padding
+
         // Data layout (v0831):
         // [Rotation Values] -> [padding] -> [Rotation Times] -> [padding] ->
         // [Position Values] -> [padding] -> [Position Times (if PositionKeysInfo != 0)]
 
-        // Read rotation values first
-        KeyRotations = ReadRotations(b, NumRotationKeys, RotationFormat);
-        AlignTo4Bytes(b);
-
-        // Read rotation time keys
-        RotationKeyTimes = ReadKeyTimes(b, NumRotationKeys, RotationTimeFormat);
-        AlignTo4Bytes(b);
-
-        // Read position values
-        KeyPositions = ReadPositions(b, NumPositionKeys, PositionFormat);
-        AlignTo4Bytes(b);
-
-        // Position time keys only if PositionKeysInfo != 0, otherwise shares rotation times
-        if (PositionKeysInfo != 0)
+        if (NumRotationKeys > 0)
         {
-            PositionKeyTimes = ReadKeyTimes(b, NumPositionKeys, PositionTimeFormat);
+            KeyRotations = ReadRotations(b, NumRotationKeys, RotationFormat);
+            AlignTo4Bytes(b);
+
+            RotationKeyTimes = ReadKeyTimes(b, NumRotationKeys, RotationTimeFormat);
+            AlignTo4Bytes(b);
         }
-        else
+
+        if (NumPositionKeys > 0)
         {
-            PositionKeyTimes = RotationKeyTimes;
+            KeyPositions = ReadPositions(b, NumPositionKeys, PositionFormat);
+            AlignTo4Bytes(b);
+
+            // Position time keys only if PositionKeysInfo != eKeyTimeRotation (0),
+            // otherwise position shares rotation's time track
+            if (PositionKeysInfo != 0)
+            {
+                PositionKeyTimes = ReadKeyTimes(b, NumPositionKeys, PositionTimeFormat);
+            }
+            else
+            {
+                PositionKeyTimes = RotationKeyTimes;
+            }
         }
     }
 
@@ -104,8 +113,7 @@ internal sealed class ChunkController_831 : ChunkController
     {
         if (TracksAligned != 0)
         {
-            var pos = b.BaseStream.Position;
-            var remainder = pos % 4;
+            var remainder = b.BaseStream.Position % 4;
             if (remainder != 0)
                 b.ReadBytes((int)(4 - remainder));
         }

--- a/CgfConverterIntegrationTests/IntegrationTests/NewWorld/NewWorldIntegrationTests.cs
+++ b/CgfConverterIntegrationTests/IntegrationTests/NewWorld/NewWorldIntegrationTests.cs
@@ -1,9 +1,13 @@
 ﻿using CgfConverter;
+using CgfConverter.CryEngineCore;
 using CgfConverter.Renderers.Collada;
 using CgfConverterTests.TestUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Numerics;
 using System.Threading;
 
 namespace CgfConverterTests.IntegrationTests;
@@ -139,6 +143,67 @@ public class NewWorldIntegrationTests
         colladaData.GenerateDaeObject();
         var daeObject = colladaData.DaeObject;
         var nodes = daeObject.Library_Visual_Scene.Visual_Scene[0].Node;
+    }
+
+    [TestMethod]
+    public void ChairSittingIdle_CAF_Controller831_ParsesCorrectly()
+    {
+        var cafPath = $@"{objectDir}\animations\gameplay\character\player\male\roleplay\chair\roleply_chair_sitting_idle.caf";
+        var model = Model.FromStream(cafPath, File.OpenRead(cafPath), closeStream: true);
+
+        var controllers = model.ChunkMap.Values.OfType<ChunkController_831>().ToList();
+        Assert.IsTrue(controllers.Count > 0, "Should have ChunkController_831 chunks");
+
+        foreach (var ctrl in controllers)
+        {
+            // Verify quaternions are approximately normalized (length ~1.0)
+            // Compressed formats (SmallTree48Bit, SmallTree64BitExt) may have minor precision loss
+            foreach (var rot in ctrl.KeyRotations)
+            {
+                var length = rot.Length();
+                Assert.IsTrue(length > 0.9f && length < 1.1f,
+                    $"Controller {ctrl.ControllerId:X}: rotation not normalized, length={length}");
+            }
+
+            // Verify positions are finite and reasonable
+            foreach (var pos in ctrl.KeyPositions)
+            {
+                Assert.IsFalse(float.IsNaN(pos.X) || float.IsNaN(pos.Y) || float.IsNaN(pos.Z),
+                    $"Controller {ctrl.ControllerId:X}: NaN in position data");
+                Assert.IsTrue(pos.Length() < 1000f,
+                    $"Controller {ctrl.ControllerId:X}: position magnitude unreasonable ({pos.Length()})");
+            }
+
+            // Key times should be monotonically non-decreasing
+            for (int i = 1; i < ctrl.RotationKeyTimes.Count; i++)
+            {
+                Assert.IsTrue(ctrl.RotationKeyTimes[i] >= ctrl.RotationKeyTimes[i - 1],
+                    $"Controller {ctrl.ControllerId:X}: rotation key times not monotonic at index {i}");
+            }
+
+            for (int i = 1; i < ctrl.PositionKeyTimes.Count; i++)
+            {
+                Assert.IsTrue(ctrl.PositionKeyTimes[i] >= ctrl.PositionKeyTimes[i - 1],
+                    $"Controller {ctrl.ControllerId:X}: position key times not monotonic at index {i}");
+            }
+        }
+    }
+
+    [TestMethod]
+    public void PlayerMale_Chr_LoadsSkeleton()
+    {
+        var chrPath = $@"{objectDir}\objects\characters\player\male\player_male.chr";
+        var args = new string[] { chrPath, "-usd", "-objectdir", objectDir };
+        int result = testUtils.argsHandler.ProcessArgs(args);
+        Assert.AreEqual(0, result);
+
+        var cryData = new CryEngine(chrPath, testUtils.argsHandler.Args.PackFileSystem,
+            new CryEngineOptions(ObjectDir: objectDir));
+        cryData.ProcessCryengineFiles();
+
+        // Verify skeleton loaded
+        Assert.IsNotNull(cryData.SkinningInfo?.CompiledBones, "Skeleton should be loaded");
+        Assert.IsTrue(cryData.SkinningInfo.CompiledBones.Count > 0, "Should have bones");
     }
 
 }

--- a/CgfConverterIntegrationTests/ManualTests/ManualRenderTests.cs
+++ b/CgfConverterIntegrationTests/ManualTests/ManualRenderTests.cs
@@ -30,6 +30,7 @@ public class ManualRenderTests
     private readonly string sc41ObjectDir = @"d:\depot\sc4.1\data";
     private readonly string sc46ObjectDir = @"d:\depot\sc4.6\data";
     private readonly string archeageObjectDir = @"d:\depot\archeage";
+    private readonly string newWorldObjectDir = @"d:\depot\newworld";
 
     [TestInitialize]
     public void Initialize()
@@ -446,6 +447,28 @@ public class ManualRenderTests
     {
         RenderToUsd($@"{sc46ObjectDir}\Objects\Spaceships\Ships\DRAK\Buccaneer\Exterior\DRAK_Buccaneer.cga", sc46ObjectDir, includeAnimations: false);
     }
+    #endregion
+
+    #region New World
+
+    [TestMethod]
+    public void NewWorld_PlayerMale_USD()
+    {
+        RenderToUsd($@"{newWorldObjectDir}\objects\characters\player\male\player_male.chr", newWorldObjectDir, includeAnimations: true);
+    }
+
+    [TestMethod]
+    public void NewWorld_PlayerMale_Collada()
+    {
+        RenderToCollada($@"{newWorldObjectDir}\objects\characters\player\male\player_male.chr", newWorldObjectDir);
+    }
+
+    [TestMethod]
+    public void NewWorld_PlayerMale_Gltf()
+    {
+        RenderToGltf($@"{newWorldObjectDir}\objects\characters\player\male\player_male.chr", newWorldObjectDir);
+    }
+
     #endregion
 
     #region Helper Methods

--- a/CgfConverterTestingConsole/Program.cs
+++ b/CgfConverterTestingConsole/Program.cs
@@ -372,6 +372,26 @@ static void DumpSkinning(CryEngine cryData, int vertCount)
 
 static void RunCustom(CryEngine cryData)
 {
+    // Inspect raw timing chunks and controller data from the direct model
+    Console.WriteLine("=== Raw Timing and Controller Data ===\n");
+    foreach (var model in cryData.Models)
+    {
+        Console.WriteLine($"Model: {model.FileName}");
+        var timingChunks = model.ChunkMap.Values.OfType<ChunkTimingFormat>().ToList();
+        foreach (var tc in timingChunks)
+        {
+            Console.WriteLine($"  Timing: SecsPerTick={tc.SecsPerTick}, TicksPerFrame={tc.TicksPerFrame}");
+            Console.WriteLine($"  GlobalRange: Start={tc.GlobalRange.Start}, End={tc.GlobalRange.End}");
+            if (tc.TicksPerFrame > 0)
+            {
+                int startFrame = tc.GlobalRange.Start / tc.TicksPerFrame;
+                int endFrame = tc.GlobalRange.End / tc.TicksPerFrame;
+                Console.WriteLine($"  Calculated frame range: [{startFrame}..{endFrame}] ({endFrame - startFrame + 1} frames)");
+            }
+        }
+        Console.WriteLine();
+    }
+
     var bones = cryData.SkinningInfo?.CompiledBones;
     if (bones is null) { Console.WriteLine("No bones"); return; }
 


### PR DESCRIPTION
## Summary
- **Fix ChunkController_831 struct padding**: The C++ struct `CONTROLLER_CHUNK_DESC_0831` is 20 bytes (18 bytes of fields + 2 bytes compiler alignment padding), but we were only reading 18 bytes, causing all subsequent animation data to be offset by 2 bytes. This produced corrupted quaternions, non-monotonic key times, and garbage position data in New World CAF animations.
- **Fix chrparams `#filepath` stateful parsing**: The `#filepath` directive is stateful — each occurrence sets the base directory for subsequent animation entries until the next `#filepath`. Previously only the first `#filepath` was read, so animations from later directory blocks (e.g., 3,700+ CAFs in `player_shared.chrparams`) were not found.
- **Add integration tests** for Controller_831 parsing (quaternion normalization, key time monotonicity, position sanity) and skeleton loading.
- **Add manual render tests** for New World player_male USD/Collada/glTF export with animations.

## Test plan
- [x] `ChairSittingIdle_CAF_Controller831_ParsesCorrectly` — validates all 74 controllers parse with normalized quaternions and monotonic key times
- [x] `PlayerMale_Chr_LoadsSkeleton` — verifies skeleton loads from .chr file
- [x] Manual render tests produce valid USDA with correct `endTimeCode` matching animation frame count
- [x] Verified animation playback in Blender (103 frames, correct frame range in USDA header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)