### PR TITLE
Fix IVO DBA animations: block iteration, SNORM decode, frame range

### DIFF
--- a/CgfConverter/CryEngine/CryEngine.cs
+++ b/CgfConverter/CryEngine/CryEngine.cs
@@ -1221,7 +1221,7 @@ public partial class CryEngine
             FilePath = filePath
         };
 
-        // Get timing info from timing chunk
+        // Get timing info — traditional CAF uses ChunkTimingFormat; IVO CAF uses ChunkIvoAnimInfo
         var timingChunk = cafModel.ChunkMap.Values.OfType<ChunkTimingFormat>().FirstOrDefault();
         if (timingChunk is not null)
         {
@@ -1229,6 +1229,19 @@ public partial class CryEngine
             animation.TicksPerFrame = timingChunk.TicksPerFrame;
             animation.StartFrame = timingChunk.GlobalRange.Start;
             animation.EndFrame = timingChunk.GlobalRange.End;
+        }
+        else
+        {
+            // IVO CAF: key times are frame numbers; derive timing from ChunkIvoAnimInfo
+            var ivoAnimInfo = cafModel.ChunkMap.Values.OfType<ChunkIvoAnimInfo>().FirstOrDefault();
+            if (ivoAnimInfo is not null)
+            {
+                float fps = ivoAnimInfo.FramesPerSecond > 0 ? ivoAnimInfo.FramesPerSecond : 30f;
+                animation.SecsPerTick = 1f / fps;
+                animation.TicksPerFrame = 1;
+                animation.StartFrame = 0;
+                animation.EndFrame = (int)ivoAnimInfo.EndFrame;
+            }
         }
 
         // Check for additive animation flag from GlobalAnimationHeaderCAF chunk

--- a/CgfConverter/CryEngineCore/Chunks/ChunkIvoCAF_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkIvoCAF_900.cs
@@ -222,67 +222,53 @@ internal sealed class ChunkIvoCAF_900 : ChunkIvoCAF
                 break;
 
             case IvoPositionFormat.SNormFull:
-                // 0xC1xx: SNORM with 24-byte header, all channels (6 bytes per key)
+                // 0xC1xx: 24-byte header [scale Vec3, offset Vec3] + 6 bytes per key.
+                // All three axes always present. Decode: u16 * scale + offset.
                 {
-                    // Read 24-byte header: rangeMin (12 bytes) + rangeMax (12 bytes)
-                    Vector3 rangeMin = b.ReadVector3();
-                    Vector3 rangeMax = b.ReadVector3();
+                    Vector3 scale = b.ReadVector3();
+                    Vector3 offset = b.ReadVector3();
 
                     for (int i = 0; i < count; i++)
                     {
-                        short sx = b.ReadInt16();
-                        short sy = b.ReadInt16();
-                        short sz = b.ReadInt16();
+                        ushort sx = b.ReadUInt16();
+                        ushort sy = b.ReadUInt16();
+                        ushort sz = b.ReadUInt16();
 
-                        float x = IvoAnimationHelpers.DecompressSNorm(sx, rangeMin.X, rangeMax.X);
-                        float y = IvoAnimationHelpers.DecompressSNorm(sy, rangeMin.Y, rangeMax.Y);
-                        float z = IvoAnimationHelpers.DecompressSNorm(sz, rangeMin.Z, rangeMax.Z);
+                        float x = IvoAnimationHelpers.DecompressSNorm(sx, scale.X, offset.X);
+                        float y = IvoAnimationHelpers.DecompressSNorm(sy, scale.Y, offset.Y);
+                        float z = IvoAnimationHelpers.DecompressSNorm(sz, scale.Z, offset.Z);
 
                         positions.Add(new Vector3(x, y, z));
                     }
                     HelperMethods.Log(LogLevelEnum.Debug,
-                        $"    Position (0xC1 SNORM full): {count} keys, rangeMin=({rangeMin.X:F4}, {rangeMin.Y:F4}, {rangeMin.Z:F4}), rangeMax=({rangeMax.X:F4}, {rangeMax.Y:F4}, {rangeMax.Z:F4})");
+                        $"    Position (0xC1 SNORM full): {count} keys, scale=({scale.X:F4}, {scale.Y:F4}, {scale.Z:F4}), offset=({offset.X:F4}, {offset.Y:F4}, {offset.Z:F4})");
                 }
                 break;
 
             case IvoPositionFormat.SNormPacked:
-                // 0xC2xx: SNORM with 24-byte header, packed active channels only
+                // 0xC2xx: 24-byte header [scale Vec3, offset Vec3] + 2 bytes per active
+                // axis per key, interleaved. Inactive axes use FLT_MAX sentinel in `scale`
+                // and decode to `offset` (constant, no animation). Decode: u16 * scale + offset.
                 {
-                    // Read 24-byte header: rangeMin (12 bytes) + rangeMax (12 bytes)
-                    // Inactive channels use FLT_MAX as sentinel in rangeMin
-                    Vector3 rangeMin = b.ReadVector3();
-                    Vector3 rangeMax = b.ReadVector3();
+                    Vector3 scale = b.ReadVector3();
+                    Vector3 offset = b.ReadVector3();
 
-                    bool xActive = IvoAnimationHelpers.IsChannelActive(rangeMin.X);
-                    bool yActive = IvoAnimationHelpers.IsChannelActive(rangeMin.Y);
-                    bool zActive = IvoAnimationHelpers.IsChannelActive(rangeMin.Z);
+                    bool xActive = IvoAnimationHelpers.IsChannelActive(scale.X);
+                    bool yActive = IvoAnimationHelpers.IsChannelActive(scale.Y);
+                    bool zActive = IvoAnimationHelpers.IsChannelActive(scale.Z);
 
                     for (int i = 0; i < count; i++)
                     {
-                        float x = 0, y = 0, z = 0;
-
-                        if (xActive)
-                        {
-                            short sx = b.ReadInt16();
-                            x = IvoAnimationHelpers.DecompressSNorm(sx, rangeMin.X, rangeMax.X);
-                        }
-                        if (yActive)
-                        {
-                            short sy = b.ReadInt16();
-                            y = IvoAnimationHelpers.DecompressSNorm(sy, rangeMin.Y, rangeMax.Y);
-                        }
-                        if (zActive)
-                        {
-                            short sz = b.ReadInt16();
-                            z = IvoAnimationHelpers.DecompressSNorm(sz, rangeMin.Z, rangeMax.Z);
-                        }
+                        float x = xActive ? IvoAnimationHelpers.DecompressSNorm(b.ReadUInt16(), scale.X, offset.X) : offset.X;
+                        float y = yActive ? IvoAnimationHelpers.DecompressSNorm(b.ReadUInt16(), scale.Y, offset.Y) : offset.Y;
+                        float z = zActive ? IvoAnimationHelpers.DecompressSNorm(b.ReadUInt16(), scale.Z, offset.Z) : offset.Z;
 
                         positions.Add(new Vector3(x, y, z));
                     }
 
                     string activeChannels = $"{(xActive ? "X" : "")}{(yActive ? "Y" : "")}{(zActive ? "Z" : "")}";
                     HelperMethods.Log(LogLevelEnum.Debug,
-                        $"    Position (0xC2 SNORM packed): {count} keys, active=[{activeChannels}], rangeMin=({rangeMin.X:F4}, {rangeMin.Y:F4}, {rangeMin.Z:F4}), rangeMax=({rangeMax.X:F4}, {rangeMax.Y:F4}, {rangeMax.Z:F4})");
+                        $"    Position (0xC2 SNORM packed): {count} keys, active=[{activeChannels}], scale=({scale.X:F4}, {scale.Y:F4}, {scale.Z:F4}), offset=({offset.X:F4}, {offset.Y:F4}, {offset.Z:F4})");
                 }
                 break;
 

