### PR TITLE
Heffay Chunk Detective - Noir Edition

### DIFF
--- a/CgfConverter/CryEngineCore/Model.Scanner.cs
+++ b/CgfConverter/CryEngineCore/Model.Scanner.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using CgfConverter.Diagnostics.ChunkScanning;
+using CgfConverter.Services;
+
+namespace CgfConverter.CryEngineCore;
+
+public partial class Model
+{
+    internal static ChunkScanFileResult ScanChunkIssues(string fileName, Stream stream, bool closeStream = false)
+    {
+        var records = new List<ChunkIssueRecord>();
+        var model = new Model
+        {
+            FileName = fileName
+        };
+
+        try
+        {
+            using var reader = new EndiannessChangeableBinaryReader(stream);
+
+            try
+            {
+                model.ReadFileHeader(reader);
+            }
+            catch (Exception ex)
+            {
+                records.Add(CreateFileFailureRecord(fileName, model, ChunkParserStage.FileHeader, ex));
+                return CreateResult(fileName, model, records);
+            }
+
+            try
+            {
+                model.ReadChunkTable(reader);
+            }
+            catch (Exception ex)
+            {
+                records.Add(CreateFileFailureRecord(fileName, model, ChunkParserStage.ChunkTable, ex));
+                return CreateResult(fileName, model, records);
+            }
+
+            for (var i = 0; i < model.chunkHeaders.Count; i++)
+            {
+                var header = model.chunkHeaders[i];
+                Chunk chunk;
+
+                try
+                {
+                    chunk = Chunk.New(header.ChunkType, header.Version);
+                }
+                catch (NotSupportedException ex)
+                {
+                    records.Add(CreateHeaderRecord(
+                        ChunkIssueKind.UnsupportedChunkVersion,
+                        fileName,
+                        model,
+                        header,
+                        i,
+                        ChunkParserStage.ChunkFactory,
+                        ex));
+                    continue;
+                }
+                catch (Exception ex)
+                {
+                    records.Add(CreateHeaderRecord(
+                        ChunkIssueKind.ParseFailure,
+                        fileName,
+                        model,
+                        header,
+                        i,
+                        ChunkParserStage.ChunkFactory,
+                        ex));
+                    continue;
+                }
+
+                chunk.Load(model, header);
+
+                if (chunk is ChunkUnknown)
+                {
+                    records.Add(CreateHeaderRecord(
+                        ChunkIssueKind.UnknownChunkType,
+                        fileName,
+                        model,
+                        header,
+                        i,
+                        ChunkParserStage.ChunkFactory));
+                }
+
+                try
+                {
+                    chunk.Read(reader);
+                }
+                catch (Exception ex)
+                {
+                    records.Add(CreateHeaderRecord(
+                        ChunkIssueKind.ParseFailure,
+                        fileName,
+                        model,
+                        header,
+                        i,
+                        ChunkParserStage.ChunkRead,
+                        ex,
+                        chunk.DataSize));
+                    continue;
+                }
+
+                try
+                {
+                    chunk.SkipBytes(reader);
+                }
+                catch (Exception ex)
+                {
+                    records.Add(CreateHeaderRecord(
+                        ChunkIssueKind.ParseFailure,
+                        fileName,
+                        model,
+                        header,
+                        i,
+                        ChunkParserStage.ChunkSkip,
+                        ex,
+                        chunk.DataSize));
+                }
+            }
+
+            return CreateResult(fileName, model, records);
+        }
+        finally
+        {
+            if (closeStream)
+                stream.Close();
+        }
+    }
+
+    private static ChunkScanFileResult CreateResult(
+        string fileName,
+        Model model,
+        IReadOnlyList<ChunkIssueRecord> records)
+    {
+        return new ChunkScanFileResult(
+            fileName,
+            model.FileSignature,
+            model.FileSignature is null ? null : (uint)model.FileVersion,
+            records);
+    }
+
+    private static ChunkIssueRecord CreateFileFailureRecord(
+        string fileName,
+        Model model,
+        ChunkParserStage stage,
+        Exception exception)
+    {
+        return new ChunkIssueRecord
+        {
+            IssueKind = ChunkIssueKind.ParseFailure,
+            InputPath = fileName,
+            Extension = Path.GetExtension(fileName).ToLowerInvariant(),
+            ModelFileName = model.FileName,
+            FileSignature = model.FileSignature,
+            FileVersion = model.FileSignature is null ? null : (uint)model.FileVersion,
+            ParserStage = stage,
+            ExceptionType = exception.GetType().Name,
+            ExceptionMessage = exception.Message
+        };
+    }
+
+    private static ChunkIssueRecord CreateHeaderRecord(
+        ChunkIssueKind issueKind,
+        string fileName,
+        Model model,
+        ChunkHeader header,
+        int occurrenceIndex,
+        ChunkParserStage stage,
+        Exception? exception = null,
+        uint? dataSize = null)
+    {
+        var isIvo = model.FileVersion == FileVersion.x0900;
+        uint? chunkSize = isIvo && header.Size == 0 ? null : header.Size;
+
+        return new ChunkIssueRecord
+        {
+            IssueKind = issueKind,
+            InputPath = fileName,
+            Extension = Path.GetExtension(fileName).ToLowerInvariant(),
+            ModelFileName = model.FileName,
+            FileSignature = model.FileSignature,
+            FileVersion = (uint)model.FileVersion,
+            ChunkTypeValue = (uint)header.ChunkType,
+            ChunkTypeHex = FormatHex((uint)header.ChunkType),
+            ChunkTypeName = Enum.IsDefined(typeof(ChunkType), header.ChunkType) ? header.ChunkType.ToString() : null,
+            ChunkVersionRawHex = FormatHex(header.VersionRaw),
+            ChunkVersionHex = FormatHex(header.Version),
+            ChunkId = header.ID,
+            ChunkIdIsGenerated = isIvo,
+            ChunkOffset = header.Offset,
+            ChunkOffsetHex = FormatHex(header.Offset),
+            ChunkSize = chunkSize,
+            ChunkDataSize = dataSize,
+            OccurrenceIndex = occurrenceIndex,
+            ParserStage = stage,
+            ExceptionType = exception?.GetType().Name,
+            ExceptionMessage = exception?.Message
+        };
+    }
+
+    private static string FormatHex(uint value)
+    {
+        return $"0x{value:X}";
+    }
+}

--- a/CgfConverter/CryEngineCore/Model.cs
+++ b/CgfConverter/CryEngineCore/Model.cs
@@ -8,7 +8,7 @@ using CgfConverter.Services;
 
 namespace CgfConverter.CryEngineCore;
 
