### PR TITLE
Add Inno Setup installer and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,175 @@
+name: Release
+
+# Two trigger modes:
+#
+#   1. Tag push (final releases)
+#      Push a tag matching v*.*.* (no pre-release suffix) and a new full
+#      GitHub Release is created at that tag.
+#
+#         git tag v2.0.0
+#         git push --tags
+#
+#   2. Manual dispatch (pre-releases / re-runs)
+#      Run from the Actions UI; pick the branch (e.g. release/v2.0) and
+#      provide the target tag (e.g. v2.0.0). Builds from HEAD of that
+#      branch and clobbers assets onto the existing GitHub Release. The
+#      pre-release flag on the GitHub Release entry is preserved — this
+#      workflow does NOT toggle it. Manage that in the GitHub UI.
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+  workflow_dispatch:
+    inputs:
+      target_tag:
+        description: 'Existing GitHub Release tag to upload assets to (e.g. v2.0.0). Release must already exist; this clobbers its assets.'
+        required: true
+        type: string
+
+permissions:
+  contents: write   # needed to create releases and upload assets
+
+jobs:
+  release:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read version from Directory.Build.props
+        id: version
+        shell: pwsh
+        run: |
+          [xml]$props = Get-Content Directory.Build.props
+          $version = $props.Project.PropertyGroup.Version
+          if ([string]::IsNullOrWhiteSpace($version)) {
+            Write-Error "Version not found in Directory.Build.props"
+            exit 1
+          }
+          "version=$version" | Out-File -Append $env:GITHUB_OUTPUT
+          Write-Host "Project version: $version"
+
+      - name: Resolve target tag
+        id: target
+        shell: pwsh
+        run: |
+          if ('${{ github.event_name }}' -eq 'push') {
+            # Tag push: tag is in github.ref (refs/tags/vX.Y.Z)
+            $tag = '${{ github.ref_name }}'
+            $isDispatch = 'false'
+          } else {
+            $tag = '${{ inputs.target_tag }}'
+            $isDispatch = 'true'
+          }
+          "tag=$tag" | Out-File -Append $env:GITHUB_OUTPUT
+          "is_dispatch=$isDispatch" | Out-File -Append $env:GITHUB_OUTPUT
+          Write-Host "Target tag: $tag (dispatch=$isDispatch)"
+
+      - name: Verify tag matches Directory.Build.props version (push only)
+        if: github.event_name == 'push'
+        shell: pwsh
+        run: |
+          $tag = '${{ steps.target.outputs.tag }}'
+          $expected = "v${{ steps.version.outputs.version }}"
+          if ($tag -ne $expected) {
+            Write-Error "Tag '$tag' does not match Directory.Build.props version '$expected'. Refusing to release."
+            exit 1
+          }
+          Write-Host "Tag matches: $tag"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Run unit tests
+        run: dotnet test --filter TestCategory=unit --configuration Release
+
+      - name: Publish self-contained Windows binary
+        # SourceRevisionId stamps the commit SHA into AssemblyInformationalVersion,
+        # so `cgf-converter -usage` prints e.g. "v2.0.0+a3f72b1c..."
+        run: >
+          dotnet publish cgf-converter\cgf-converter.csproj
+          --configuration Release
+          --runtime win-x64
+          --self-contained
+          /p:SourceRevisionId=${{ github.sha }}
+
+      - name: Compile installer with Inno Setup
+        # Inno Setup is preinstalled on the windows-latest runner image.
+        shell: pwsh
+        run: |
+          $iscc = "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+          if (-not (Test-Path $iscc)) {
+            $iscc = (Get-Command iscc.exe -ErrorAction SilentlyContinue).Source
+          }
+          if (-not $iscc) { Write-Error "ISCC.exe not found"; exit 1 }
+          & $iscc installer\cgf-converter.iss
+          if ($LASTEXITCODE -ne 0) { Write-Error "Inno Setup compile failed"; exit $LASTEXITCODE }
+
+      # ─── Code signing (placeholder — wire up once cert is available) ───
+      #
+      # Once you have a code signing cert (SignPath, MS Trusted Signing,
+      # or a purchased OV/EV cert), add a signing step here. Sign BOTH
+      # cgf-converter.exe (before installer compile, so the signed exe
+      # gets bundled) AND the installer .exe (after compile, so users
+      # see "verified publisher" on the SmartScreen prompt).
+      #
+      # Always include a timestamp (/tr) so signatures survive cert expiry.
+      #
+      # Example (signtool, OV/EV cert in cert store):
+      #
+      # - name: Sign cgf-converter.exe
+      #   shell: pwsh
+      #   run: |
+      #     & signtool sign /sha1 ${{ secrets.CERT_THUMBPRINT }} `
+      #       /tr http://timestamp.sectigo.com /td sha256 /fd sha256 `
+      #       cgf-converter\bin\Release\net9.0\win-x64\publish\cgf-converter.exe
+      #
+      # - name: Sign installer
+      #   shell: pwsh
+      #   run: |
+      #     & signtool sign /sha1 ${{ secrets.CERT_THUMBPRINT }} `
+      #       /tr http://timestamp.sectigo.com /td sha256 /fd sha256 `
+      #       installer\output\cgf-converter-setup-${{ steps.version.outputs.version }}.exe
+
+      - name: Stage release assets
+        shell: pwsh
+        run: |
+          $stage = "release-assets"
+          New-Item -ItemType Directory -Force -Path $stage | Out-Null
+          Copy-Item "cgf-converter\bin\Release\net9.0\win-x64\publish\cgf-converter.exe"     $stage\
+          Copy-Item "cgf-converter\bin\Release\net9.0\win-x64\publish\cgf-converter.pdb"     $stage\
+          Copy-Item "cgf-converter\bin\Release\net9.0\win-x64\publish\CgfConverter.pdb"      $stage\
+          Copy-Item "installer\output\cgf-converter-setup-${{ steps.version.outputs.version }}.exe" $stage\
+          Get-ChildItem $stage | Format-Table Name, Length
+
+      - name: Create GitHub Release (tag push, full release)
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: |
+          $tag = '${{ steps.target.outputs.tag }}'
+          gh release create $tag `
+            --title $tag `
+            --generate-notes `
+            release-assets\*
+
+      - name: Upload assets to existing Release (manual dispatch, clobber)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: |
+          $tag = '${{ steps.target.outputs.tag }}'
+          # Verify the release exists before clobbering — fail loud, not silent.
+          gh release view $tag > $null
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Release '$tag' does not exist. Create it manually first (with the desired pre-release flag), then re-run this dispatch."
+            exit 1
+          }
+          gh release upload $tag release-assets\* --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -317,6 +317,6 @@ OpenCover/
 *.dds.*
 *.mtl
 
-# Github configs
-.github/
+# Inno Setup installer build output
+installer/output/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,64 @@ dotnet run -- "C:\GameAssets\ship.cga" -objectdir "C:\GameAssets\Objects"
 dotnet run -- ship.cgf -gltf -objectdir "C:\GameAssets\Objects"
 ```
 
