### PR TITLE
Fix Collada renderer not binding TexSlot1/TexSlot10 textures to phong

### DIFF
--- a/CgfConverter/Renderers/Collada/ColladaModelRenderer.Materials.cs
+++ b/CgfConverter/Renderers/Collada/ColladaModelRenderer.Materials.cs
@@ -141,60 +141,64 @@ public partial class ColladaModelRenderer
         phong.Diffuse = new ColladaFXCommonColorOrTextureType();
         phong.Specular = new ColladaFXCommonColorOrTextureType();
 
-        // Add all the emissive, etc features to the phong
-        // Need to check if a texture exists.  If so, refer to the sampler.  Should be a <Texture Map="Diffuse" line if there is a map.
+        // Bind one phong slot per channel using a priority-ordered fallback. Star Citizen #ivo
+        // materials don't use named map types — diffuse comes in as TexSlot1 and specular as
+        // TexSlot10. The parser already remaps TexSlot2→Normals, TexSlot4→Specular, TexSlot9→Diffuse,
+        // so the fallback only needs to cover the slot indices that aren't auto-remapped.
         bool diffuseFound = false;
         bool specularFound = false;
 
         if (subMat.Textures is not null && !_args.NoTextures)
         {
-            foreach (var texture in subMat.Textures)
+            var diffuseTexture = PickTextureByPriority(subMat.Textures,
+                Texture.MapTypeEnum.Diffuse, Texture.MapTypeEnum.TexSlot1);
+            if (diffuseTexture is not null)
             {
-                if (texture.Map == Texture.MapTypeEnum.Diffuse)
+                diffuseFound = true;
+                phong.Diffuse.Texture = new ColladaTexture
                 {
-                    diffuseFound = true;
-                    phong.Diffuse.Texture = new ColladaTexture
-                    {
-                        // Texcoord is the ID of the UV source in geometries.  Not needed.
-                        Texture = effectName + "_" + texture.Map + "-sampler",
-                        TexCoord = ""
-                    };
-                }
+                    // Texcoord is the ID of the UV source in geometries.  Not needed.
+                    Texture = effectName + "_" + diffuseTexture.Map + "-sampler",
+                    TexCoord = ""
+                };
+            }
 
-                if (texture.Map == Texture.MapTypeEnum.Specular)
+            var specularTexture = PickTextureByPriority(subMat.Textures,
+                Texture.MapTypeEnum.Specular, Texture.MapTypeEnum.TexSlot10);
+            if (specularTexture is not null)
+            {
+                specularFound = true;
+                phong.Specular.Texture = new ColladaTexture
                 {
-                    specularFound = true;
-                    phong.Specular.Texture = new ColladaTexture
-                    {
-                        Texture = effectName + "_" + texture.Map + "-sampler",
-                        TexCoord = ""
-                    };
-                }
+                    Texture = effectName + "_" + specularTexture.Map + "-sampler",
+                    TexCoord = ""
+                };
+            }
 
-                if (texture.Map == Texture.MapTypeEnum.Normals)
+            var normalTexture = PickTextureByPriority(subMat.Textures, Texture.MapTypeEnum.Normals);
+            if (normalTexture is not null)
+            {
+                // Bump maps go in an extra node.
+                ColladaExtra[] extras = new ColladaExtra[1];
+                ColladaExtra extra = new();
+                extras[0] = extra;
+
+                technique.Extra = extras;
+
+                // Create the technique for the extra
+                ColladaTechnique[] extraTechniques = new ColladaTechnique[1];
+                ColladaTechnique extraTechnique = new();
+                extra.Technique = extraTechniques;
+
+                extraTechniques[0] = extraTechnique;
+                extraTechnique.profile = "FCOLLADA";
+
+                ColladaBumpMap bumpMap = new() { Textures = new ColladaTexture[1] };
+                bumpMap.Textures[0] = new ColladaTexture
                 {
-                    // Bump maps go in an extra node.
-                    ColladaExtra[] extras = new ColladaExtra[1];
-                    ColladaExtra extra = new();
-                    extras[0] = extra;
-
-                    technique.Extra = extras;
-
-                    // Create the technique for the extra
-                    ColladaTechnique[] extraTechniques = new ColladaTechnique[1];
-                    ColladaTechnique extraTechnique = new();
-                    extra.Technique = extraTechniques;
-
-                    extraTechniques[0] = extraTechnique;
-                    extraTechnique.profile = "FCOLLADA";
-
-                    ColladaBumpMap bumpMap = new() { Textures = new ColladaTexture[1] };
-                    bumpMap.Textures[0] = new ColladaTexture
-                    {
-                        Texture = effectName + "_" + texture.Map + "-sampler"
-                    };
-                    extraTechnique.Data = new XmlElement[1] { bumpMap };
-                }
+                    Texture = effectName + "_" + normalTexture.Map + "-sampler"
+                };
+                extraTechnique.Data = new XmlElement[1] { bumpMap };
             }
         }
 