-public class Model
+public partial class Model
 {
     /// <summary> The Root of the loaded object </summary>
     public ChunkNode? RootNode { get; internal set; }

--- a/CgfConverter/Diagnostics/ChunkScanning/ChunkIssueKind.cs
+++ b/CgfConverter/Diagnostics/ChunkScanning/ChunkIssueKind.cs
@@ -1,0 +1,8 @@
+namespace CgfConverter.Diagnostics.ChunkScanning;
+
+public enum ChunkIssueKind
+{
+    UnknownChunkType,
+    UnsupportedChunkVersion,
+    ParseFailure
+}

--- a/CgfConverter/Diagnostics/ChunkScanning/ChunkIssueRecord.cs
+++ b/CgfConverter/Diagnostics/ChunkScanning/ChunkIssueRecord.cs
@@ -1,0 +1,27 @@
+namespace CgfConverter.Diagnostics.ChunkScanning;
+
+public sealed record ChunkIssueRecord
+{
+    public required ChunkIssueKind IssueKind { get; init; }
+    public required string InputPath { get; init; }
+    public string? RelativePath { get; init; }
+    public string? Extension { get; init; }
+    public string? ModelFileName { get; init; }
+    public string? FileSignature { get; init; }
+    public uint? FileVersion { get; init; }
+    public uint? ChunkTypeValue { get; init; }
+    public string? ChunkTypeHex { get; init; }
+    public string? ChunkTypeName { get; init; }
+    public string? ChunkVersionRawHex { get; init; }
+    public string? ChunkVersionHex { get; init; }
+    public int? ChunkId { get; init; }
+    public bool ChunkIdIsGenerated { get; init; }
+    public uint? ChunkOffset { get; init; }
+    public string? ChunkOffsetHex { get; init; }
+    public uint? ChunkSize { get; init; }
+    public uint? ChunkDataSize { get; init; }
+    public int? OccurrenceIndex { get; init; }
+    public ChunkParserStage ParserStage { get; init; }
+    public string? ExceptionType { get; init; }
+    public string? ExceptionMessage { get; init; }
+}

--- a/CgfConverter/Diagnostics/ChunkScanning/ChunkParserStage.cs
+++ b/CgfConverter/Diagnostics/ChunkScanning/ChunkParserStage.cs
@@ -1,0 +1,11 @@
+namespace CgfConverter.Diagnostics.ChunkScanning;
+
+public enum ChunkParserStage
+{
+    FileOpen,
+    FileHeader,
+    ChunkTable,
+    ChunkFactory,
+    ChunkRead,
+    ChunkSkip
+}

--- a/CgfConverter/Diagnostics/ChunkScanning/ChunkScanArgsHandler.cs
+++ b/CgfConverter/Diagnostics/ChunkScanning/ChunkScanArgsHandler.cs
@@ -1,0 +1,129 @@
+using System;
+using System.IO;
+using CgfConverter.Utilities;
+
+namespace CgfConverter.Diagnostics.ChunkScanning;
+
+public sealed class ChunkScanArgsHandler
+{
+    public ChunkScanOptions Options { get; } = new();
+
+    public int ProcessArgs(string[] args, TextWriter? errorWriter = null)
+    {
+        errorWriter ??= Console.Error;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i].ToLowerInvariant())
+            {
+                case "-recursive":
+                    Options.Recursive = true;
+                    break;
+                case "-format":
+                    if (!TryReadValue(args, ref i, errorWriter, "-format", out var format))
+                        return 1;
+                    if (!Enum.TryParse(format, true, out ChunkScanReportFormat parsedFormat))
+                    {
+                        errorWriter.WriteLine("Invalid scan report format '{0}'. Expected console, csv, or json.", format);
+                        return 1;
+                    }
+                    Options.Format = parsedFormat;
+                    break;
+                case "-out":
+                    if (!TryReadValue(args, ref i, errorWriter, "-out", out var outputPath))
+                        return 1;
+                    Options.OutputPath = outputPath;
+                    break;
+                case "-mt":
+                case "-maxthreads":
+                    if (!TryReadValue(args, ref i, errorWriter, args[i], out var maxThreadsText))
+                        return 1;
+                    if (!int.TryParse(maxThreadsText, out var maxThreads) || maxThreads < 0)
+                    {
+                        errorWriter.WriteLine("Invalid max thread count '{0}'. Expected a non-negative integer.", maxThreadsText);
+                        return 1;
+                    }
+                    Options.MaxThreads = maxThreads == 0 ? Environment.ProcessorCount : maxThreads;
+                    break;
+                case "-loglevel":
+                    if (!TryReadValue(args, ref i, errorWriter, "-loglevel", out var logLevel))
+                        return 1;
+                    if (!Enum.TryParse(logLevel, true, out LogLevelEnum parsedLevel))
+                    {
+                        errorWriter.WriteLine("Invalid log level '{0}'.", logLevel);
+                        return 1;
+                    }
+                    Options.LogLevel = parsedLevel;
+                    HelperMethods.LogLevel = parsedLevel;
+                    break;
+                case "-usage":
+                case "-help":
+                case "--help":
+                    PrintUsage(Console.Out);
+                    return 1;
+                default:
+                    if (args[i].StartsWith('-'))
+                    {
+                        errorWriter.WriteLine("Unknown scan option '{0}'.", args[i]);
+                        return 1;
+                    }
+                    Options.Inputs.Add(args[i]);
+                    break;
+            }
+        }
+
+        if (Options.Inputs.Count == 0)
+        {
+            errorWriter.WriteLine("scan-unknown-chunks requires at least one input file or directory.");
+            return 1;
+        }
+
+        if (Options.OutputPath is not null)
+            Options.Format = InferFormat(Options.OutputPath, Options.Format);
+
+        return 0;
+    }
+
+    public static void PrintUsage(TextWriter writer)
+    {
+        writer.WriteLine("cgf-converter scan-unknown-chunks <input> [options]");
+        writer.WriteLine();
+        writer.WriteLine("Options:");
+        writer.WriteLine("  -recursive        Recursively scan local directories.");
+        writer.WriteLine("  -format <fmt>     Output format: console, csv, or json.");
+        writer.WriteLine("  -out <file>       Write report to a file. .json/.csv infer format when -format is omitted.");
+        writer.WriteLine("  -mt <n>           Max threads. 0 = all cores.");
+        writer.WriteLine("  -loglevel <lvl>   Optional log level.");
+        writer.WriteLine();
+        writer.WriteLine("Scanned extensions:");
+        writer.WriteLine("  .cgf .cga .chr .skin .anim .soc .caf .dba");
+    }
+
+    private static bool TryReadValue(
+        string[] args,
+        ref int index,
+        TextWriter errorWriter,
+        string option,
+        out string value)
+    {
+        if (++index >= args.Length)
+        {
+            errorWriter.WriteLine("{0} requires a value.", option);
+            value = string.Empty;
+            return false;
+        }
+
+        value = args[index];
+        return true;
+    }
+
+    private static ChunkScanReportFormat InferFormat(string outputPath, ChunkScanReportFormat currentFormat)
+    {
+        return Path.GetExtension(outputPath).ToLowerInvariant() switch
+        {
+            ".json" => ChunkScanReportFormat.Json,
+            ".csv" => ChunkScanReportFormat.Csv,
+            _ => currentFormat
+        };
+    }
+}

--- a/CgfConverter/Diagnostics/ChunkScanning/ChunkScanCommand.cs
+++ b/CgfConverter/Diagnostics/ChunkScanning/ChunkScanCommand.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+
+namespace CgfConverter.Diagnostics.ChunkScanning;
+
+public static class ChunkScanCommand
+{
+    public static int Run(string[] args)
+    {
+        var argsHandler = new ChunkScanArgsHandler();
+        if (argsHandler.ProcessArgs(args) != 0)
+        {
+            ChunkScanArgsHandler.PrintUsage(Console.Error);
+            return 1;
+        }
+
+        try
+        {
+            var report = new UnknownChunkScanner().Scan(argsHandler.Options);
+            var writer = CreateWriter(argsHandler.Options.Format);
+
+            if (argsHandler.Options.OutputPath is null)
+            {
+                writer.Write(report, Console.Out);
+            }
+            else
+            {
+                using var output = new StreamWriter(argsHandler.Options.OutputPath);
+                writer.Write(report, output);
+                Console.WriteLine("Wrote {0} report: {1}", argsHandler.Options.Format.ToString().ToLowerInvariant(), argsHandler.Options.OutputPath);
+            }
+
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine("Failed to scan unknown chunks: {0}", ex.Message);
+            return 1;
+        }
+    }
+
+    private static IChunkScanReportWriter CreateWriter(ChunkScanReportFormat format)
+    {
+        return format switch
+        {
+            ChunkScanReportFormat.Csv => new CsvChunkScanReportWriter(),
+            ChunkScanReportFormat.Json => new JsonChunkScanReportWriter(),
+            _ => new ConsoleChunkScanReportWriter(),
+        };
+    }
+}

--- a/CgfConverter/Diagnostics/ChunkScanning/ChunkScanFileResult.cs
+++ b/CgfConverter/Diagnostics/ChunkScanning/ChunkScanFileResult.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace CgfConverter.Diagnostics.ChunkScanning;
+
+internal sealed record ChunkScanFileResult(
+    string InputPath,
+    string? FileSignature,
+    uint? FileVersion,
+    IReadOnlyList<ChunkIssueRecord> Records);

--- a/CgfConverter/Diagnostics/ChunkScanning/ChunkScanOptions.cs
+++ b/CgfConverter/Diagnostics/ChunkScanning/ChunkScanOptions.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using CgfConverter.Utilities;
+
+namespace CgfConverter.Diagnostics.ChunkScanning;
+
+public sealed class ChunkScanOptions
+{
+    public List<string> Inputs { get; } = [];
+    public bool Recursive { get; set; }
+    public ChunkScanReportFormat Format { get; set; } = ChunkScanReportFormat.Console;
+    public string? OutputPath { get; set; }
+    public int MaxThreads { get; set; } = Environment.ProcessorCount;
+    public LogLevelEnum? LogLevel { get; set; }
+}