+### Build the Windows Installer
+
+End-user installer is built with **Inno Setup 6** (per-user install by default, with PATH editing).
+
+**Prerequisite (one-time):** install Inno Setup from https://jrsoftware.org/isinfo.php. On this machine, `ISCC.exe` lives at `C:\Users\Geoff\AppData\Local\Programs\Inno Setup 6\ISCC.exe` (per-user install — not on PATH unless explicitly added).
+
+```powershell
+# Step 1: publish the self-contained Windows binary (must come first — installer pulls from this path)
+dotnet publish cgf-converter\cgf-converter.csproj -c Release
+
+# Step 2: compile the installer
+& "$env:LOCALAPPDATA\Programs\Inno Setup 6\ISCC.exe" installer\cgf-converter.iss
+
+# Output: installer\output\cgf-converter-setup-<version>.exe
+```
+
+**Files involved:**
+- `installer/cgf-converter.iss` — the Inno Setup script (commented thoroughly)
+- `installer/README.txt` — short readme that ships with the install
+- `installer/output/` — gitignored, holds the compiled installer
+
+**Critical invariants:**
+- The `AppId` GUID in `cgf-converter.iss` (`267AC84D-FD30-4860-A971-393139539822`) **must stay stable across versions**. Changing it will create duplicate Add/Remove Programs entries and break upgrades.
+- The version in `cgf-converter.iss` (`MyAppVersion`) is currently hardcoded — **keep it in sync with `Directory.Build.props`** when bumping versions, or template it via `iscc /D` later.
+- The publish-output path in the script (`PublishDir`) targets `cgf-converter\bin\Release\net9.0\win-x64\publish` — if the TargetFramework changes, update this path too.
+
+**Testing the installer:**
+The safe way is **Windows Sandbox** (Settings → Apps → Optional Features → enable "Windows Sandbox", reboot once). Drag the `.exe` into a sandbox session, install, open a new PowerShell, run `cgf-converter -usage`, then uninstall and verify PATH is clean. Sandbox state is disposable, so installer bugs can't pollute the dev machine. Avoid testing PATH edits on the actual dev machine — uninstall regressions there are tedious to clean up.
+
+**Inno Setup deprecation note:** the script uses `WizardIsTaskSelected` (modern). Older `IsTaskSelected` still works but emits a [Hint] warning at compile time. If a future update emits new deprecation hints, fix them rather than ignoring — Inno's deprecations get removed eventually.
+
+### Release workflow
+
+Releases are produced by `.github/workflows/release.yml`, which has two trigger modes:
+
+**Tag push (final releases):**
+```bash
+git tag v2.0.0
+git push --tags
+```
+Creates a new GitHub Release at the tag, uploads installer + raw exe + PDBs. The workflow asserts the tag matches the version in `Directory.Build.props` and refuses to release on mismatch — keeps `Directory.Build.props` as the single source of truth.
+
+**Manual dispatch (pre-releases / re-runs):**
+- Go to Actions → "Release" → "Run workflow"
+- Pick the branch (e.g. `release/v2.0`)
+- Provide the existing GitHub Release tag (e.g. `v2.0.0`)
+- Workflow builds from HEAD of that branch and **clobbers** assets onto the existing Release entry
+
+The pre-release flag on the GitHub Release entry is preserved across dispatch runs — the workflow never toggles it. To make a Release entry "pre-release," edit it in the GitHub UI once; subsequent clobbers don't change the flag. To promote pre-release → final, uncheck "Set as a pre-release" in the GitHub UI when ready.
+
+**Critical:** dispatch refuses to clobber a non-existent release. If the target tag doesn't have a Release yet, create it manually in the UI first (so you can set the pre-release flag intentionally), then dispatch.
+
+**Pattern in use:** ONE rolling pre-release entry per major version (avoids RC clutter on the Releases page). RC tags can exist locally in git for traceability but the workflow ignores them.
+
+**Commit SHA in builds:** the workflow passes `/p:SourceRevisionId=$GITHUB_SHA` to `dotnet publish`, which stamps the SHA into the assembly's `InformationalVersion`. `cgf-converter -usage` reads this attribute, so CI builds print `v2.0.0+a3f72b1c...` — every reported bug pins to an exact commit. Local builds without a SHA print just `v2.0.0`.
+
+**Code signing:** placeholder commented in the workflow. When a code signing cert is available (SignPath OSS, MS Trusted Signing, or purchased OV/EV), uncomment the `signtool sign` steps and add the cert thumbprint to GitHub repository secrets as `CERT_THUMBPRINT`. Always include `/tr <timestamp-url>` so signatures survive cert expiry.
+
 ## Versioning
 
 The application version is managed in `Directory.Build.props` at the repo root. This single file sets the version for all projects in the solution.