@@ -313,6 +317,17 @@ public partial class ColladaModelRenderer
             Array.Resize(ref DaeObject.Library_Images.Image, DaeObject.Library_Images.Image.Length + images.Length);
             images.CopyTo(DaeObject.Library_Images.Image, arraySize);
         }
+    }
+
+    private static Texture? PickTextureByPriority(Texture[] textures, params Texture.MapTypeEnum[] priorityList)
+    {
+        foreach (var mapType in priorityList)
+        {
+            var match = textures.FirstOrDefault(t => t.Map == mapType);
+            if (match is not null)
+                return match;
+        }
+        return null;
     }
 
     private string GetMaterialName(string matKey, string submatName)

--- a/CgfConverterIntegrationTests/UnitTests/ColladaMaterialTests.cs
+++ b/CgfConverterIntegrationTests/UnitTests/ColladaMaterialTests.cs
@@ -1,0 +1,125 @@
+using CgfConverter;
+using CgfConverter.Models.Materials;
+using CgfConverter.PackFileSystem;
+using CgfConverter.Renderers.Collada;
+using CgfConverter.Renderers.Collada.Collada.Collada_FX.Effects;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+
+namespace CgfConverterTests.UnitTests;
+
+[TestClass]
+[TestCategory("unit")]
+public class ColladaMaterialTests
+{
+    private string tempDir = string.Empty;
+    private ColladaModelRenderer renderer = null!;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        tempDir = Path.Combine(Path.GetTempPath(), "ColladaMaterialTests_" + Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+
+        var args = new Args { NoTextures = false, OutputDir = tempDir };
+        var packFs = new RealFileSystem(tempDir);
+        var fakeInput = Path.Combine(tempDir, "fake.cgf");
+        File.WriteAllBytes(fakeInput, []);
+
+        var cryData = new CryEngine(fakeInput, packFs);
+        renderer = new ColladaModelRenderer(args, cryData);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(tempDir))
+            Directory.Delete(tempDir, recursive: true);
+    }
+
+    private static Material BuildSubMaterial(string name, params (string mapString, string file)[] textures)
+    {
+        var mat = new Material { Name = name };
+        mat.Textures = new Texture[textures.Length];
+        for (int i = 0; i < textures.Length; i++)
+            mat.Textures[i] = new Texture { MapString = textures[i].mapString, File = textures[i].file };
+        return mat;
+    }
+
+    private static string? GetPhongDiffuseTextureRef(ColladaEffect effect)
+        => effect.Profile_COMMON?[0].Technique?.Phong?.Diffuse?.Texture?.Texture;
+
+    private static string? GetPhongSpecularTextureRef(ColladaEffect effect)
+        => effect.Profile_COMMON?[0].Technique?.Phong?.Specular?.Texture?.Texture;
+
+    [TestMethod]
+    public void CreateColladaEffect_TexSlot1Only_BindsTexSlot1AsDiffuse()
+    {
+        // Star Citizen #ivo materials: Map="TexSlot1" is the diffuse slot.
+        // Without the fix, no diffuse texture is bound and Blender shows a flat color.
+        var subMat = BuildSubMaterial("pom_decals",
+            ("TexSlot1", "argo_pom_diff.dds"),
+            ("Bumpmap", "argo_pom_ddna.dds"),
+            ("TexSlot8", "argo_pom_displ.dds"));
+
+        var effect = renderer.CreateColladaEffect("argo_mole_interior.mtl", subMat);
+
+        Assert.IsNotNull(effect);
+        var diffuseRef = GetPhongDiffuseTextureRef(effect);
+        Assert.IsNotNull(diffuseRef, "Expected phong diffuse to be bound to a texture sampler when only TexSlot1 is present");
+        StringAssert.EndsWith(diffuseRef, "_TexSlot1-sampler");
+    }
+
+    [TestMethod]
+    public void CreateColladaEffect_DiffuseAndTexSlot1_PrefersExplicitDiffuse()
+    {
+        // Regression guard for materials like rubber_flooring that have BOTH a literal
+        // Diffuse entry and a TexSlot1 entry. Explicit Diffuse must win.
+        var subMat = BuildSubMaterial("rubber_flooring",
+            ("TexSlot1", "rubber_worn_diff.dds"),
+            ("Bumpmap", "rubber_worn_ddna.dds"),
+            ("Diffuse", "rubber_grip_diff.dds"),
+            ("TexSlot11", "rubber_grip_displ.dds"));
+
+        var effect = renderer.CreateColladaEffect("argo_mole_interior.mtl", subMat);
+
+        Assert.IsNotNull(effect);
+        var diffuseRef = GetPhongDiffuseTextureRef(effect);
+        Assert.IsNotNull(diffuseRef);
+        StringAssert.EndsWith(diffuseRef, "_Diffuse-sampler",
+            "Explicit Diffuse map should take precedence over TexSlot1");
+    }
+
+    [TestMethod]
+    public void CreateColladaEffect_TexSlot10Only_BindsTexSlot10AsSpecular()
+    {
+        // TexSlot10 is the #ivo specular slot. TexSlot4 is already remapped to Specular at parse,
+        // but TexSlot10 is not — verify the renderer falls back to it.
+        var subMat = BuildSubMaterial("metal_dark",
+            ("TexSlot1", "metal_dark_diff.dds"),
+            ("TexSlot10", "metal_dark_spec.dds"));
+
+        var effect = renderer.CreateColladaEffect("argo_mole_interior.mtl", subMat);
+
+        Assert.IsNotNull(effect);
+        var specularRef = GetPhongSpecularTextureRef(effect);
+        Assert.IsNotNull(specularRef, "Expected phong specular to be bound when only TexSlot10 is present");
+        StringAssert.EndsWith(specularRef, "_TexSlot10-sampler");
+    }
+
+    [TestMethod]
+    public void CreateColladaEffect_NoDiffuseTexture_FallsBackToColor()
+    {
+        // Sanity: when no diffuse-eligible texture exists, phong falls back to a color, not a texture.
+        var subMat = BuildSubMaterial("cables");
+        subMat.Diffuse = "1 1 1";
+
+        var effect = renderer.CreateColladaEffect("argo_mole_interior.mtl", subMat);
+
+        Assert.IsNotNull(effect);
+        var phong = effect.Profile_COMMON?[0].Technique?.Phong;
+        Assert.IsNotNull(phong);
+        Assert.IsNull(phong.Diffuse?.Texture, "Expected no diffuse texture when no eligible textures present");
+        Assert.IsNotNull(phong.Diffuse?.Color, "Expected diffuse color fallback when no textures present");
+    }
+}