--- a/CgfConverter/Diagnostics/ChunkScanning/ChunkScanReport.cs
+++ b/CgfConverter/Diagnostics/ChunkScanning/ChunkScanReport.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace CgfConverter.Diagnostics.ChunkScanning;
+
+public sealed record ChunkScanReport
+{
+    public string SchemaVersion { get; init; } = "1.0";
+    public DateTimeOffset GeneratedAtUtc { get; init; } = DateTimeOffset.UtcNow;
+    public IReadOnlyList<string> Inputs { get; init; } = [];
+    public required ChunkScanSummary Summary { get; init; }
+    public IReadOnlyList<ChunkIssueRecord> Records { get; init; } = [];
+}

--- a/CgfConverter/Diagnostics/ChunkScanning/ChunkScanReportFormat.cs
+++ b/CgfConverter/Diagnostics/ChunkScanning/ChunkScanReportFormat.cs
@@ -1,0 +1,8 @@
+namespace CgfConverter.Diagnostics.ChunkScanning;
+
+public enum ChunkScanReportFormat
+{
+    Console,
+    Csv,
+    Json
+}

--- a/CgfConverter/Diagnostics/ChunkScanning/ChunkScanSummary.cs
+++ b/CgfConverter/Diagnostics/ChunkScanning/ChunkScanSummary.cs
@@ -1,0 +1,12 @@
+namespace CgfConverter.Diagnostics.ChunkScanning;
+
+public sealed record ChunkScanSummary
+{
+    public int FilesDiscovered { get; init; }
+    public int FilesScanned { get; init; }
+    public int FilesWithIssues { get; init; }
+    public int UnknownChunkOccurrences { get; init; }
+    public int UnsupportedVersionOccurrences { get; init; }
+    public int ParseFailureOccurrences { get; init; }
+    public int ErrorFiles { get; init; }
+}

--- a/CgfConverter/Diagnostics/ChunkScanning/ConsoleChunkScanReportWriter.cs
+++ b/CgfConverter/Diagnostics/ChunkScanning/ConsoleChunkScanReportWriter.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace CgfConverter.Diagnostics.ChunkScanning;
+
+public sealed class ConsoleChunkScanReportWriter : IChunkScanReportWriter
+{
+    public void Write(ChunkScanReport report, TextWriter writer)
+    {
+        writer.WriteLine("Scanned {0} of {1} discovered file(s).", report.Summary.FilesScanned, report.Summary.FilesDiscovered);
+        writer.WriteLine("Files with issues: {0}", report.Summary.FilesWithIssues);
+        writer.WriteLine("Unknown chunk occurrences: {0}", report.Summary.UnknownChunkOccurrences);
+        writer.WriteLine("Unsupported chunk version occurrences: {0}", report.Summary.UnsupportedVersionOccurrences);
+        writer.WriteLine("Parse failure occurrences: {0}", report.Summary.ParseFailureOccurrences);
+        writer.WriteLine("Files with parse failures: {0}", report.Summary.ErrorFiles);
+
+        WriteGroupedSection(writer, "Top unknown chunk patterns:", report.Records
+            .Where(r => r.IssueKind == ChunkIssueKind.UnknownChunkType));
+        WriteGroupedSection(writer, "Top unsupported chunk version patterns:", report.Records
+            .Where(r => r.IssueKind == ChunkIssueKind.UnsupportedChunkVersion));
+
+        var failures = report.Records
+            .Where(r => r.IssueKind == ChunkIssueKind.ParseFailure)
+            .OrderBy(r => r.InputPath, StringComparer.InvariantCultureIgnoreCase)
+            .ThenBy(r => r.OccurrenceIndex ?? -1)
+            .Take(10)
+            .ToList();
+
+        if (failures.Count == 0)
+            return;
+
+        writer.WriteLine();
+        writer.WriteLine("Parse failure examples:");
+        foreach (var failure in failures)
+        {
+            writer.WriteLine(
+                "  {0} [{1}] {2}: {3}",
+                failure.InputPath,
+                failure.ParserStage,
+                failure.ExceptionType,
+                failure.ExceptionMessage);
+        }
+    }
+
+    private static void WriteGroupedSection(TextWriter writer, string title, IEnumerable<ChunkIssueRecord> records)
+    {
+        var groups = records
+            .GroupBy(r => new { r.ChunkTypeHex, r.ChunkTypeName, r.ChunkVersionHex })
+            .Select(g => new
+            {
+                g.Key.ChunkTypeHex,
+                g.Key.ChunkTypeName,
+                g.Key.ChunkVersionHex,
+                Count = g.Count(),
+                Files = g.Select(r => r.InputPath).Distinct(StringComparer.InvariantCultureIgnoreCase).Count(),
+                Example = g.Select(r => r.InputPath).OrderBy(path => path, StringComparer.InvariantCultureIgnoreCase).First()
+            })
+            .OrderByDescending(g => g.Count)
+            .ThenBy(g => g.ChunkTypeHex, StringComparer.InvariantCultureIgnoreCase)
+            .ThenBy(g => g.ChunkVersionHex, StringComparer.InvariantCultureIgnoreCase)
+            .Take(10)
+            .ToList();
+
+        if (groups.Count == 0)
+            return;
+
+        writer.WriteLine();
+        writer.WriteLine(title);
+        foreach (var group in groups)
+        {
+            writer.WriteLine(
+                "  {0} {1} version {2}: {3} occurrence(s) in {4} file(s), example {5}",
+                group.ChunkTypeHex,
+                group.ChunkTypeName is null ? string.Empty : $"({group.ChunkTypeName})",
+                group.ChunkVersionHex,
+                group.Count,
+                group.Files,
+                group.Example);
+        }
+    }
+}

--- a/CgfConverter/Diagnostics/ChunkScanning/CsvChunkScanReportWriter.cs
+++ b/CgfConverter/Diagnostics/ChunkScanning/CsvChunkScanReportWriter.cs
@@ -1,0 +1,79 @@
+using System.IO;
+using System.Linq;
+
+namespace CgfConverter.Diagnostics.ChunkScanning;
+
+public sealed class CsvChunkScanReportWriter : IChunkScanReportWriter
+{
+    private static readonly string[] Headers =
+    [
+        "issueKind",
+        "inputPath",
+        "relativePath",
+        "extension",
+        "modelFileName",
+        "fileSignature",
+        "fileVersion",
+        "chunkTypeValue",
+        "chunkTypeHex",
+        "chunkTypeName",
+        "chunkVersionRawHex",
+        "chunkVersionHex",
+        "chunkId",
+        "chunkIdIsGenerated",
+        "chunkOffset",
+        "chunkOffsetHex",
+        "chunkSize",
+        "chunkDataSize",
+        "occurrenceIndex",
+        "parserStage",
+        "exceptionType",
+        "exceptionMessage"
+    ];
+
+    public void Write(ChunkScanReport report, TextWriter writer)
+    {
+        writer.WriteLine(string.Join(",", Headers.Select(Escape)));
+
+        foreach (var record in report.Records)
+        {
+            var fields = new string?[]
+            {
+                record.IssueKind.ToString(),
+                record.InputPath,
+                record.RelativePath,
+                record.Extension,
+                record.ModelFileName,
+                record.FileSignature,
+                record.FileVersion?.ToString(),
+                record.ChunkTypeValue?.ToString(),
+                record.ChunkTypeHex,
+                record.ChunkTypeName,
+                record.ChunkVersionRawHex,
+                record.ChunkVersionHex,
+                record.ChunkId?.ToString(),
+                record.ChunkIdIsGenerated.ToString(),
+                record.ChunkOffset?.ToString(),
+                record.ChunkOffsetHex,
+                record.ChunkSize?.ToString(),
+                record.ChunkDataSize?.ToString(),
+                record.OccurrenceIndex?.ToString(),
+                record.ParserStage.ToString(),
+                record.ExceptionType,
+                record.ExceptionMessage
+            };
+            writer.WriteLine(string.Join(",", fields.Select(Escape)));
+        }
+    }
+
+    internal static string Escape(string? value)
+    {
+        if (value is null)
+            return string.Empty;
+
+        if (!value.Contains(',') && !value.Contains('"') && !value.Contains('\r') && !value.Contains('\n'))
+            return value;
+
+        return $"\"{value.Replace("\"", "\"\"")}\"";
+    }
+}

--- a/CgfConverter/Diagnostics/ChunkScanning/IChunkScanReportWriter.cs
+++ b/CgfConverter/Diagnostics/ChunkScanning/IChunkScanReportWriter.cs
@@ -1,0 +1,8 @@
+using System.IO;
+
+namespace CgfConverter.Diagnostics.ChunkScanning;
+
+public interface IChunkScanReportWriter
+{
+    void Write(ChunkScanReport report, TextWriter writer);
+}