--- a/CgfConverter/Services/ArgsHandler.cs
+++ b/CgfConverter/Services/ArgsHandler.cs
@@ -310,7 +310,7 @@ public sealed class ArgsHandler
         Console.WriteLine();
         Console.WriteLine("cgf-converter [-usage] | <.cgf file> [-dae] [-obj] [-glb] [-gltf] [-usd] [-notex/-png/-tif/-tga] [-excludenode <nodename>] [-excludemat <matname>] [-loglevel <LogLevel>] [-objectdir <ObjectDir>] [-anim]");
         Console.WriteLine();
-        Console.WriteLine($"CryEngine Converter v{Assembly.GetEntryAssembly()?.GetName().Version}");
+        Console.WriteLine($"CryEngine Converter v{GetInformationalVersion()}");
         Console.WriteLine();
         Console.WriteLine("-usage:            Prints out the usage statement");
         Console.WriteLine();
@@ -363,5 +363,12 @@ public sealed class ArgsHandler
         Console.WriteLine();
         Console.WriteLine("-loglevel:         Set the output log level (verbose, debug, info, warn, error, critical, none)");
         Console.WriteLine();
+    }
+
+    private static string GetInformationalVersion()
+    {
+        var entry = Assembly.GetEntryAssembly();
+        var info = entry?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        return info ?? entry?.GetName().Version?.ToString() ?? "unknown";
     }
 }

