### PR TITLE
Bump GitHub Actions versions and fix build.yml net8.0 → net9.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build
         run: dotnet build
@@ -23,7 +23,7 @@ jobs:
         run: dotnet publish
 
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cgf-converter
-          path: cgf-converter\bin\Release\net8.0\win-x64\publish
+          path: cgf-converter\bin\Release\net9.0\win-x64\publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Read version from Directory.Build.props
         id: version
@@ -81,7 +81,7 @@ jobs:
           Write-Host "Tag matches: $tag"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '9.0.x'
 


### PR DESCRIPTION
## Summary

Two issues surfaced when \`build.yml\` ran after PR #254:

1. **\`build.yml\` upload step** pointed at \`cgf-converter\bin\Release\net8.0\\`. The project moved to net9.0 some time ago. The upload step has been silently finding zero files (\"No files were found with the provided path\") for an unknown number of master pushes.
2. **Node.js 20 deprecation warnings** — \`actions/checkout@v4\` and \`actions/upload-artifact@v4\` use Node.js 20, which GitHub [deprecated in Sept 2025](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) and removes from runners in Sept 2026.

Bumps to current major versions:
- \`actions/checkout@v4\` → \`@v6\`
- \`actions/upload-artifact@v4\` → \`@v7\`
- \`actions/setup-dotnet@v4\` → \`@v5\`

\`release.yml\` had only the action-version issue — the publish path was already correct on net9.0.

## Follow-up needed

The same \`release.yml\` change needs to be ported to \`release/v2.0\`, since dispatch runs use the workflow definition from the dispatched branch (not master). Will do that as a separate small PR after this lands.

## Test plan

- [ ] After merge, build.yml runs on master push and the upload step actually finds files
- [ ] No more Node 20 deprecation warnings on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)