--- a/CgfConverter/Diagnostics/ChunkScanning/JsonChunkScanReportWriter.cs
+++ b/CgfConverter/Diagnostics/ChunkScanning/JsonChunkScanReportWriter.cs
@@ -1,0 +1,21 @@
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace CgfConverter.Diagnostics.ChunkScanning;
+
+public sealed class JsonChunkScanReportWriter : IChunkScanReportWriter
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public void Write(ChunkScanReport report, TextWriter writer)
+    {
+        writer.Write(JsonSerializer.Serialize(report, Options));
+        writer.WriteLine();
+    }
+}

--- a/CgfConverter/Diagnostics/ChunkScanning/UnknownChunkScanner.cs
+++ b/CgfConverter/Diagnostics/ChunkScanning/UnknownChunkScanner.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using CgfConverter.CryEngineCore;
+
+namespace CgfConverter.Diagnostics.ChunkScanning;
+
+public sealed class UnknownChunkScanner
+{
+    private static readonly HashSet<string> SupportedExtensions = new(StringComparer.InvariantCultureIgnoreCase)
+    {
+        ".cgf",
+        ".cga",
+        ".chr",
+        ".skin",
+        ".anim",
+        ".soc",
+        ".caf",
+        ".dba"
+    };
+
+    public ChunkScanReport Scan(ChunkScanOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var inputs = EnumerateInputs(options);
+        var records = new List<ChunkIssueRecord>();
+        var filesScanned = 0;
+
+        // TODO: v2 - replace with Parallel.ForEach using options.MaxThreads
+        foreach (var input in inputs)
+        {
+            filesScanned++;
+            try
+            {
+                using var stream = File.OpenRead(input);
+                records.AddRange(Model.ScanChunkIssues(input, stream).Records);
+            }
+            catch (Exception ex)
+            {
+                records.Add(new ChunkIssueRecord
+                {
+                    IssueKind = ChunkIssueKind.ParseFailure,
+                    InputPath = input,
+                    RelativePath = null,
+                    Extension = Path.GetExtension(input).ToLowerInvariant(),
+                    ParserStage = ChunkParserStage.FileOpen,
+                    ExceptionType = ex.GetType().Name,
+                    ExceptionMessage = ex.Message
+                });
+            }
+        }
+
+        var orderedRecords = records
+            .OrderBy(r => r.InputPath, StringComparer.InvariantCultureIgnoreCase)
+            .ThenBy(r => r.OccurrenceIndex ?? -1)
+            .ThenBy(r => r.IssueKind)
+            .ToList();
+
+        var filesWithIssues = orderedRecords
+            .Select(r => r.InputPath)
+            .Distinct(StringComparer.InvariantCultureIgnoreCase)
+            .Count();
+
+        return new ChunkScanReport
+        {
+            Inputs = options.Inputs.ToList(),
+            Records = orderedRecords,
+            Summary = new ChunkScanSummary
+            {
+                FilesDiscovered = inputs.Count,
+                FilesScanned = filesScanned,
+                FilesWithIssues = filesWithIssues,
+                UnknownChunkOccurrences = orderedRecords.Count(r => r.IssueKind == ChunkIssueKind.UnknownChunkType),
+                UnsupportedVersionOccurrences = orderedRecords.Count(r => r.IssueKind == ChunkIssueKind.UnsupportedChunkVersion),
+                ParseFailureOccurrences = orderedRecords.Count(r => r.IssueKind == ChunkIssueKind.ParseFailure),
+                ErrorFiles = orderedRecords
+                    .Where(r => r.IssueKind == ChunkIssueKind.ParseFailure)
+                    .Select(r => r.InputPath)
+                    .Distinct(StringComparer.InvariantCultureIgnoreCase)
+                    .Count()
+            }
+        };
+    }
+
+    public IReadOnlyList<string> EnumerateInputs(ChunkScanOptions options)
+    {
+        var found = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+
+        foreach (var input in options.Inputs)
+        {
+            if (File.Exists(input))
+            {
+                AddIfSupported(found, Path.GetFullPath(input));
+                continue;
+            }
+
+            if (Directory.Exists(input))
+            {
+                var searchOption = options.Recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
+                foreach (var file in Directory.EnumerateFiles(input, "*.*", searchOption))
+                    AddIfSupported(found, Path.GetFullPath(file));
+                continue;
+            }
+
+            foreach (var file in ExpandLocalGlob(input))
+                AddIfSupported(found, Path.GetFullPath(file));
+        }
+
+        return found
+            .OrderBy(path => path, StringComparer.InvariantCultureIgnoreCase)
+            .ToList();
+    }
+
+    public static bool IsSupportedModelExtension(string path)
+    {
+        return SupportedExtensions.Contains(Path.GetExtension(path));
+    }
+
+    private static void AddIfSupported(HashSet<string> paths, string path)
+    {
+        if (IsSupportedModelExtension(path))
+            paths.Add(path);
+    }
+
+    private static IEnumerable<string> ExpandLocalGlob(string pattern)
+    {
+        if (!pattern.Contains('*') && !pattern.Contains('?'))
+            return [];
+
+        var directory = Path.GetDirectoryName(pattern);
+        if (string.IsNullOrWhiteSpace(directory))
+            directory = Directory.GetCurrentDirectory();
+
+        var filePattern = Path.GetFileName(pattern);
+        if (!Directory.Exists(directory))
+            return [];
+
+        return Directory.EnumerateFiles(directory, filePattern, SearchOption.TopDirectoryOnly);
+    }
+}

--- a/CgfConverter/Services/ArgsHandler.cs
+++ b/CgfConverter/Services/ArgsHandler.cs
@@ -431,6 +431,12 @@ public sealed class ArgsHandler
         Console.WriteLine("-throw:            Throw Exceptions to installed debugger.");
         Console.WriteLine("-dump:             Dump missing/bad chunk info for support.");
         Console.WriteLine();
+        Console.WriteLine(" Diagnostic commands:");
+        Console.WriteLine("cgf-converter scan-unknown-chunks <input> [options]");
+        Console.WriteLine("                   Scan .cgf .cga .chr .skin .anim .soc .caf .dba files for unknown or unsupported chunks.");
+        Console.WriteLine("                   Options: -recursive -format <console|csv|json> -out <file> -mt <n> -loglevel <lvl>");
+        Console.WriteLine("                   .json and .csv output paths infer report format when -format is omitted.");
+        Console.WriteLine();
     }
 
     public override string ToString() => $@"Input file: {InputFiles}, Object Dir: {string.Join(',', DataDir)}, Output file: {OutputFile}";