### PR DESCRIPTION
## Summary
- Star Citizen #ivo materials use slot-indexed map names (`TexSlot1` for diffuse, `TexSlot10` for specular). The Collada renderer was matching only the literal `Diffuse`/`Specular` enum values, so phong's diffuse/specular slots fell back to flat colors. Blender had no image to attach to Principled BSDF, even though all the textures appeared in the Image Editor.
- `MaterialTextureManager` (used by glTF/USD) already handles this with priority-ordered fallback chains. This change brings Collada in line: `Diffuse` > `TexSlot1` for diffuse, `Specular` > `TexSlot10` for specular. Normals already auto-remaps from `TexSlot2` at parse time, so it needed no change.
- Explicit named slots win, so materials with both an explicit `Diffuse` entry and a `TexSlot1` entry (e.g. `rubber_flooring`) keep their existing binding — verified manually and via regression test.

Verified by re-rendering `cockpit_doorframe_double_cockpit.cgf` from ARGO MOLE: all 6 submaterials in Blender (`pom_decals`, `paint_secondary_grey`, `rubber`, `rubber_flooring`, `metal_dark`, `metal_grates`) now have a phong diffuse texture binding instead of just a color.

## Test plan
- [x] New unit tests in `ColladaMaterialTests.cs` (4 cases): TexSlot1-only binds as diffuse; both Diffuse+TexSlot1 prefers explicit Diffuse (regression guard); TexSlot10-only binds as specular; no textures falls back to color
- [x] Full unit suite passes (122/122)
- [x] Manual verification: re-rendered the cockpit asset and confirmed all 6 materials in the .dae now have `<diffuse><texture .../></diffuse>` instead of `<diffuse><color>1 1 1</color></diffuse>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)