### PR TITLE
Port action-version bumps to release/v2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build
         run: dotnet build
@@ -23,7 +23,7 @@ jobs:
         run: dotnet publish
 
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cgf-converter
-          path: cgf-converter\bin\Release\net8.0\win-x64\publish
+          path: cgf-converter\bin\Release\net9.0\win-x64\publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Read version from Directory.Build.props
         id: version
@@ -81,7 +81,7 @@ jobs:
           Write-Host "Tag matches: $tag"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '9.0.x'
 


### PR DESCRIPTION
## Summary

Identical fix to PR #255, ported from master to \`release/v2.0\`. Why this needs to live on both branches:

- \`build.yml\` runs from whichever branch is being pushed → master's fix doesn't help \`release/v2.0\` pushes
- \`release.yml\` registers its dispatch trigger from master, but **dispatch RUNS use the workflow definition from the dispatched branch**. So when you dispatch the release workflow against \`release/v2.0\`, the deprecated action versions on \`release/v2.0\`'s copy are what actually execute. Master's fix wouldn't have silenced the warnings on the real run.

## Changes

- \`actions/checkout@v4\` → \`@v6\`
- \`actions/upload-artifact@v4\` → \`@v7\`
- \`actions/setup-dotnet@v4\` → \`@v5\`
- \`build.yml\` upload path: \`net8.0\` → \`net9.0\`

Five insertions, five deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)