--- a/CgfConverterIntegrationTests/UnitTests/ChunkScanArgsHandlerTests.cs
+++ b/CgfConverterIntegrationTests/UnitTests/ChunkScanArgsHandlerTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.IO;
+using System.Linq;
+using CgfConverter.Diagnostics.ChunkScanning;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CgfConverterTests.UnitTests;
+
+[TestClass]
+[TestCategory("unit")]
+public class ChunkScanArgsHandlerTests
+{
+    [TestMethod]
+    public void ProcessArgs_DirectInput_AddsInput()
+    {
+        var handler = new ChunkScanArgsHandler();
+
+        var result = handler.ProcessArgs(["ship.cgf"]);
+
+        Assert.AreEqual(0, result);
+        Assert.AreEqual("ship.cgf", handler.Options.Inputs.Single());
+    }
+
+    [TestMethod]
+    public void ProcessArgs_MultipleInputs_AddsInputs()
+    {
+        var handler = new ChunkScanArgsHandler();
+
+        var result = handler.ProcessArgs(["ship.cgf", "ship.skin"]);
+
+        Assert.AreEqual(0, result);
+        Assert.AreEqual(2, handler.Options.Inputs.Count);
+    }
+
+    [TestMethod]
+    public void ProcessArgs_Recursive_SetsRecursive()
+    {
+        var handler = new ChunkScanArgsHandler();
+
+        var result = handler.ProcessArgs(["objects", "-recursive"]);
+
+        Assert.AreEqual(0, result);
+        Assert.IsTrue(handler.Options.Recursive);
+    }
+
+    [TestMethod]
+    public void ProcessArgs_FormatJson_SetsJson()
+    {
+        var handler = new ChunkScanArgsHandler();
+
+        var result = handler.ProcessArgs(["ship.cgf", "-format", "json"]);
+
+        Assert.AreEqual(0, result);
+        Assert.AreEqual(ChunkScanReportFormat.Json, handler.Options.Format);
+    }
+
+    [TestMethod]
+    public void ProcessArgs_FormatCsv_SetsCsv()
+    {
+        var handler = new ChunkScanArgsHandler();
+
+        var result = handler.ProcessArgs(["ship.cgf", "-format", "csv"]);
+
+        Assert.AreEqual(0, result);
+        Assert.AreEqual(ChunkScanReportFormat.Csv, handler.Options.Format);
+    }
+
+    [TestMethod]
+    public void ProcessArgs_OutJson_InfersJson()
+    {
+        var handler = new ChunkScanArgsHandler();
+
+        var result = handler.ProcessArgs(["ship.cgf", "-out", "report.json"]);
+
+        Assert.AreEqual(0, result);
+        Assert.AreEqual(ChunkScanReportFormat.Json, handler.Options.Format);
+    }
+
+    [TestMethod]
+    public void ProcessArgs_OutCsv_InfersCsv()
+    {
+        var handler = new ChunkScanArgsHandler();
+
+        var result = handler.ProcessArgs(["ship.cgf", "-out", "report.csv"]);
+
+        Assert.AreEqual(0, result);
+        Assert.AreEqual(ChunkScanReportFormat.Csv, handler.Options.Format);
+    }
+
+    [TestMethod]
+    public void ProcessArgs_InvalidFormat_ReturnsError()
+    {
+        var handler = new ChunkScanArgsHandler();
+
+        var result = handler.ProcessArgs(["ship.cgf", "-format", "xml"], TextWriter.Null);
+
+        Assert.AreEqual(1, result);
+    }
+
+    [TestMethod]
+    public void ProcessArgs_MaxThreadsZero_UsesProcessorCount()
+    {
+        var handler = new ChunkScanArgsHandler();
+
+        var result = handler.ProcessArgs(["ship.cgf", "-mt", "0"]);
+
+        Assert.AreEqual(0, result);
+        Assert.AreEqual(Environment.ProcessorCount, handler.Options.MaxThreads);
+    }
+
+    [TestMethod]
+    public void ProcessArgs_NegativeMaxThreads_ReturnsError()
+    {
+        var handler = new ChunkScanArgsHandler();
+
+        var result = handler.ProcessArgs(["ship.cgf", "-mt", "-1"], TextWriter.Null);
+
+        Assert.AreEqual(1, result);
+    }
+
+    [TestMethod]
+    public void ProcessArgs_NonNumericMaxThreads_ReturnsError()
+    {
+        var handler = new ChunkScanArgsHandler();
+
+        var result = handler.ProcessArgs(["ship.cgf", "-mt", "many"], TextWriter.Null);
+
+        Assert.AreEqual(1, result);
+    }
+
+    [TestMethod]
+    public void ProcessArgs_UnknownDashOption_ReturnsError()
+    {
+        var handler = new ChunkScanArgsHandler();
+
+        var result = handler.ProcessArgs(["ship.cgf", "-bad"], TextWriter.Null);
+
+        Assert.AreEqual(1, result);
+    }
+
+    [TestMethod]
+    public void ProcessArgs_NoInput_ReturnsError()
+    {
+        var handler = new ChunkScanArgsHandler();
+
+        var result = handler.ProcessArgs([], TextWriter.Null);
+
+        Assert.AreEqual(1, result);
+    }
+}

--- a/CgfConverterIntegrationTests/UnitTests/ChunkScanReportWriterTests.cs
+++ b/CgfConverterIntegrationTests/UnitTests/ChunkScanReportWriterTests.cs
@@ -1,0 +1,116 @@
+using System.IO;
+using System.Text.Json;
+using CgfConverter.Diagnostics.ChunkScanning;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CgfConverterTests.UnitTests;
+
+[TestClass]
+[TestCategory("unit")]
+public class ChunkScanReportWriterTests
+{
+    [TestMethod]
+    public void CsvWriter_WritesHeader()
+    {
+        using var writer = new StringWriter();
+
+        new CsvChunkScanReportWriter().Write(CreateReport(), writer);
+
+        StringAssert.StartsWith(writer.ToString(), "issueKind,inputPath,relativePath");
+    }
+
+    [TestMethod]
+    public void CsvWriter_EscapesComma()
+    {
+        using var writer = new StringWriter();
+
+        new CsvChunkScanReportWriter().Write(CreateReport(inputPath: "a,b.cgf"), writer);
+
+        StringAssert.Contains(writer.ToString(), "\"a,b.cgf\"");
+    }
+
+    [TestMethod]
+    public void CsvWriter_EscapesQuote()
+    {
+        using var writer = new StringWriter();
+
+        new CsvChunkScanReportWriter().Write(CreateReport(inputPath: "a\"b.cgf"), writer);
+
+        StringAssert.Contains(writer.ToString(), "\"a\"\"b.cgf\"");
+    }
+
+    [TestMethod]
+    public void CsvWriter_EscapesNewline()
+    {
+        using var writer = new StringWriter();
+
+        new CsvChunkScanReportWriter().Write(CreateReport(exceptionMessage: "line1\nline2"), writer);
+
+        StringAssert.Contains(writer.ToString(), "\"line1\nline2\"");
+    }
+
+    [TestMethod]
+    public void JsonWriter_ContainsSchemaVersionSummaryAndRecords()
+    {
+        using var writer = new StringWriter();
+
+        new JsonChunkScanReportWriter().Write(CreateReport(), writer);
+        using var document = JsonDocument.Parse(writer.ToString());
+
+        Assert.IsTrue(document.RootElement.TryGetProperty("schemaVersion", out var schemaVersion));
+        Assert.AreEqual("1.0", schemaVersion.GetString());
+        Assert.IsTrue(document.RootElement.TryGetProperty("generatedAtUtc", out _));
+        Assert.IsTrue(document.RootElement.TryGetProperty("inputs", out _));
+        Assert.IsTrue(document.RootElement.TryGetProperty("summary", out _));
+        Assert.IsTrue(document.RootElement.TryGetProperty("records", out _));
+    }
+
+    [TestMethod]
+    public void ConsoleWriter_ContainsSummaryCountLines()
+    {
+        using var writer = new StringWriter();
+
+        new ConsoleChunkScanReportWriter().Write(CreateReport(), writer);
+        var output = writer.ToString();
+
+        StringAssert.Contains(output, "Scanned 1 of 1 discovered file(s).");
+        StringAssert.Contains(output, "Unknown chunk occurrences: 1");
+        StringAssert.Contains(output, "Files with issues: 1");
+    }
+
+    private static ChunkScanReport CreateReport(
+        string inputPath = "ship.cgf",
+        string? exceptionMessage = null)
+    {
+        var record = new ChunkIssueRecord
+        {
+            IssueKind = ChunkIssueKind.UnknownChunkType,
+            InputPath = inputPath,
+            Extension = ".cgf",
+            FileSignature = "CrCh",
+            FileVersion = 0x746,
+            ChunkTypeValue = 0xCCCC2333,
+            ChunkTypeHex = "0xCCCC2333",
+            ChunkVersionRawHex = "0x1",
+            ChunkVersionHex = "0x1",
+            ChunkOffset = 32,
+            ChunkOffsetHex = "0x20",
+            OccurrenceIndex = 0,
+            ParserStage = ChunkParserStage.ChunkFactory,
+            ExceptionMessage = exceptionMessage
+        };
+
+        return new ChunkScanReport
+        {
+            Inputs = [inputPath],
+            Records = [record],
+            Summary = new ChunkScanSummary
+            {
+                FilesDiscovered = 1,
+                FilesScanned = 1,
+                FilesWithIssues = 1,
+                UnknownChunkOccurrences = 1
+            }
+        };
+    }
+}