--- a/installer/README.txt
+++ b/installer/README.txt
@@ -1,0 +1,52 @@
+Cryengine Converter
+===================
+
+Cryengine Converter is a command-line tool. It is now installed and (if you
+chose the option during install) added to your PATH.
+
+QUICK START
+-----------
+
+  1. Open a NEW terminal window. Existing terminals will not pick up the
+     PATH change automatically.
+
+     We recommend Windows Terminal with a PowerShell tab:
+       https://aka.ms/terminal
+
+  2. Verify the install by running:
+
+       cgf-converter -usage
+
+     You should see the full usage banner.
+
+  3. Convert your first asset:
+
+       cgf-converter <path-to-asset.cgf> -objectdir <path-to-data-directory>
+
+     The -objectdir argument is required for materials and textures to
+     resolve correctly. Always pass it.
+
+
+DOCUMENTATION
+-------------
+
+  Full documentation, examples, and the complete CLI reference:
+    https://github.com/Markemp/Cryengine-Converter
+
+  Tutorial videos:
+    https://github.com/Markemp/Cryengine-Converter#tutorial-videos
+
+
+SUPPORT
+-------
+
+  Report bugs:
+    https://github.com/Markemp/Cryengine-Converter/issues
+
+
+UNINSTALL
+---------
+
+  Use Settings -> Apps -> Installed Apps, find "Cryengine Converter",
+  and click Uninstall. The uninstaller will remove the program files and
+  also remove this directory from your PATH.