--- a/CgfConverter/CryEngineCore/Chunks/ChunkIvoCAF_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkIvoCAF_900.cs
@@ -242,9 +242,9 @@ internal sealed class ChunkIvoCAF_900 : ChunkIvoCAF
             case IvoPositionFormat.SNormFull:
                 // 0xC1xx: SNORM with 24-byte header, all channels (6 bytes per key)
                 {
-                    // Read 24-byte header: channelMask (12 bytes) + scale (12 bytes)
-                    Vector3 channelMask = b.ReadVector3();
-                    Vector3 scale = b.ReadVector3();
+                    // Read 24-byte header: rangeMin (12 bytes) + rangeMax (12 bytes)
+                    Vector3 rangeMin = b.ReadVector3();
+                    Vector3 rangeMax = b.ReadVector3();
 
                     for (int i = 0; i < count; i++)
                     {
@@ -252,27 +252,28 @@ internal sealed class ChunkIvoCAF_900 : ChunkIvoCAF
                         short sy = b.ReadInt16();
                         short sz = b.ReadInt16();
 
-                        float x = IvoAnimationHelpers.DecompressSNorm(sx, scale.X);
-                        float y = IvoAnimationHelpers.DecompressSNorm(sy, scale.Y);
-                        float z = IvoAnimationHelpers.DecompressSNorm(sz, scale.Z);
+                        float x = IvoAnimationHelpers.DecompressSNorm(sx, rangeMin.X, rangeMax.X);
+                        float y = IvoAnimationHelpers.DecompressSNorm(sy, rangeMin.Y, rangeMax.Y);
+                        float z = IvoAnimationHelpers.DecompressSNorm(sz, rangeMin.Z, rangeMax.Z);
 
                         positions.Add(new Vector3(x, y, z));
                     }
                     HelperMethods.Log(LogLevelEnum.Debug,
-                        $"    Position (0xC1 SNORM full): {count} keys, scale=({scale.X:F4}, {scale.Y:F4}, {scale.Z:F4})");
+                        $"    Position (0xC1 SNORM full): {count} keys, rangeMin=({rangeMin.X:F4}, {rangeMin.Y:F4}, {rangeMin.Z:F4}), rangeMax=({rangeMax.X:F4}, {rangeMax.Y:F4}, {rangeMax.Z:F4})");
                 }
                 break;
 
             case IvoPositionFormat.SNormPacked:
                 // 0xC2xx: SNORM with 24-byte header, packed active channels only
                 {
-                    // Read 24-byte header: channelMask (12 bytes) + scale (12 bytes)
-                    Vector3 channelMask = b.ReadVector3();
-                    Vector3 scale = b.ReadVector3();
+                    // Read 24-byte header: rangeMin (12 bytes) + rangeMax (12 bytes)
+                    // Inactive channels use FLT_MAX as sentinel in rangeMin
+                    Vector3 rangeMin = b.ReadVector3();
+                    Vector3 rangeMax = b.ReadVector3();
 
-                    bool xActive = IvoAnimationHelpers.IsChannelActive(channelMask.X);
-                    bool yActive = IvoAnimationHelpers.IsChannelActive(channelMask.Y);
-                    bool zActive = IvoAnimationHelpers.IsChannelActive(channelMask.Z);
+                    bool xActive = IvoAnimationHelpers.IsChannelActive(rangeMin.X);
+                    bool yActive = IvoAnimationHelpers.IsChannelActive(rangeMin.Y);
+                    bool zActive = IvoAnimationHelpers.IsChannelActive(rangeMin.Z);
 
                     for (int i = 0; i < count; i++)
                     {
@@ -281,17 +282,17 @@ internal sealed class ChunkIvoCAF_900 : ChunkIvoCAF
                         if (xActive)
                         {
                             short sx = b.ReadInt16();
-                            x = IvoAnimationHelpers.DecompressSNorm(sx, scale.X);
+                            x = IvoAnimationHelpers.DecompressSNorm(sx, rangeMin.X, rangeMax.X);
                         }
                         if (yActive)
                         {
                             short sy = b.ReadInt16();
-                            y = IvoAnimationHelpers.DecompressSNorm(sy, scale.Y);
+                            y = IvoAnimationHelpers.DecompressSNorm(sy, rangeMin.Y, rangeMax.Y);
                         }
                         if (zActive)
                         {
                             short sz = b.ReadInt16();
-                            z = IvoAnimationHelpers.DecompressSNorm(sz, scale.Z);
+                            z = IvoAnimationHelpers.DecompressSNorm(sz, rangeMin.Z, rangeMax.Z);
                         }
 
                         positions.Add(new Vector3(x, y, z));
@@ -299,7 +300,7 @@ internal sealed class ChunkIvoCAF_900 : ChunkIvoCAF
 
                     string activeChannels = $"{(xActive ? "X" : "")}{(yActive ? "Y" : "")}{(zActive ? "Z" : "")}";
                     HelperMethods.Log(LogLevelEnum.Debug,
-                        $"    Position (0xC2 SNORM packed): {count} keys, active=[{activeChannels}], scale=({scale.X:F4}, {scale.Y:F4}, {scale.Z:F4})");
+                        $"    Position (0xC2 SNORM packed): {count} keys, active=[{activeChannels}], rangeMin=({rangeMin.X:F4}, {rangeMin.Y:F4}, {rangeMin.Z:F4}), rangeMax=({rangeMax.X:F4}, {rangeMax.Y:F4}, {rangeMax.Z:F4})");
                 }
                 break;
 

--- a/CgfConverter/CryEngineCore/Chunks/ChunkIvoCAF_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkIvoCAF_900.cs
@@ -89,11 +89,16 @@ internal sealed class ChunkIvoCAF_900 : ChunkIvoCAF
             var ctrl = Controllers[i];
 
             // Warn about unknown rotation format flags
-            // Known formats: 0x8040 = ubyte time array, 0x8042 = uint16 time with 8-byte header
-            if (ctrl.HasRotation && ctrl.RotFormatFlags != 0x8040 && ctrl.RotFormatFlags != 0x8042)
+            // High byte: 0x80 = uncompressed, 0x82 = SmallTree48BitQuat
+            // Low nibble: 0x0 = ubyte time array, 0x2 = uint16 time header
+            if (ctrl.HasRotation)
             {
-                HelperMethods.Log(LogLevelEnum.Warning,
-                    $"ChunkIvoCAF_900: Bone {i} (0x{BoneHashes[i]:X08}) has unknown rotation format flag 0x{ctrl.RotFormatFlags:X4} (expected 0x8040 or 0x8042)");
+                byte rotCompression = IvoAnimationHelpers.GetRotationCompression(ctrl.RotFormatFlags);
+                if (rotCompression != 0x80 && rotCompression != 0x82)
+                {
+                    HelperMethods.Log(LogLevelEnum.Warning,
+                        $"ChunkIvoCAF_900: Bone {i} (0x{BoneHashes[i]:X08}) has unknown rotation compression 0x{rotCompression:X2} in flags 0x{ctrl.RotFormatFlags:X4}");
+                }
             }
 
             // Warn about unknown position format flags