--- a/CgfConverterIntegrationTests/UnitTests/ModelChunkScanTests.cs
+++ b/CgfConverterIntegrationTests/UnitTests/ModelChunkScanTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.IO;
+using System.Linq;
+using CgfConverter;
+using CgfConverter.Diagnostics.ChunkScanning;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CgfConverterTests.UnitTests;
+
+[TestClass]
+[TestCategory("unit")]
+public class ModelChunkScanTests
+{
+    [TestMethod]
+    public void Scan_SyntheticUnknownChunk_RecordsUnknownChunkType()
+    {
+        using var temp = TempModelFile.Create(BuildCrChFile([(0x3333, 0x0001)]));
+
+        var report = new UnknownChunkScanner().Scan(new ChunkScanOptions
+        {
+            Inputs = { temp.Path }
+        });
+
+        Assert.AreEqual(1, report.Summary.FilesScanned);
+        Assert.AreEqual(1, report.Summary.UnknownChunkOccurrences);
+        Assert.AreEqual(ChunkIssueKind.UnknownChunkType, report.Records.Single().IssueKind);
+        Assert.AreEqual(ChunkParserStage.ChunkFactory, report.Records.Single().ParserStage);
+    }
+
+    [TestMethod]
+    public void Scan_SyntheticUnsupportedKnownChunkVersion_RecordsUnsupportedChunkVersion()
+    {
+        using var temp = TempModelFile.Create(BuildCrChFile([(0x1000, 0xFFFF)]));
+
+        var report = new UnknownChunkScanner().Scan(new ChunkScanOptions
+        {
+            Inputs = { temp.Path }
+        });
+
+        Assert.AreEqual(1, report.Summary.UnsupportedVersionOccurrences);
+        Assert.AreEqual(ChunkIssueKind.UnsupportedChunkVersion, report.Records.Single().IssueKind);
+        Assert.AreEqual(ChunkParserStage.ChunkFactory, report.Records.Single().ParserStage);
+        Assert.AreEqual(((uint)ChunkType.Mesh).ToString(), report.Records.Single().ChunkTypeValue?.ToString());
+    }
+
+    [TestMethod]
+    public void Scan_InvalidHeader_RecordsParseFailureAtFileHeader()
+    {
+        using var temp = TempModelFile.Create([0x01, 0x02, 0x03]);
+
+        var report = new UnknownChunkScanner().Scan(new ChunkScanOptions
+        {
+            Inputs = { temp.Path }
+        });
+
+        Assert.AreEqual(1, report.Summary.ParseFailureOccurrences);
+        Assert.AreEqual(ChunkParserStage.FileHeader, report.Records.Single().ParserStage);
+    }
+
+    [TestMethod]
+    public void Scan_MalformedChunkTable_RecordsParseFailureAtChunkTable()
+    {
+        using var temp = TempModelFile.Create(BuildCrChHeaderOnly(chunkTableOffset: 128, numChunks: 1));
+
+        var report = new UnknownChunkScanner().Scan(new ChunkScanOptions
+        {
+            Inputs = { temp.Path }
+        });
+
+        Assert.AreEqual(1, report.Summary.ParseFailureOccurrences);
+        Assert.AreEqual(ChunkParserStage.ChunkTable, report.Records.Single().ParserStage);
+    }
+
+    private static byte[] BuildCrChFile((ushort TypeLow, ushort Version)[] chunks)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream);
+        var chunkTableOffset = 16u;
+        var bodyOffset = chunkTableOffset + (uint)(chunks.Length * 16);
+
+        writer.Write("CrCh"u8.ToArray());
+        writer.Write((uint)FileVersion.x0746);
+        writer.Write((uint)chunks.Length);
+        writer.Write((int)chunkTableOffset);
+
+        for (var i = 0; i < chunks.Length; i++)
+        {
+            writer.Write(chunks[i].TypeLow);
+            writer.Write(chunks[i].Version);
+            writer.Write(i + 1);
+            writer.Write(0u);
+            writer.Write(bodyOffset);
+        }
+
+        while (stream.Length < bodyOffset)
+            writer.Write((byte)0);
+
+        return stream.ToArray();
+    }
+
+    private static byte[] BuildCrChHeaderOnly(uint chunkTableOffset, uint numChunks)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream);
+
+        writer.Write("CrCh"u8.ToArray());
+        writer.Write((uint)FileVersion.x0746);
+        writer.Write(numChunks);
+        writer.Write((int)chunkTableOffset);
+
+        return stream.ToArray();
+    }
+
+    private sealed class TempModelFile : IDisposable
+    {
+        public string Path { get; }
+
+        private TempModelFile(byte[] contents)
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"{Guid.NewGuid():N}.cgf");
+            File.WriteAllBytes(Path, contents);
+        }
+
+        public static TempModelFile Create(byte[] contents) => new(contents);
+
+        public void Dispose()
+        {
+            if (File.Exists(Path))
+                File.Delete(Path);
+        }
+    }
+}