--- a/installer/cgf-converter.iss
+++ b/installer/cgf-converter.iss
@@ -1,0 +1,181 @@
+; Inno Setup script for Cryengine Converter
+;
+; Build instructions:
+;   1. Publish the executable first:
+;        dotnet publish cgf-converter\cgf-converter.csproj -c Release
+;   2. From this directory, compile the installer:
+;        iscc cgf-converter.iss
+;   3. Output goes to .\output\cgf-converter-setup-<version>.exe
+;
+; Inno Setup 6.2.0 or newer required (https://jrsoftware.org/isinfo.php).
+
+#define MyAppName "Cryengine Converter"
+#define MyAppVersion "2.0.0"
+#define MyAppPublisher "Heffay Presents"
+#define MyAppURL "https://github.com/Markemp/Cryengine-Converter"
+#define MyAppExeName "cgf-converter.exe"
+
+; Path to the published binary, relative to this script.
+#define PublishDir "..\cgf-converter\bin\Release\net9.0\win-x64\publish"
+
+[Setup]
+; AppId uniquely identifies this application.
+; Do NOT change this between versions or upgrades will create duplicate entries.
+AppId={{267AC84D-FD30-4860-A971-393139539822}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}/issues
+AppUpdatesURL={#MyAppURL}/releases
+VersionInfoVersion={#MyAppVersion}.0
+
+; Install destination. {autopf} resolves to:
+;   - %ProgramFiles%\Cryengine Converter   when installing for all users (admin)
+;   - %LocalAppData%\Programs\Cryengine Converter   when installing per-user
+DefaultDirName={autopf}\{#MyAppName}
+UsePreviousAppDir=yes
+
+; Uninstaller registers under HKCU or HKLM based on install mode.
+UninstallDisplayName={#MyAppName} {#MyAppVersion}
+UninstallDisplayIcon={app}\{#MyAppExeName}
+
+; Per-user install by default (no UAC prompt). User can choose all-users at startup.
+PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=dialog
+
+; No Start Menu folder — this is a CLI tool.
+DisableProgramGroupPage=yes
+DisableDirPage=auto
+DisableReadyPage=no
+
+; Compression
+Compression=lzma2/ultra64
+SolidCompression=yes
+LZMAUseSeparateProcess=yes
+
+; UI
+WizardStyle=modern
+WizardSizePercent=120
+
+; Output
+OutputDir=output
+OutputBaseFilename=cgf-converter-setup-{#MyAppVersion}
+
+; License
+LicenseFile=..\LICENSE
+
+; Allow the installer to broadcast WM_SETTINGCHANGE so newly opened terminals
+; pick up our PATH edit without requiring a logoff.
+ChangesEnvironment=yes
+
+; Architecture
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "addtopath"; Description: "Add {#MyAppName} to PATH (recommended — required to run cgf-converter from any directory)"; GroupDescription: "Additional tasks:"; Flags: checkedonce
+
+[Files]
+Source: "{#PublishDir}\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\LICENSE"; DestDir: "{app}"; DestName: "LICENSE.txt"; Flags: ignoreversion
+Source: "README.txt"; DestDir: "{app}"; Flags: ignoreversion
+
+[Run]
+Filename: "{app}\README.txt"; Description: "View installation README"; Flags: postinstall shellexec skipifsilent unchecked
+
+[Code]
+const
+  EnvironmentKey_HKCU = 'Environment';
+  EnvironmentKey_HKLM = 'System\CurrentControlSet\Control\Session Manager\Environment';
+
+procedure GetEnvKeyContext(var RootKey: Integer; var EnvKey: string);
+begin
+  if IsAdminInstallMode then begin
+    RootKey := HKEY_LOCAL_MACHINE;
+    EnvKey := EnvironmentKey_HKLM;
+  end else begin
+    RootKey := HKEY_CURRENT_USER;
+    EnvKey := EnvironmentKey_HKCU;
+  end;
+end;
+
+function PathContainsDir(const PathValue, AppDir: string): Boolean;
+begin
+  // Sentinel-wrap with semicolons so we match whole entries only,
+  // not e.g. 'C:\Foo' as a substring of 'C:\FooBar'. Case-insensitive.
+  Result := Pos(
+    ';' + LowerCase(AppDir) + ';',
+    ';' + LowerCase(PathValue) + ';'
+  ) > 0;
+end;
+
+procedure AddDirToPath(const AppDir: string);
+var
+  RootKey: Integer;
+  EnvKey, OrigPath, NewPath: string;
+begin
+  GetEnvKeyContext(RootKey, EnvKey);
+
+  if not RegQueryStringValue(RootKey, EnvKey, 'Path', OrigPath) then
+    OrigPath := '';
+
+  if PathContainsDir(OrigPath, AppDir) then
+    Exit;
+
+  if (Length(OrigPath) = 0) then
+    NewPath := AppDir
+  else if (OrigPath[Length(OrigPath)] = ';') then
+    NewPath := OrigPath + AppDir
+  else
+    NewPath := OrigPath + ';' + AppDir;
+
+  RegWriteExpandStringValue(RootKey, EnvKey, 'Path', NewPath);
+end;
+
+procedure RemoveDirFromPath(const AppDir: string);
+var
+  RootKey: Integer;
+  EnvKey, OrigPath, Wrapped, LowerWrapped, LowerEntry: string;
+  P, EntryLen: Integer;
+begin
+  GetEnvKeyContext(RootKey, EnvKey);
+
+  if not RegQueryStringValue(RootKey, EnvKey, 'Path', OrigPath) then
+    Exit;
+
+  Wrapped := ';' + OrigPath + ';';
+  LowerWrapped := LowerCase(Wrapped);
+  LowerEntry := ';' + LowerCase(AppDir) + ';';
+
+  P := Pos(LowerEntry, LowerWrapped);
+  if P = 0 then
+    Exit;
+
+  EntryLen := Length(AppDir) + 1;  { drop our entry plus its trailing semicolon }
+  Delete(Wrapped, P, EntryLen);
+
+  { Strip the leading and trailing semicolons we added for matching. }
+  if (Length(Wrapped) > 0) and (Wrapped[1] = ';') then
+    Delete(Wrapped, 1, 1);
+  if (Length(Wrapped) > 0) and (Wrapped[Length(Wrapped)] = ';') then
+    Delete(Wrapped, Length(Wrapped), 1);
+
+  RegWriteExpandStringValue(RootKey, EnvKey, 'Path', Wrapped);
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if CurStep = ssPostInstall then
+    if WizardIsTaskSelected('addtopath') then
+      AddDirToPath(ExpandConstant('{app}'));
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+begin
+  if CurUninstallStep = usUninstall then
+    RemoveDirFromPath(ExpandConstant('{app}'));
+end;


### PR DESCRIPTION
## Summary

Two things, packaged together because they're the same shipping pipeline:

- **Inno Setup installer** for end-user Windows distribution. Per-user default, with all-users escalation. Properly edits PATH and properly removes it on uninstall. Tested locally — install + freshly-opened terminal sees \`cgf-converter\`, uninstall removes the PATH entry cleanly.
- **GitHub Actions release workflow** with two trigger modes:
  - **Tag push** of \`vX.Y.Z\` creates a new full Release. Asserts the tag matches \`Directory.Build.props\` version.
  - **Manual dispatch** clobbers assets onto an existing Release entry (the pattern in use here — one rolling pre-release per major version, no RC-clutter on the Releases page). Refuses to clobber a non-existent Release, forcing intentional pre-release-flag decisions in the UI.
- Commit SHA stamped into \`AssemblyInformationalVersion\` via \`SourceRevisionId\`, so \`cgf-converter -usage\` prints \`v2.0.0+a3f72b1c...\` on CI builds. Lets bug reports pin to exact commits without RC tags being a thing.
- Code signing stubbed as a comment block — \`signtool sign\` invocation already written, just needs a cert thumbprint secret when one's available.
- Drops a bogus \`.github/\` exclusion from \`.gitignore\` that was silently hiding workflow files (the existing \`build.yml\` was tracked from before that line was added).

## Test plan

- [x] Local installer compile (Inno Setup 6) — clean compile, no warnings
- [x] Install / uninstall on dev machine — PATH added on install, removed on uninstall, freshly-opened terminal picks up changes
- [x] \`dotnet build\` after \`ArgsHandler.cs\` change — clean
- [x] \`cgf-converter -usage\` shows \`v2.0.0+<sha>\` (verified locally; .NET 9 auto-detects git HEAD)
- [ ] Reviewer to skim \`installer/cgf-converter.iss\` and \`.github/workflows/release.yml\`
- [ ] First dispatch run against GitHub will be the workflow's smoke test — first-run YAML/PowerShell quoting is the typical gotcha

## Notes for shipping

- **Don't merge until ready to actually run a release.** Once merged, the next dispatch from \`release/v2.0\` will rebuild and clobber the v2.0.0 pre-release assets.
- The \`Directory.Build.props\` version (\`2.0.0\`) and the installer script version must stay in sync. Bumping versions: edit \`Directory.Build.props\` first, then \`installer/cgf-converter.iss\`'s \`MyAppVersion\`, then commit, then tag.
- Signing is deferred per separate plan (SignPath OSS application, then uncomment the workflow block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)