@@ -154,7 +159,7 @@ internal sealed class ChunkIvoCAF_900 : ChunkIvoCAF
 
                 // Rotation data is at controllerStart + rotDataOffset
                 b.BaseStream.Seek(controllerStart + ctrl.RotDataOffset, SeekOrigin.Begin);
-                var rotations = ReadRotationKeys(b, ctrl.NumRotKeys, ctrl.RotFormatFlags);
+                var rotations = IvoAnimationHelpers.ReadRotationKeys(b, ctrl.NumRotKeys, ctrl.RotFormatFlags);
                 Rotations[boneHash] = rotations;
             }
 
@@ -190,29 +195,6 @@ internal sealed class ChunkIvoCAF_900 : ChunkIvoCAF
 
         HelperMethods.Log(LogLevelEnum.Debug,
             $"ChunkIvoCAF_900: Parsed {Rotations.Count} rotation tracks, {Positions.Count} position tracks");
-    }
-
-    private List<Quaternion> ReadRotationKeys(BinaryReader b, int count, ushort formatFlags)
-    {
-        var rotations = new List<Quaternion>(count);
-
-        // Per 010 template: #ivo CAF uses uncompressed quaternions (16 bytes each)
-        // Format flag 0x8042 indicates standard rotation track with uncompressed quats
-        byte compression = (byte)(formatFlags & 0xFF);
-
-        for (int i = 0; i < count; i++)
-        {
-            Quaternion rot = compression switch
-            {
-                0x42 => b.ReadQuaternion(),                    // Standard uncompressed (16 bytes)
-                0x40 => b.ReadQuaternion(),                    // Uncompressed variant (16 bytes)
-                0x00 => b.ReadQuaternion(),                    // NoCompressQuat (16 bytes)
-                _ => b.ReadQuaternion()                        // Default to uncompressed
-            };
-            rotations.Add(rot);
-        }
-
-        return rotations;
     }
 
     /// <summary>

--- a/CgfConverter/CryEngineCore/Chunks/ChunkIvoDBAData_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkIvoDBAData_900.cs
@@ -84,6 +84,15 @@ internal sealed class ChunkIvoDBAData_900 : ChunkIvoDBAData
                 };
             }
 
+            // The next #dba block starts immediately after this block's controller
+            // headers. Verified against AEGS Avenger landing-gear DBA: blocks are
+            // packed header-back-to-header (12 + 4*bones + 24*bones), and the
+            // shared keyframe pool follows all the headers. DataSize is NOT the
+            // stride to the next block — it's the per-animation keyframe-pool
+            // size, used only as a hint. Capture the position now, before
+            // ParseAnimationData seeks around inside the keyframe pool.
+            long positionAfterHeaders = b.BaseStream.Position;
+
             // Create animation block with parsed data
             var animBlock = new IvoAnimationBlock
             {
@@ -98,24 +107,8 @@ internal sealed class ChunkIvoDBAData_900 : ChunkIvoDBAData
 
             AnimationBlocks.Add(animBlock);
 
-            // Advance to next block. DataSize covers the entire block from its start
-            // (including sig + BoneCount + Magic + DataSize fields), consistent with CAF.
-            long nextBlockStart = blockStart + header.DataSize;
-            b.BaseStream.Seek(nextBlockStart, SeekOrigin.Begin);
-
-            // Diagnostic: warn if the next position looks wrong (not at a #dba sig or dataEnd)
-            if (nextBlockStart < dataEnd)
-            {
-                long savedPos = b.BaseStream.Position;
-                string nextSig = Encoding.ASCII.GetString(b.ReadBytes(4));
-                if (nextSig != "#dba")
-                {
-                    HelperMethods.Log(LogLevelEnum.Warning,
-                        $"ChunkIvoDBAData_900: Expected #dba at block {blockIndex + 1} start (0x{nextBlockStart:X}), got '{nextSig}'. DataSize={header.DataSize}");
-                }
-                b.BaseStream.Seek(savedPos, SeekOrigin.Begin);
-            }
-
+            // Restore position to the start of the next block's header
+            b.BaseStream.Seek(positionAfterHeaders, SeekOrigin.Begin);
             blockIndex++;
         }
 

--- a/CgfConverter/CryEngineCore/Chunks/ChunkIvoDBAData_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkIvoDBAData_900.cs
@@ -145,7 +145,7 @@ internal sealed class ChunkIvoDBAData_900 : ChunkIvoDBAData
 
                 // Parse rotation data
                 b.BaseStream.Seek(controllerStart + ctrl.RotDataOffset, SeekOrigin.Begin);
-                var rotations = IvoAnimationHelpers.ReadRotationKeys(b, ctrl.NumRotKeys);
+                var rotations = IvoAnimationHelpers.ReadRotationKeys(b, ctrl.NumRotKeys, ctrl.RotFormatFlags);
                 block.Rotations[boneHash] = rotations;
                 rotationCount++;
             }

--- a/CgfConverter/CryEngineCore/Chunks/ChunkIvoDBAData_900.cs
+++ b/CgfConverter/CryEngineCore/Chunks/ChunkIvoDBAData_900.cs
@@ -84,12 +84,6 @@ internal sealed class ChunkIvoDBAData_900 : ChunkIvoDBAData
                 };
             }
 
-            // Save position after controller headers - this is where the next block starts!
-            // DBA format: headers are sequential, keyframe data is at the end accessed via offsets.
-            // The next #dba block starts right after the current block's controller headers,
-            // NOT at blockEnd (which is where this block's keyframe data extends to).
-            long positionAfterHeaders = b.BaseStream.Position;
-
             // Create animation block with parsed data
             var animBlock = new IvoAnimationBlock
             {
@@ -104,8 +98,24 @@ internal sealed class ChunkIvoDBAData_900 : ChunkIvoDBAData
 
             AnimationBlocks.Add(animBlock);
 
-            // Restore position to after headers - next block starts here, not at blockEnd
-            b.BaseStream.Seek(positionAfterHeaders, SeekOrigin.Begin);
+            // Advance to next block. DataSize covers the entire block from its start
+            // (including sig + BoneCount + Magic + DataSize fields), consistent with CAF.
+            long nextBlockStart = blockStart + header.DataSize;
+            b.BaseStream.Seek(nextBlockStart, SeekOrigin.Begin);
+
+            // Diagnostic: warn if the next position looks wrong (not at a #dba sig or dataEnd)
+            if (nextBlockStart < dataEnd)
+            {
+                long savedPos = b.BaseStream.Position;
+                string nextSig = Encoding.ASCII.GetString(b.ReadBytes(4));
+                if (nextSig != "#dba")
+                {
+                    HelperMethods.Log(LogLevelEnum.Warning,
+                        $"ChunkIvoDBAData_900: Expected #dba at block {blockIndex + 1} start (0x{nextBlockStart:X}), got '{nextSig}'. DataSize={header.DataSize}");
+                }
+                b.BaseStream.Seek(savedPos, SeekOrigin.Begin);
+            }
+
             blockIndex++;
         }
 

--- a/CgfConverter/Models/Structs/IvoAnimationStructs.cs
+++ b/CgfConverter/Models/Structs/IvoAnimationStructs.cs
@@ -57,17 +57,19 @@ public static class IvoAnimationHelpers
     public static byte GetTimeFormat(ushort formatFlags) => (byte)(formatFlags & 0x0F);
 
     /// <summary>