--- a/CgfConverterIntegrationTests/UnitTests/UnknownChunkScannerTests.cs
+++ b/CgfConverterIntegrationTests/UnitTests/UnknownChunkScannerTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.IO;
+using System.Linq;
+using CgfConverter.Diagnostics.ChunkScanning;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CgfConverterTests.UnitTests;
+
+[TestClass]
+[TestCategory("unit")]
+public class UnknownChunkScannerTests
+{
+    [TestMethod]
+    public void IsSupportedModelExtension_IncludesSupportedExtensionsCaseInsensitively()
+    {
+        Assert.IsTrue(UnknownChunkScanner.IsSupportedModelExtension("ship.CGF"));
+        Assert.IsTrue(UnknownChunkScanner.IsSupportedModelExtension("ship.cga"));
+        Assert.IsTrue(UnknownChunkScanner.IsSupportedModelExtension("ship.chr"));
+        Assert.IsTrue(UnknownChunkScanner.IsSupportedModelExtension("ship.skin"));
+        Assert.IsTrue(UnknownChunkScanner.IsSupportedModelExtension("ship.anim"));
+        Assert.IsTrue(UnknownChunkScanner.IsSupportedModelExtension("ship.soc"));
+        Assert.IsTrue(UnknownChunkScanner.IsSupportedModelExtension("ship.caf"));
+        Assert.IsTrue(UnknownChunkScanner.IsSupportedModelExtension("ship.dba"));
+    }
+
+    [TestMethod]
+    public void IsSupportedModelExtension_ExcludesUnsupportedExtensions()
+    {
+        Assert.IsFalse(UnknownChunkScanner.IsSupportedModelExtension("texture.dds"));
+        Assert.IsFalse(UnknownChunkScanner.IsSupportedModelExtension("material.mtl"));
+        Assert.IsFalse(UnknownChunkScanner.IsSupportedModelExtension("entity.xml"));
+        Assert.IsFalse(UnknownChunkScanner.IsSupportedModelExtension("leveldata.xml"));
+    }
+
+    [TestMethod]
+    public void EnumerateInputs_DirectFile_IncludesSupportedFile()
+    {
+        using var temp = TempDirectory.Create();
+        var file = temp.WriteFile("ship.cgf", []);
+
+        var result = new UnknownChunkScanner().EnumerateInputs(new ChunkScanOptions
+        {
+            Inputs = { file }
+        });
+
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual(Path.GetFullPath(file), result[0]);
+    }
+
+    [TestMethod]
+    public void EnumerateInputs_DirectoryWithoutRecursive_FindsOnlyTopLevelSupportedFiles()
+    {
+        using var temp = TempDirectory.Create();
+        var top = temp.WriteFile("ship.cgf", []);
+        temp.WriteFile("texture.dds", []);
+        temp.WriteFile(Path.Combine("nested", "nested.cgf"), []);
+
+        var result = new UnknownChunkScanner().EnumerateInputs(new ChunkScanOptions
+        {
+            Inputs = { temp.Path }
+        });
+
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual(Path.GetFullPath(top), result[0]);
+    }
+
+    [TestMethod]
+    public void EnumerateInputs_DirectoryWithRecursive_FindsNestedSupportedFiles()
+    {
+        using var temp = TempDirectory.Create();
+        var top = temp.WriteFile("ship.cgf", []);
+        var nested = temp.WriteFile(Path.Combine("nested", "nested.skin"), []);
+
+        var result = new UnknownChunkScanner().EnumerateInputs(new ChunkScanOptions
+        {
+            Inputs = { temp.Path },
+            Recursive = true
+        });
+
+        CollectionAssert.AreEquivalent(
+            new[] { Path.GetFullPath(top), Path.GetFullPath(nested) },
+            result.ToArray());
+    }
+
+    [TestMethod]
+    public void EnumerateInputs_DuplicatePaths_DeDuplicates()
+    {
+        using var temp = TempDirectory.Create();
+        var file = temp.WriteFile("ship.cgf", []);
+
+        var result = new UnknownChunkScanner().EnumerateInputs(new ChunkScanOptions
+        {
+            Inputs = { file, file }
+        });
+
+        Assert.AreEqual(1, result.Count);
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+        private TempDirectory()
+        {
+            Directory.CreateDirectory(Path);
+        }
+
+        public static TempDirectory Create() => new();
+
+        public string WriteFile(string relativePath, byte[] content)
+        {
+            var path = System.IO.Path.Combine(Path, relativePath);
+            Directory.CreateDirectory(System.IO.Path.GetDirectoryName(path)!);
+            File.WriteAllBytes(path, content);
+            return path;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, true);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ cgf-converter [-usage] | <.cgf file> [-outputfile <output file>] [-objectdir <Ob
 -throw:           Throw Exceptions to installed debugger
 ```
 
+### Building from source
+
+Building from source requires the .NET 9 SDK. The CLI project is `cgf-converter`.
+
+```
+dotnet build "Cryengine Converter.sln"
+```
+
+Local build output may include warnings such as an ImageSharp vulnerability advisory and a Microsoft.XmlSerializer.Generator / SGEN warning. These warnings were observed during local build verification and do not prevent the solution from building.
+
+Developer documentation: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+
 Ok, so how do you actually **USE** it?
 
 I'm going to assume you've already taken a Cryengine based game (Mechwarrior Online, Star Citizen, etc) and extracted the `.pak` files into a directory structure that essentially mimics a Cryengine layout.

--- a/cgf-converter/cgf-converter.cs
+++ b/cgf-converter/cgf-converter.cs
@@ -1,4 +1,5 @@
 ﻿using CgfConverter.Renderers;
+using CgfConverter.Diagnostics.ChunkScanning;
 using CgfConverter.Renderers.Collada;
 using CgfConverter.Renderers.Gltf;
 using CgfConverter.Renderers.Wavefront;
@@ -36,6 +37,9 @@ public class Program
         var customCulture = (CultureInfo)Thread.CurrentThread.CurrentCulture.Clone();
         customCulture.NumberFormat.NumberDecimalSeparator = ".";
         Thread.CurrentThread.CurrentCulture = customCulture;
+
+        if (args.Length > 0 && args[0].Equals("scan-unknown-chunks", StringComparison.OrdinalIgnoreCase))
+            return ChunkScanCommand.Run(args.Skip(1).ToArray());
 
         var argsHandler = new ArgsHandler();
         var numErrorsOccurred = argsHandler.ProcessArgs(args);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,77 @@
+# CgfConverter Architecture
+
+## Overview
+
+CgfConverter currently converts CryEngine / Lumberyard-style assets into more portable 3D formats. As implemented, it reads model, material, texture, animation-related, and terrain data from game-like asset layouts, including Star Citizen formats where supported, and writes output through renderer-specific export paths.
+
+## Project layout
+
+| Project | Role | Target / notes |
+| --- | --- | --- |
+| `cgf-converter` | Command-line executable and conversion entry point. | .NET executable; references the `CgfConverter` library. |
+| `CgfConverter` | Core parser, model representation, material handling, texture handling, pack-file access, and renderers. | .NET library; contains most implementation code. |
+| `CgfConverterIntegrationTests` | Unit and integration tests for parsing, conversion, math utilities, XML handling, and renderer output. | Integration tests may require local game files that are not included in the repository. |
+| `CgfConverterTestingConsole` | Ad hoc developer console for local parser experiments. | Uses local paths and is not the public CLI. |
+
+## Data flow
+
+```text
+Input files
+  -> CLI argument parsing
+  -> CryEngine orchestration
+  -> Model / chunk parsing
+  -> material and texture resolution
+  -> renderer
+  -> output files
+```
+
+Renderer families currently include Collada, glTF / GLB, Wavefront OBJ, and USD-related code. Existing README text marks OBJ as no longer supported, so it should be treated as deprecated. Existing README text also describes USD as work in progress.
+
+## Key types
+
+| Type | Namespace / path | Role |
+| --- | --- | --- |
+| `CryEngine` | `CgfConverter/CryEngine/CryEngine.cs` | Orchestrates model loading, sidecar discovery, material creation, node structure, skinning, and animation discovery for model files. |
+| `Model` | `CgfConverter/CryEngineCore/Model.cs` | Represents one parsed model or animation container and owns the chunk map for that file. |
+| `Chunk` | `CgfConverter/CryEngineCore/Chunks/Chunk.cs` | Base type and factory for versioned chunk readers. |
+| `IRenderer` | `CgfConverter/Renderers/IRenderer.cs` | Renderer interface used by output implementations. |
+| `ArgsHandler` | `CgfConverter/Services/ArgsHandler.cs` | Current CLI argument parser and holder for conversion options. |
+| `CascadedPackFileSystem` | `CgfConverter/PackFileSystem/CascadedPackFileSystem.cs` | Provides layered file lookup over real directories and supported pack-file sources. |
+| `ColladaModelRenderer` | `CgfConverter/Renderers/Collada/ColladaModelRenderer.cs` | Writes Collada model output. |
+| `GltfModelRenderer` | `CgfConverter/Renderers/Gltf/GltfModelRenderer.cs` | Writes glTF / GLB model output. |
+
+## Chunk system
+
+CryEngine model files are organized as chunks. A chunk is a typed binary record such as mesh data, node hierarchy data, material name data, skinning data, animation controller data, or a game-specific variant of those structures.
+
+Version-specific chunk classes exist because the same conceptual chunk can have different binary layouts across engine versions, games, and Star Citizen format updates. The `Chunk` factory chooses an implementation based on chunk type and version, and falls back to `ChunkUnknown` for unrecognized chunk types.
+
+Chunk classes live under `CgfConverter/CryEngineCore/Chunks`. Shared chunk identifiers and related enums live in `CgfConverter/Enums/Enums.cs`. When an asset format changes, these files are usually the first place to inspect.
+
+## Renderers
+
+Renderers translate the parsed `CryEngine` or terrain data into output formats. The command-line entry point selects renderer implementations based on parsed arguments and then calls `IRenderer.Render()`.
+
+`IRenderer` is the current extension point for output formats. Collada is described in the existing README as the default and most feature-complete path. glTF / GLB output is supported as implemented in the CLI and renderer code.
+
+## CLI parsing
+
+`ArgsHandler` is the current CLI parsing location. This document intentionally does not provide a full CLI reference; a focused CLI reference would be better handled in a later documentation PR.
+
+## Testing
+
+The repository contains unit tests and integration tests. Unit tests cover utility behavior and parser support that can run without a local game asset depot. Integration tests may require local game assets or Star Citizen installation/extraction files; `CONTRIBUTING.md` notes that those files are not included in the repository.
+
+Verified unit-test command:
+
+```powershell
+dotnet test --filter TestCategory=unit
+```
+
+## Areas under active development
+
+As of this repository state, existing docs and code comments indicate continued work around animation export, including CAF-related support. Existing README text also identifies USD output as work in progress.
+
+## Build output notes
+
+Local build output may include warnings such as an ImageSharp vulnerability advisory and a Microsoft.XmlSerializer.Generator / SGEN warning. These warnings were observed during local build verification and do not prevent the solution from building.


### PR DESCRIPTION
## Summary
PR Heffay Chunk Detective - Noir Edition,
adds a dedicated diagnostic command for finding unknown and unsupported CryEngine chunk data.
PR probably needs some fine tuning and addition documentation, the goal was tossed between two hungry pigs as they fought each other on the best solutions until a hybrid solution was implemented. Hopefully it was not implemented poorly and we can discover all unknown chunks successfully in time to catch them in the act.

```powershell
cgf-converter scan-unknown-chunks <input> [options]
```

Internally, I have been calling this **Heffay Chunk Detective - Noir Edition** because the goal is to make mystery chunks easier to track down after game format changes.

This PR is intended to help maintainers and contributors quickly identify which assets contain chunk types or chunk versions the converter does not currently understand. That should make future Star Citizen / CryEngine format update triage easier, especially after patches where CIG changes binary layouts or introduces new chunk variants.

## Why this is useful

When game data changes, the first hard part is often figuring out:

- Which files are affected?
- Which chunk type changed?
- Is it a totally unknown chunk type?
- Is it a known chunk type with a new unsupported version?
- Is the failure happening while reading the file header, chunk table, chunk factory, chunk body, or stream alignment?
- How many assets are affected?
- Are the affected assets concentrated in one file category, such as `.skin`, `.cga`, `.cgf`, `.caf`, etc.?

This PR adds a scanner that answers those questions without running the normal export/render pipeline.

## New command

```powershell
cgf-converter scan-unknown-chunks <input> [options]
```

Options:

```text
-recursive        Recursively scan local directories.
-format <fmt>     Output format: console, csv, or json.
-out <file>       Write report to a file. .json/.csv infer format when -format is omitted.
-mt <n>           Max threads. 0 = all cores.
-loglevel <lvl>   Optional log level.
```

Supported scanned extensions:

```text
.cgf .cga .chr .skin .anim .soc .caf .dba
```

Examples:

```powershell
# Show usage / validation
cgf-converter scan-unknown-chunks

# Scan one file and print a console summary
cgf-converter scan-unknown-chunks "D:\SC\Data\Objects\example.cgf"

# Recursively scan an extracted asset directory and write JSON
cgf-converter scan-unknown-chunks "D:\SC\Data\Objects" -recursive -format json -out "D:\reports\unknown_chunks.json"

# Infer JSON format from output extension
cgf-converter scan-unknown-chunks "D:\SC\Data\Objects" -recursive -out "D:\reports\unknown_chunks.json"

# Write CSV for spreadsheet/pivot-table investigation
cgf-converter scan-unknown-chunks "D:\SC\Data\Objects" -recursive -out "D:\reports\unknown_chunks.csv"
```

## What the scanner reports

The scanner records three kinds of issues:

### `UnknownChunkType`

A chunk type value was not recognized by the chunk factory and became `ChunkUnknown`.

This helps identify entirely new chunk type values.

### `UnsupportedChunkVersion`

A chunk type is known, but the version is not implemented and currently throws a `NotSupportedException`.

This is especially useful when an existing chunk layout changes between game builds.

### `ParseFailure`

The scanner encountered a file open, file header, chunk table, chunk factory, chunk read, or chunk skip failure.

This helps distinguish unknown chunk/version cases from more general parsing failures.

## Output formats

### Console

The console output is intended for quick human triage. It summarizes counts and grouped chunk type/version patterns rather than dumping every issue row for huge scans.

### CSV

CSV output writes one row per issue and is intended for spreadsheet filtering, sorting, pivot tables, and community investigation.

CSV escaping handles commas, quotes, carriage returns, and newlines.

### JSON

JSON output is intended for automated comparison between builds.

The root object includes:

```json
{
  "schemaVersion": "1.0",
  "generatedAtUtc": "...",
  "inputs": [],
  "summary": {},
  "records": []
}
```

The schema version is a string so future report changes can use versions such as `"1.1"` or `"2.0"`.

## Parser behavior and safety

This PR intentionally keeps normal conversion/export behavior unchanged.

Normal conversion still uses the existing flow:

```text
ArgsHandler
  -> Program.Run
  -> ExportSingleModel / ExportSingleTerrain
  -> CryEngine / CryTerrain
  -> renderers
```

The new scanner uses a separate diagnostic flow:

```text
Program.Main
  -> scan-unknown-chunks early command branch
  -> ChunkScanCommand
  -> UnknownChunkScanner
  -> scanner-only Model helper
  -> report writer
```

The scanner command is detected before normal `ArgsHandler.ProcessArgs`, so it does not fall through into normal conversion/export behavior.

## Scanner-only parsing

A scanner-only partial class was added:

```text
CgfConverter/CryEngineCore/Model.Scanner.cs
```

`Model.cs` was changed to `partial` so the scanner helper can reuse scanner-only access without making parser internals public.

The scanner helper:

- reads the file header
- reads the chunk table
- loops chunk headers
- calls `Chunk.New(...)` in scanner-only try/catch logic
- records `UnsupportedChunkVersion` when a known type has an unsupported version
- records `UnknownChunkType` when `ChunkUnknown` is created
- calls `chunk.Load(...)`, `chunk.Read(...)`, and `chunk.SkipBytes(...)` in scanner-only try/catch blocks
- records `ParseFailure` for read/skip failures
- does not run renderers
- does not build output models
- does not store raw chunk bytes

The normal `Model.FromStream`, `Load`, and `ReadChunks` behavior is not changed.

## Files added

Core diagnostic files:

```text
CgfConverter/Diagnostics/ChunkScanning/ChunkIssueKind.cs
CgfConverter/Diagnostics/ChunkScanning/ChunkIssueRecord.cs
CgfConverter/Diagnostics/ChunkScanning/ChunkParserStage.cs
CgfConverter/Diagnostics/ChunkScanning/ChunkScanArgsHandler.cs
CgfConverter/Diagnostics/ChunkScanning/ChunkScanCommand.cs
CgfConverter/Diagnostics/ChunkScanning/ChunkScanFileResult.cs
CgfConverter/Diagnostics/ChunkScanning/ChunkScanOptions.cs
CgfConverter/Diagnostics/ChunkScanning/ChunkScanReport.cs
CgfConverter/Diagnostics/ChunkScanning/ChunkScanReportFormat.cs
CgfConverter/Diagnostics/ChunkScanning/ChunkScanSummary.cs
CgfConverter/Diagnostics/ChunkScanning/ConsoleChunkScanReportWriter.cs
CgfConverter/Diagnostics/ChunkScanning/CsvChunkScanReportWriter.cs
CgfConverter/Diagnostics/ChunkScanning/IChunkScanReportWriter.cs
CgfConverter/Diagnostics/ChunkScanning/JsonChunkScanReportWriter.cs
CgfConverter/Diagnostics/ChunkScanning/UnknownChunkScanner.cs
CgfConverter/CryEngineCore/Model.Scanner.cs
```

Tests added:

```text
CgfConverterIntegrationTests/UnitTests/ChunkScanArgsHandlerTests.cs
CgfConverterIntegrationTests/UnitTests/ChunkScanReportWriterTests.cs
CgfConverterIntegrationTests/UnitTests/ModelChunkScanTests.cs
CgfConverterIntegrationTests/UnitTests/UnknownChunkScannerTests.cs
```

Existing files changed:

```text
CgfConverter/CryEngineCore/Model.cs
CgfConverter/Services/ArgsHandler.cs
cgf-converter/cgf-converter.cs
```

## Notes on threading

`-mt` is parsed and validated. `-mt 0` maps to `Environment.ProcessorCount`.

For v1, scanning remains sequential to avoid introducing thread-safety risk around parser internals. A TODO was added for a future pass to replace the scan loop with bounded parallel scanning using `options.MaxThreads`.

## Out of scope for this PR

This PR intentionally does **not** add:

- raw chunk byte capture
- raw hex sampling
- baseline known-unknown databases
- P4K direct scanning
- terrain `leveldata.xml` scanning
- CI fail-on-issues behavior
- package updates
- workflow changes
- renderer changes
- normal conversion behavior changes

## Verification

Build:

```powershell
D:\dev\dotnet\dotnet.exe build "Cryengine Converter.sln"
```

Result:

```text
Build succeeded.
0 errors.
```

Unit tests:

```powershell
D:\dev\dotnet\dotnet.exe test --filter TestCategory=unit
```

Result:

```text
Failed: 0, Passed: 110, Skipped: 0, Total: 110
```

Manual smoke tests:

```powershell
D:\dev\dotnet\dotnet.exe run --project cgf-converter -- scan-unknown-chunks
```

Result: prints expected validation error and usage because no input was provided.

```powershell
D:\dev\dotnet\dotnet.exe run --project cgf-converter -- scan-unknown-chunks . -recursive -format json -out D:\dev\scdata\work\cryengine_converter_docs\heffay_smoke_report.json
```

Result: writes a JSON report successfully.

Sample output from the smoke report:

```json
{
  "schemaVersion": "1.0",
  "generatedAtUtc": "2026-05-09T23:48:18.1385099+00:00",
  "inputs": [
    "."
  ],
  "summary": {
    "filesDiscovered": 0,
    "filesScanned": 0,
    "filesWithIssues": 0,
    "unknownChunkOccurrences": 0,
    "unsupportedVersionOccurrences": 0,
    "parseFailureOccurrences": 0,
    "errorFiles": 0
  },
  "records": []
}
```

The source repo itself does not contain `.cgf`, `.cga`, `.chr`, `.skin`, `.anim`, `.soc`, or `.dba` files, so `filesDiscovered: 0` is expected for that smoke test.

## Notes on warnings

The build may show existing warnings such as the ImageSharp advisory and Microsoft.XmlSerializer.Generator / SGEN warning. This PR does not modify packages or build tooling and does not attempt to address unrelated existing warnings.

## Review notes

The goal of this PR is to provide a clean diagnostic tool that makes unknown chunk investigation repeatable.

It should help turn “something changed in the build” into a concrete report showing which chunk type/version patterns appeared and which files are affected.