-    /// Decompresses a SNORM int16 value to float using scale factor.
-    /// Formula: (snormValue / 32767.0f) * scale
+    /// Decompresses a SNORM int16 value to float using per-bone local bounds.
+    /// The 24-byte header stores rangeMin and rangeMax for each axis.
+    /// Formula: rangeMin + ((snormValue + 32767) / 65534.0f) * (rangeMax - rangeMin)
     /// </summary>
-    public static float DecompressSNorm(short snormValue, float scale)
-        => (snormValue / 32767.0f) * scale;
+    public static float DecompressSNorm(short snormValue, float rangeMin, float rangeMax)
+        => rangeMin + ((snormValue + 32767) / 65534.0f) * (rangeMax - rangeMin);
 
     /// <summary>
-    /// Checks if a channel is active (not masked with FLT_MAX sentinel).
+    /// Checks if a channel is active. Inactive channels use FLT_MAX as a sentinel
+    /// in the rangeMin field of the 24-byte SNORM header.
     /// </summary>
-    public static bool IsChannelActive(float channelMaskValue)
-        => channelMaskValue < FltMaxSentinel;
+    public static bool IsChannelActive(float rangeMinValue)
+        => rangeMinValue < FltMaxSentinel;
 
     /// <summary>
     /// Reads time keys from a binary reader based on format flags.
@@ -164,9 +166,10 @@ public static class IvoAnimationHelpers
             case IvoPositionFormat.SNormFull:
                 // 0xC1xx: SNORM with 24-byte header, all channels (6 bytes per key)
                 {
-                    // Read 24-byte header: channelMask (12 bytes) + scale (12 bytes)
-                    Vector3 channelMask = ReadVector3(b);
-                    Vector3 scale = ReadVector3(b);
+                    // Read 24-byte header: rangeMin (12 bytes) + rangeMax (12 bytes)
+                    // Each i16 maps the full [-32767, +32767] range to [rangeMin, rangeMax]
+                    Vector3 rangeMin = ReadVector3(b);
+                    Vector3 rangeMax = ReadVector3(b);
 
                     for (int i = 0; i < count; i++)
                     {
@@ -174,9 +177,9 @@ public static class IvoAnimationHelpers
                         short sy = b.ReadInt16();
                         short sz = b.ReadInt16();
 
-                        float x = DecompressSNorm(sx, scale.X);
-                        float y = DecompressSNorm(sy, scale.Y);
-                        float z = DecompressSNorm(sz, scale.Z);
+                        float x = DecompressSNorm(sx, rangeMin.X, rangeMax.X);
+                        float y = DecompressSNorm(sy, rangeMin.Y, rangeMax.Y);
+                        float z = DecompressSNorm(sz, rangeMin.Z, rangeMax.Z);
 
                         positions.Add(new Vector3(x, y, z));
                     }
@@ -186,13 +189,14 @@ public static class IvoAnimationHelpers
             case IvoPositionFormat.SNormPacked:
                 // 0xC2xx: SNORM with 24-byte header, packed active channels only
                 {
-                    // Read 24-byte header: channelMask (12 bytes) + scale (12 bytes)
-                    Vector3 channelMask = ReadVector3(b);
-                    Vector3 scale = ReadVector3(b);
+                    // Read 24-byte header: rangeMin (12 bytes) + rangeMax (12 bytes)
+                    // Inactive channels use FLT_MAX as sentinel in rangeMin
+                    Vector3 rangeMin = ReadVector3(b);
+                    Vector3 rangeMax = ReadVector3(b);
 
-                    bool xActive = IsChannelActive(channelMask.X);
-                    bool yActive = IsChannelActive(channelMask.Y);
-                    bool zActive = IsChannelActive(channelMask.Z);
+                    bool xActive = IsChannelActive(rangeMin.X);
+                    bool yActive = IsChannelActive(rangeMin.Y);
+                    bool zActive = IsChannelActive(rangeMin.Z);
 
                     for (int i = 0; i < count; i++)
                     {
@@ -201,17 +205,17 @@ public static class IvoAnimationHelpers
                         if (xActive)
                         {
                             short sx = b.ReadInt16();
-                            x = DecompressSNorm(sx, scale.X);
+                            x = DecompressSNorm(sx, rangeMin.X, rangeMax.X);
                         }
                         if (yActive)
                         {
                             short sy = b.ReadInt16();
-                            y = DecompressSNorm(sy, scale.Y);
+                            y = DecompressSNorm(sy, rangeMin.Y, rangeMax.Y);
                         }
                         if (zActive)
                         {
                             short sz = b.ReadInt16();
-                            z = DecompressSNorm(sz, scale.Z);
+                            z = DecompressSNorm(sz, rangeMin.Z, rangeMax.Z);
                         }
 
                         positions.Add(new Vector3(x, y, z));

--- a/CgfConverter/Models/Structs/IvoAnimationStructs.cs
+++ b/CgfConverter/Models/Structs/IvoAnimationStructs.cs
@@ -58,19 +58,21 @@ public static class IvoAnimationHelpers
     public static byte GetTimeFormat(ushort formatFlags) => (byte)(formatFlags & 0x0F);
 
     /// <summary>
-    /// Decompresses a SNORM int16 value to float using per-bone local bounds.
-    /// The 24-byte header stores rangeMin and rangeMax for each axis.
-    /// Formula: rangeMin + ((snormValue + 32767) / 65534.0f) * (rangeMax - rangeMin)
+    /// Decompresses a quantized u16 position value using per-bone scale and offset.
+    /// The 24-byte header stores [scale Vec3, offset Vec3]. Despite the historical
+    /// "SNORM" naming, the value is read as an unsigned 16-bit integer.
+    /// Formula: u16 * scale + offset (per axis).
+    /// Cross-validated against StarBreaker's reference reader on AEGS Avenger DBA.
     /// </summary>
-    public static float DecompressSNorm(short snormValue, float rangeMin, float rangeMax)
-        => rangeMin + ((snormValue + 32767) / 65534.0f) * (rangeMax - rangeMin);
+    public static float DecompressSNorm(ushort u16Value, float scale, float offset)
+        => u16Value * scale + offset;
 
     /// <summary>
     /// Checks if a channel is active. Inactive channels use FLT_MAX as a sentinel
-    /// in the rangeMin field of the 24-byte SNORM header.
+    /// in the scale component of the 24-byte position header.
     /// </summary>
-    public static bool IsChannelActive(float rangeMinValue)
-        => rangeMinValue < FltMaxSentinel;
+    public static bool IsChannelActive(float scaleValue)
+        => MathF.Abs(scaleValue) < FltMaxSentinel;
 
     /// <summary>
     /// Reads time keys from a binary reader based on format flags.
@@ -173,22 +175,22 @@ public static class IvoAnimationHelpers
                 break;
 
             case IvoPositionFormat.SNormFull:
-                // 0xC1xx: SNORM with 24-byte header, all channels (6 bytes per key)
+                // 0xC1xx: 24-byte header followed by 6 bytes per key.
+                // Header layout: [scale Vec3, offset Vec3]. All three axes present.
+                // Per-axis decode: u16 * scale + offset.
                 {
-                    // Read 24-byte header: rangeMin (12 bytes) + rangeMax (12 bytes)
-                    // Each i16 maps the full [-32767, +32767] range to [rangeMin, rangeMax]
-                    Vector3 rangeMin = ReadVector3(b);
-                    Vector3 rangeMax = ReadVector3(b);
+                    Vector3 scale = ReadVector3(b);
+                    Vector3 offset = ReadVector3(b);
 
                     for (int i = 0; i < count; i++)
                     {
-                        short sx = b.ReadInt16();
-                        short sy = b.ReadInt16();
-                        short sz = b.ReadInt16();
+                        ushort sx = b.ReadUInt16();
+                        ushort sy = b.ReadUInt16();
+                        ushort sz = b.ReadUInt16();
 
-                        float x = DecompressSNorm(sx, rangeMin.X, rangeMax.X);
-                        float y = DecompressSNorm(sy, rangeMin.Y, rangeMax.Y);
-                        float z = DecompressSNorm(sz, rangeMin.Z, rangeMax.Z);
+                        float x = DecompressSNorm(sx, scale.X, offset.X);
+                        float y = DecompressSNorm(sy, scale.Y, offset.Y);
+                        float z = DecompressSNorm(sz, scale.Z, offset.Z);
 
                         positions.Add(new Vector3(x, y, z));
                     }
@@ -196,36 +198,23 @@ public static class IvoAnimationHelpers
                 break;
 
             case IvoPositionFormat.SNormPacked:
-                // 0xC2xx: SNORM with 24-byte header, packed active channels only
+                // 0xC2xx: 24-byte header followed by 2 bytes per active axis per key,
+                // interleaved (verified empirically vs StarBreaker hex dump).
+                // Header layout: [scale Vec3, offset Vec3]. Inactive axes use FLT_MAX
+                // sentinel in the scale field; their value is just `offset` for every key.
                 {
-                    // Read 24-byte header: rangeMin (12 bytes) + rangeMax (12 bytes)
-                    // Inactive channels use FLT_MAX as sentinel in rangeMin
-                    Vector3 rangeMin = ReadVector3(b);
-                    Vector3 rangeMax = ReadVector3(b);
+                    Vector3 scale = ReadVector3(b);
+                    Vector3 offset = ReadVector3(b);
 
-                    bool xActive = IsChannelActive(rangeMin.X);
-                    bool yActive = IsChannelActive(rangeMin.Y);
-                    bool zActive = IsChannelActive(rangeMin.Z);
+                    bool xActive = IsChannelActive(scale.X);
+                    bool yActive = IsChannelActive(scale.Y);
+                    bool zActive = IsChannelActive(scale.Z);
 
                     for (int i = 0; i < count; i++)
                     {
-                        float x = 0, y = 0, z = 0;
-
-                        if (xActive)
-                        {
-                            short sx = b.ReadInt16();
-                            x = DecompressSNorm(sx, rangeMin.X, rangeMax.X);
-                        }
-                        if (yActive)
-                        {
-                            short sy = b.ReadInt16();
-                            y = DecompressSNorm(sy, rangeMin.Y, rangeMax.Y);
-                        }
-                        if (zActive)
-                        {
-                            short sz = b.ReadInt16();
-                            z = DecompressSNorm(sz, rangeMin.Z, rangeMax.Z);
-                        }
+                        float x = xActive ? DecompressSNorm(b.ReadUInt16(), scale.X, offset.X) : offset.X;
+                        float y = yActive ? DecompressSNorm(b.ReadUInt16(), scale.Y, offset.Y) : offset.Y;
+                        float z = zActive ? DecompressSNorm(b.ReadUInt16(), scale.Z, offset.Z) : offset.Z;
 
                         positions.Add(new Vector3(x, y, z));
                     }

--- a/CgfConverter/Models/Structs/IvoAnimationStructs.cs
+++ b/CgfConverter/Models/Structs/IvoAnimationStructs.cs
@@ -1,3 +1,4 @@
+using Extensions;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -116,23 +117,31 @@ public static class IvoAnimationHelpers
     }
 
     /// <summary>
-    /// Reads rotation keyframes (uncompressed quaternions).
+    /// Gets the rotation compression type from the high byte of format flags.
+    /// 0x80 = uncompressed (16 bytes), 0x82 = SmallTree48BitQuat (6 bytes).
+    /// </summary>
+    public static byte GetRotationCompression(ushort formatFlags) => (byte)((formatFlags >> 8) & 0xFF);
+
+    /// <summary>
+    /// Reads rotation keyframes, dispatching on the compression type in the high byte of formatFlags.
     /// </summary>
     /// <param name="b">Binary reader positioned at rotation data.</param>
     /// <param name="count">Number of rotation keys.</param>
+    /// <param name="formatFlags">Rotation format flags. High byte: 0x80 = uncompressed, 0x82 = SmallTree48BitQuat.</param>
     /// <returns>List of quaternion rotations.</returns>
-    public static List<Quaternion> ReadRotationKeys(BinaryReader b, int count)
+    public static List<Quaternion> ReadRotationKeys(BinaryReader b, int count, ushort formatFlags)
     {
         var rotations = new List<Quaternion>(count);
+        byte compression = GetRotationCompression(formatFlags);
 
-        // Ivo CAF/DBA uses uncompressed quaternions (16 bytes each: x, y, z, w)
         for (int i = 0; i < count; i++)
         {
-            float x = b.ReadSingle();
-            float y = b.ReadSingle();
-            float z = b.ReadSingle();
-            float w = b.ReadSingle();
-            rotations.Add(new Quaternion(x, y, z, w));
+            Quaternion rot = compression switch
+            {
+                0x82 => b.ReadSmallTree48BitQuat(),   // SmallTree48BitQuat: 6 bytes, "smallest three" encoding
+                _    => b.ReadQuaternion(),            // 0x80 uncompressed: 16 bytes (x, y, z, w floats)
+            };
+            rotations.Add(rot);
         }
 
         return rotations;

--- a/CgfConverter/Renderers/Gltf/BaseGltfRenderer.Animation.cs
+++ b/CgfConverter/Renderers/Gltf/BaseGltfRenderer.Animation.cs
@@ -460,6 +460,11 @@ public partial class BaseGltfRenderer
     {
         newAnimation = new GltfAnimation { Name = animName };
 
+        // Build hash → controller index map for posFormat lookup
+        var hashToControllerIndex = block.BoneHashes
+            .Select((hash, idx) => (hash, idx))
+            .ToDictionary(x => x.hash, x => x.idx);
+
         foreach (var boneHash in block.BoneHashes)
         {
             // Try to find node by bone hash (CRC32 of bone name)
@@ -500,10 +505,16 @@ public partial class BaseGltfRenderer
                         $"ivo_dba/{animName}/pos_time/{boneHash:X08}", -1, null,
                         keyTimes.Select(t => (t - startTime) / 30f).ToArray());
 
-                    // Ivo DBA stores DELTA positions (added to rest translation)
-                    // TODO: need to add rest translation before SwapAxes when Ivo glTF export is implemented
+                    // C0 (float) = absolute local positions, use directly.
+                    // C1/C2 (SNORM) = delta from rest pose, add rest translation first.
+                    ushort posFormat = hashToControllerIndex.TryGetValue(boneHash, out var ctrlIdx)
+                        && ctrlIdx < block.Controllers.Length
+                        ? block.Controllers[ctrlIdx].PosFormatFlags
+                        : (ushort)0;
+                    bool isAbsolute = IvoAnimationHelpers.GetPositionFormat(posFormat) == IvoPositionFormat.FloatVector3;
+
                     var absolutePositions = positions
-                        .Select(SwapAxesForPosition)
+                        .Select(p => SwapAxesForPosition(isAbsolute ? p : restTranslation + p))
                         .ToArray();
 
                     var posAccessor = AddAccessor(

--- a/CgfConverter/Renderers/Gltf/BaseGltfRenderer.Animation.cs
+++ b/CgfConverter/Renderers/Gltf/BaseGltfRenderer.Animation.cs
@@ -460,11 +460,6 @@ public partial class BaseGltfRenderer
     {
         newAnimation = new GltfAnimation { Name = animName };
 
-        // Build hash → controller index map for posFormat lookup
-        var hashToControllerIndex = block.BoneHashes
-            .Select((hash, idx) => (hash, idx))
-            .ToDictionary(x => x.hash, x => x.idx);
-
         foreach (var boneHash in block.BoneHashes)
         {
             // Try to find node by bone hash (CRC32 of bone name)
@@ -505,16 +500,12 @@ public partial class BaseGltfRenderer
                         $"ivo_dba/{animName}/pos_time/{boneHash:X08}", -1, null,
                         keyTimes.Select(t => (t - startTime) / 30f).ToArray());
 
-                    // C0 (float) = absolute local positions, use directly.
-                    // C1/C2 (SNORM) = delta from rest pose, add rest translation first.
-                    ushort posFormat = hashToControllerIndex.TryGetValue(boneHash, out var ctrlIdx)
-                        && ctrlIdx < block.Controllers.Length
-                        ? block.Controllers[ctrlIdx].PosFormatFlags
-                        : (ushort)0;
-                    bool isAbsolute = IvoAnimationHelpers.GetPositionFormat(posFormat) == IvoPositionFormat.FloatVector3;
-
+                    // All Ivo position formats decode to absolute local positions.
+                    // C0 (float) is stored as a raw Vector3; C1/C2 (SNORM) decode through
+                    // a per-bone [rangeMin, rangeMax] header that maps int16 linearly into
+                    // absolute world bounds. No rest translation should be added.
                     var absolutePositions = positions
-                        .Select(p => SwapAxesForPosition(isAbsolute ? p : restTranslation + p))
+                        .Select(SwapAxesForPosition)
                         .ToArray();
 
                     var posAccessor = AddAccessor(

--- a/CgfConverter/Renderers/USD/Models/UsdHeader.cs
+++ b/CgfConverter/Renderers/USD/Models/UsdHeader.cs
@@ -27,6 +27,9 @@ public class UsdHeader
     [UsdProperty("timeCodesPerSecond")]
     public int? TimeCodesPerSecond { get; set; }
 
+    [UsdProperty("framesPerSecond")]
+    public int? FramesPerSecond { get; set; }
+
     [UsdProperty("version")]
     public string Version { get; set; } = "1.0";
 
@@ -42,6 +45,8 @@ public class UsdHeader
         sb.AppendLine($"    metersPerUnit = {MetersPerUnit}");
         if (StartTimeCode.HasValue)
             sb.AppendLine($"    startTimeCode = {StartTimeCode.Value}");
+        if (FramesPerSecond.HasValue)
+            sb.AppendLine($"    framesPerSecond = {FramesPerSecond.Value}");
         if (TimeCodesPerSecond.HasValue)
             sb.AppendLine($"    timeCodesPerSecond = {TimeCodesPerSecond.Value}");
         sb.AppendLine($"    upAxis = \"{UpAxis}\"");

--- a/CgfConverter/Renderers/USD/UsdRenderer.Animation.cs
+++ b/CgfConverter/Renderers/USD/UsdRenderer.Animation.cs
@@ -134,8 +134,13 @@ public partial class UsdRenderer
             return animations;
         }
 
-        // Set header timeline info if we have animations
+        // Set header timeline info if we have animations.
+        // Both timeCodesPerSecond AND framesPerSecond must be set: USD treats them as
+        // distinct (timeCodes are logical units; framesPerSecond is the playback hint).
+        // Blender's USD importer reads framesPerSecond for the scene FPS — when missing,
+        // it falls back to 24fps and the imported frame range can collapse to 0.
         header.TimeCodesPerSecond = 30;
+        header.FramesPerSecond = 30;
         header.StartTimeCode = 0;
         header.EndTimeCode = maxEndFrame;
 
@@ -1227,6 +1232,7 @@ public partial class UsdRenderer
             {
                 DefaultPrim = _rootPrimName,
                 TimeCodesPerSecond = 30,
+                FramesPerSecond = 30,
                 StartTimeCode = 0,
                 EndTimeCode = endFrame
             }

--- a/CgfConverter/Renderers/USD/UsdRenderer.Animation.cs
+++ b/CgfConverter/Renderers/USD/UsdRenderer.Animation.cs
@@ -457,27 +457,18 @@ public partial class UsdRenderer
                     ? restR
                     : Quaternion.Identity;
 
-                // Position interpretation depends on the storage format:
-                // - C0 (0xC0xx, raw float): ABSOLUTE local positions (replace rest translation)
-                // - C1/C2 (0xC1xx/0xC2xx, SNORM): DELTAS from rest (SNORM encodes offsets around zero)
-                // Evidence: C0 bones (UpPiston) have values near rest. C2 bones (MainWheel) in Block 1
-                // have (0,0,0) meaning "no change from rest" (zero delta), not "position at origin."
+                // All Ivo position formats decode to ABSOLUTE local positions.
+                //   C0 (0xC0xx) — raw float Vector3, used as-is.
+                //   C1/C2 (0xC1xx/0xC2xx) — SNORM int16 with a per-bone [rangeMin, rangeMax]
+                //     header that maps [-32767, +32767] linearly into absolute world bounds
+                //     (verified against AEGS Avenger DBA: rangeMax ≈ rest, rangeMin ≈ 0,
+                //     snorm=0 → midpoint of bounds, snorm=±32767 → endpoints).
+                // The previous "delta from rest" interpretation doubled the bone distance,
+                // because SNORM frames near rest were being added on top of rest.
                 Vector3 position;
                 if (trackPos is not null && trackPos.Count > 0)
                 {
-                    var rawValue = SampleIvoPositionDelta(trackPos, posTimes, frame);
-                    var posType = IvoAnimationHelpers.GetPositionFormat(posFormat);
-
-                    if (posType == IvoPositionFormat.FloatVector3)
-                    {
-                        // C0: raw float = absolute local position
-                        position = rawValue;
-                    }
-                    else
-                    {
-                        // C1/C2: SNORM compressed = delta from rest
-                        position = restTranslation + rawValue;
-                    }
+                    position = SampleIvoPositionDelta(trackPos, posTimes, frame);
                 }
                 else
                 {

--- a/CgfConverterIntegrationTests/ManualTests/ManualRenderTests.cs
+++ b/CgfConverterIntegrationTests/ManualTests/ManualRenderTests.cs
@@ -373,7 +373,7 @@ public class ManualRenderTests
     [TestMethod]
     public void Aloprat_USD()
     {
-        RenderToUsd($@"{sc46ObjectDir}\Objects\Characters\Creatures\aloprat\aloprat_skel.chr", sc46ObjectDir);
+        RenderToUsd($@"{sc46ObjectDir}\Objects\Characters\Creatures\aloprat\aloprat_skel.chr", sc46ObjectDir, includeAnimations: true);
     }
 
     [TestMethod]
@@ -427,7 +427,7 @@ public class ManualRenderTests
     [TestMethod]
     public void AEGS_Avenger_LandingGear_Back_USD()
     {
-        RenderToUsd($@"{sc46ObjectDir}\Objects\Spaceships\Ships\AEGS\LandingGear\Avenger\AEGS_Avenger_LandingGear_Back_CHR.chr", sc41ObjectDir);
+        RenderToUsd($@"{sc46ObjectDir}\Objects\Spaceships\Ships\AEGS\LandingGear\Avenger\AEGS_Avenger_LandingGear_Back_CHR.chr", sc41ObjectDir, includeAnimations: true);
     }
 
     [TestMethod]

--- a/CgfConverterTestingConsole/Program.cs
+++ b/CgfConverterTestingConsole/Program.cs
@@ -466,8 +466,7 @@ static void RunCustom(CryEngine cryData)
                             var boneName = bone?.BoneName ?? $"unknown_{hash:X8}";
                             bool isFocus = focusBones.Contains(boneName);
 
-                            if (!isFocus) continue;
-
+                            // Print every bone so we can spot SNORM ones for cross-checking.
                             var posFormat = IvoAnimationHelpers.GetPositionFormat(ctrl.PosFormatFlags);
                             Console.Write($"      {boneName,-40} hash=0x{hash:X08} fmt={posFormat,-15} posKeys={ctrl.NumPosKeys}");
 

--- a/CgfConverterTestingConsole/Program.cs
+++ b/CgfConverterTestingConsole/Program.cs
@@ -24,7 +24,7 @@ for (int i = 1; i < args.Length; i++)
     {
         objectDir = args[++i];
     }
-    else if (arg.StartsWith("--dump-") || arg == "--custom")
+    else if (arg.StartsWith("--dump-") || arg == "--custom" || arg == "--ivo-raw")
     {
         command = arg;
         commandIndex = i;
@@ -42,6 +42,14 @@ if (!File.Exists(filePath))
 {
     Console.Error.WriteLine($"File not found: {filePath}");
     return 1;
+}
+
+// --ivo-raw runs without going through CryEngine processing — walks the IVO
+// container and DB_DATA blocks directly against StarBreaker whitepaper layout.
+if (command == "--ivo-raw")
+{
+    DumpIvoRaw(filePath);
+    return 0;
 }
 
 // Parse and process the file
@@ -461,7 +469,7 @@ static void RunCustom(CryEngine cryData)
                             if (!isFocus) continue;
 
                             var posFormat = IvoAnimationHelpers.GetPositionFormat(ctrl.PosFormatFlags);
-                            Console.Write($"      {boneName,-40} fmt={posFormat,-15} posKeys={ctrl.NumPosKeys}");
+                            Console.Write($"      {boneName,-40} hash=0x{hash:X08} fmt={posFormat,-15} posKeys={ctrl.NumPosKeys}");
 
                             if (block.Positions.TryGetValue(hash, out var positions) && positions.Count > 0)
                                 Console.Write($"  parsed[0]=({positions[0].X:F6}, {positions[0].Y:F6}, {positions[0].Z:F6})");
@@ -531,6 +539,167 @@ static void RunCustom(CryEngine cryData)
                     }
                 }
             }
+        }
+    }
+}
+
+static void DumpIvoRaw(string path)
+{
+    using var fs = File.OpenRead(path);
+    using var br = new BinaryReader(fs);
+
+    // IVO header per StarBreaker whitepaper
+    string magic = System.Text.Encoding.ASCII.GetString(br.ReadBytes(4));
+    uint version = br.ReadUInt32();
+    uint chunkCount = br.ReadUInt32();
+    uint chunkTableOffset = br.ReadUInt32();
+    Console.WriteLine($"IVO header: magic='{magic}' version=0x{version:X} chunks={chunkCount} tableOffset=0x{chunkTableOffset:X}");
+    Console.WriteLine($"File size: 0x{fs.Length:X} ({fs.Length})\n");
+
+    if (magic != "#ivo") { Console.WriteLine("Not an #ivo file."); return; }
+
+    // Chunk table: 16 bytes per entry — type(u32), version(u32), fileOffset(u64)
+    fs.Seek(chunkTableOffset, SeekOrigin.Begin);
+    var chunks = new List<(uint type, uint ver, ulong off)>();
+    for (int i = 0; i < chunkCount; i++)
+    {
+        uint t = br.ReadUInt32();
+        uint v = br.ReadUInt32();
+        ulong o = br.ReadUInt64();
+        chunks.Add((t, v, o));
+        Console.WriteLine($"  chunk[{i}]: type=0x{t:X8} version=0x{v:X} fileOffset=0x{o:X}");
+    }
+    Console.WriteLine();
+
+    // Locate DB_DATA chunk (0x194FBC50)
+    var dbData = chunks.Find(c => c.type == 0x194FBC50);
+    if (dbData.off == 0) { Console.WriteLine("No DB_DATA chunk in this file."); return; }
+
+    Console.WriteLine($"=== Walking DB_DATA at file offset 0x{dbData.off:X} ===\n");
+    fs.Seek((long)dbData.off, SeekOrigin.Begin);
+
+    // First u32 of DB_DATA payload is total_size (per whitepaper)
+    long payloadStart = fs.Position;
+    uint totalSize = br.ReadUInt32();
+    Console.WriteLine($"total_size (first u32): 0x{totalSize:X} ({totalSize})");
+    Console.WriteLine($"payload starts at 0x{payloadStart:X}, blocks start at 0x{fs.Position:X}\n");
+
+    // Walk blocks per whitepaper layout:
+    //   +0x00 '#dba' (4)  +0x04 bone_count (u16)  +0x06 0xAA55 (u16)  +0x08 data_size (u32)
+    int blockIndex = 0;
+    while (true)
+    {
+        long blockStart = fs.Position;
+        if (blockStart >= fs.Length - 4) { Console.WriteLine($"Reached EOF at 0x{blockStart:X}."); break; }
+
+        byte[] sigBytes = br.ReadBytes(4);
+        string sig = System.Text.Encoding.ASCII.GetString(sigBytes);
+        ushort boneCount = br.ReadUInt16();
+        ushort magic2 = br.ReadUInt16();
+        uint dataSize = br.ReadUInt32();
+
+        Console.WriteLine($"Block[{blockIndex}] @ 0x{blockStart:X}: sig='{sig}' bones={boneCount} magic=0x{magic2:X4} data_size=0x{dataSize:X} ({dataSize})");
+        Console.WriteLine($"  raw sig bytes: {sigBytes[0]:X2} {sigBytes[1]:X2} {sigBytes[2]:X2} {sigBytes[3]:X2}");
+
+        if (sig != "#dba")
+        {
+            Console.WriteLine("  Not '#dba' — terminating loop per whitepaper rule.");
+            break;
+        }
+
+        long nextStart = blockStart + dataSize;
+        Console.WriteLine($"  blockStart + data_size = 0x{nextStart:X}");
+
+        // Peek what's at nextStart
+        if (nextStart < fs.Length - 4)
+        {
+            long savedPos = fs.Position;
+            fs.Seek(nextStart, SeekOrigin.Begin);
+            byte[] peek = br.ReadBytes(4);
+            string peekStr = System.Text.Encoding.ASCII.GetString(peek);
+            Console.WriteLine($"  peek at 0x{nextStart:X}: '{peekStr}' (raw: {peek[0]:X2} {peek[1]:X2} {peek[2]:X2} {peek[3]:X2})");
+
+            // Also check a few candidate offsets: alignment + small padding
+            foreach (long delta in new long[] { 4, 8, 16, 32, 48 })
+            {
+                long alt = nextStart + delta;
+                if (alt + 4 > fs.Length) continue;
+                fs.Seek(alt, SeekOrigin.Begin);
+                byte[] altBytes = br.ReadBytes(4);
+                string altStr = System.Text.Encoding.ASCII.GetString(altBytes);
+                if (altStr == "#dba" || altStr == "#caf")
+                    Console.WriteLine($"  >>> '#dba'/'#caf' actually found at 0x{alt:X} (= nextStart + {delta}) <<<");
+            }
+
+            fs.Seek(savedPos, SeekOrigin.Begin);
+        }
+
+        // Scan whole file for all #dba/#caf magics — print ALL of them
+        if (blockIndex == 0)
+        {
+            Console.WriteLine("  All '#dba'/'#caf' magic occurrences in file:");
+            for (long p = 0; p < fs.Length - 4; p++)
+            {
+                fs.Seek(p, SeekOrigin.Begin);
+                byte[] b4 = br.ReadBytes(4);
+                bool isDba = b4[0] == (byte)'#' && b4[1] == (byte)'d' && b4[2] == (byte)'b' && b4[3] == (byte)'a';
+                bool isCaf = b4[0] == (byte)'#' && b4[1] == (byte)'c' && b4[2] == (byte)'a' && b4[3] == (byte)'f';
+                if (isDba || isCaf)
+                    Console.WriteLine($"    0x{p:X}  '{(isDba ? "#dba" : "#caf")}'");
+            }
+        }
+        Console.WriteLine();
+
+        // Advance: try ALTERNATE stride — header(12) + boneHashes(4*n) + controllers(24*n)
+        long altStride = 12 + 4 * boneCount + 24 * boneCount;
+        long altNext = blockStart + altStride;
+        Console.WriteLine($"  alt stride (12 + 28*bones): 0x{altStride:X}  → next at 0x{altNext:X}");
+
+        // Use alt stride for actual iteration to walk full chain
+        fs.Seek(altNext, SeekOrigin.Begin);
+        blockIndex++;
+        if (blockIndex > 8) { Console.WriteLine("Stopping after 8 blocks."); break; }
+    }
+
+    // Now also try walking via DBA_META to cross-check expected animation count
+    Console.WriteLine();
+    var dbaMeta = chunks.Find(c => c.type == 0xF7351608);
+    if (dbaMeta.off != 0)
+    {
+        Console.WriteLine($"=== DBA_META at 0x{dbaMeta.off:X} (version 0x{dbaMeta.ver:X}) ===");
+        fs.Seek((long)dbaMeta.off, SeekOrigin.Begin);
+        uint count = br.ReadUInt32();
+        Console.WriteLine($"  count (animations): {count}");
+        for (int i = 0; i < count; i++)
+        {
+            long entryStart = fs.Position;
+            uint flags0 = br.ReadUInt32();
+            uint flags1 = br.ReadUInt32();
+            ushort fps = br.ReadUInt16();
+            ushort numCtrls = br.ReadUInt16();
+            uint ver2 = br.ReadUInt32();
+            uint pad = br.ReadUInt32();
+            uint endFrame = br.ReadUInt32();
+            // start_rotation (16) + start_position (8) = 24
+            fs.Seek(entryStart + 48, SeekOrigin.Begin);
+            Console.WriteLine($"  entry[{i}]: flags=({flags0:X8},{flags1:X8}) fps={fps} numControllers={numCtrls} ver=0x{ver2:X} endFrame={endFrame}");
+        }
+
+        // Skip 4-byte NUL pad, then string table
+        fs.ReadByte(); fs.ReadByte(); fs.ReadByte(); fs.ReadByte();
+        long stringStart = fs.Position;
+        Console.WriteLine($"  string table at 0x{stringStart:X}:");
+        var sb = new System.Text.StringBuilder();
+        while (fs.Position < fs.Length)
+        {
+            byte ch = br.ReadByte();
+            if (ch == 0)
+            {
+                if (sb.Length > 0) { Console.WriteLine($"    \"{sb}\""); sb.Clear(); }
+                else break; // double-null = end
+            }
+            else sb.Append((char)ch);
+            if (fs.Position >= fs.Length) break;
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes parsing and decoding of Star Citizen IVO DBA animations, cross-validated byte-for-byte against [StarBreaker](https://github.com/diogotr7/StarBreaker)'s reference Rust reader on the AEGS Avenger landing gear DBA.

(Note: the commit history on this branch contains a few intermediate/exploratory commits that were superseded by later ones — the items below describe the **net** behavior after the merge.)

- **Block iteration** (`ChunkIvoDBAData_900`): advance by header stride `12 + 28 × boneCount` instead of `data_size`. The StarBreaker whitepaper claims `data_size` is the per-block stride, but the actual reference code ignores it; keyframe data lives in a shared pool after all the headers. The previous data_size-based iteration broke parsing of all blocks past the first (e.g. only the first of four animations in `Avenger.dba` was being read).
- **SNORM position decode** (`IvoAnimationHelpers`, `ChunkIvoCAF_900`): the 24-byte position header is `[scale Vec3, offset Vec3]`, values are `u16` (not `i16`), and decode is `u16 × scale + offset`. Both `SNormFull` (0xC1) and `SNormPacked` (0xC2) verified against StarBreaker on three bones (`SubWheelCompress`, `MainWheelCompress`, `LowKnee`).
- **No rest add in renderers** (`UsdRenderer.Animation`, `BaseGltfRenderer.Animation`): all Ivo position formats decode to absolute local positions. The earlier "C1/C2 SNORM = delta from rest" interpretation doubled bone distances at runtime in both USD and glTF.
- **SmallTree48BitQuat rotation dispatch**: rotation compression type was extracted from the wrong byte (`formatFlags & 0xFF` instead of `(formatFlags >> 8) & 0xFF`). Worked by accident for uncompressed (0x80) but silently misread SmallTree48 (0x82) data. Now dispatches via `(formatFlags >> 8) & 0xFF`.
- **IVO CAF timing**: `ChunkIvoAnimInfo.EndFrame` and `FramesPerSecond` were never consumed; CAF animations always had zero duration. Falls back to `ChunkIvoAnimInfo` when no `ChunkTimingFormat` chunk is present.
- **`framesPerSecond` in USD output** (`UsdHeader`): Blender's USD importer reads `framesPerSecond` (distinct from `timeCodesPerSecond`) for the scene FPS. When missing, Blender falls back to 24fps and the imported frame range can collapse to zero. Set to 30 alongside `timeCodesPerSecond`.

Also adds `--ivo-raw` to `CgfConverterTestingConsole` for raw IVO container walks (useful for future Ivo format work) and unfilters the SNORM bone diagnostic so all bones print their hash and format — needed for cross-checking against StarBreaker's `dump_dba_packed_pos`.

## Validation

- StarBreaker `dump_dba_packed_pos` cross-check on AEGS Avenger DBA matches all decoded SNORM positions to 4 decimal places (StarBreaker's print precision) across all three position formats (FloatVector3, SNormFull, SNormPacked).
- Blender visual import on AEGS Avenger Back landing gear: bones move correctly, geometry follows, no doubling.
- Blender visual import on Aloprat (creature) walk animation: looks correct.
- Scorpius landing gear: animates correctly, very minor jankiness (likely the known ~2.29° SmallTree48BitQuat angular error noted in the StarBreaker whitepaper §0x82, not a converter bug).

## Test plan

- [x] Convert AEGS Avenger Back landing gear `.chr` with `-animations`, scrub compress + extend in Blender
- [x] Convert Aloprat skel `.chr` with `-animations`, verify walk
- [x] Convert Scorpius landing gear, verify reasonable behavior
- [x] Cross-check SNORM positions against StarBreaker for FloatVector3, SNormFull, SNormPacked formats
- [ ] Spot-check glTF animation export (parser-side fixes apply; glTF visual not separately validated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)