### PR TITLE
Migrate code signing to SignPath OSS org + installer fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,16 +135,28 @@ jobs:
           output-artifact-directory: cgf-converter\bin\Release\net9.0\win-x64\publish\signed
 
       - name: Replace unsigned exe with signed
-        # SignPath returns the signed artifact in the same envelope it received
-        # (zip, since our artifact config wraps in <zip-file>). Extract, then
-        # overwrite the original.
+        # SignPath's action may return the signed PE bare, or wrapped in a zip,
+        # or nested under a subdirectory named after the upload artifact. Be
+        # tolerant: dump the tree for diagnostics, then locate cgf-converter.exe
+        # wherever it actually landed and copy it over the unsigned original.
         shell: pwsh
         run: |
           $signedDir = "cgf-converter\bin\Release\net9.0\win-x64\publish\signed"
-          $zip = Get-ChildItem "$signedDir\*.zip" | Select-Object -First 1
-          if (-not $zip) { Write-Error "No signed zip found in $signedDir"; exit 1 }
-          Expand-Archive -Path $zip.FullName -DestinationPath "$signedDir\extracted" -Force
-          Copy-Item "$signedDir\extracted\cgf-converter.exe" `
+          Write-Host "Contents of $signedDir :"
+          Get-ChildItem $signedDir -Recurse | Select-Object FullName, Length | Format-Table -AutoSize
+
+          # If a zip is present, expand it
+          $zip = Get-ChildItem "$signedDir\*.zip" -ErrorAction SilentlyContinue | Select-Object -First 1
+          if ($zip) {
+            Write-Host "Found zip $($zip.FullName); extracting..."
+            Expand-Archive -Path $zip.FullName -DestinationPath "$signedDir\extracted" -Force
+          }
+
+          # Find the signed exe wherever it ended up
+          $signed = Get-ChildItem $signedDir -Recurse -Filter cgf-converter.exe | Select-Object -First 1
+          if (-not $signed) { Write-Error "Signed cgf-converter.exe not found under $signedDir"; exit 1 }
+          Write-Host "Using signed exe at $($signed.FullName)"
+          Copy-Item $signed.FullName `
                     "cgf-converter\bin\Release\net9.0\win-x64\publish\cgf-converter.exe" -Force
 
       - name: Compile installer with Inno Setup
@@ -182,18 +194,24 @@ jobs:
           output-artifact-directory: installer\output\signed
 
       - name: Replace unsigned installer with signed
-        # SignPath returns the signed artifact in the same envelope it received
-        # (zip, since our artifact config wraps in <zip-file>). Extract, then
-        # overwrite the original.
+        # See "Replace unsigned exe with signed" comment above — same logic.
         shell: pwsh
         run: |
           $signedDir = "installer\output\signed"
-          $zip = Get-ChildItem "$signedDir\*.zip" | Select-Object -First 1
-          if (-not $zip) { Write-Error "No signed zip found in $signedDir"; exit 1 }
-          Expand-Archive -Path $zip.FullName -DestinationPath "$signedDir\extracted" -Force
           $installer = "cgf-converter-setup-${{ steps.version.outputs.version }}.exe"
-          Copy-Item "$signedDir\extracted\$installer" `
-                    "installer\output\$installer" -Force
+          Write-Host "Contents of $signedDir :"
+          Get-ChildItem $signedDir -Recurse | Select-Object FullName, Length | Format-Table -AutoSize
+
+          $zip = Get-ChildItem "$signedDir\*.zip" -ErrorAction SilentlyContinue | Select-Object -First 1
+          if ($zip) {
+            Write-Host "Found zip $($zip.FullName); extracting..."
+            Expand-Archive -Path $zip.FullName -DestinationPath "$signedDir\extracted" -Force
+          }
+
+          $signed = Get-ChildItem $signedDir -Recurse -Filter $installer | Select-Object -First 1
+          if (-not $signed) { Write-Error "Signed $installer not found under $signedDir"; exit 1 }
+          Write-Host "Using signed installer at $($signed.FullName)"
+          Copy-Item $signed.FullName "installer\output\$installer" -Force
 
       - name: Stage release assets
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,36 @@ permissions:
   contents: write   # needed to create releases and upload assets
   actions: read     # needed for SignPath action to read artifact metadata
 
+# Serialize release runs. An accidental tag-push storm (or a runaway dispatch)
+# queues instead of fanning out into N parallel signing requests. We do NOT
+# cancel-in-progress: a run that's already mid-signing has likely submitted
+# a SignPath request, and cancelling here would leave that request orphaned
+# in SignPath's UI for someone to clean up manually.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: windows-latest
+    # Gate the entire job on a GitHub Environment with required reviewers.
+    # Even before SignPath sees a request, a human (you) has to click approve
+    # in the GitHub Actions UI. This means an attacker with only a stolen
+    # GitHub session can't trigger signing — they'd also need to bypass the
+    # environment approval, which is enforced server-side by GitHub.
+    #
+    # IMPORTANT: this YAML key is inert until the environment is configured
+    # in the repo settings:
+    #   Settings → Environments → New environment → "production-signing"
+    #     → Required reviewers: <your GitHub user>
+    #     → (optionally) Deployment branches: release/* and tags v*.*.*
+    environment: production-signing
+    # Production SignPath signing requires manual approval in the SignPath UI
+    # (Foundation OSS policy). The job idles between submitting a signing
+    # request and the reviewer clicking approve, so the default 6h job timeout
+    # is too tight for two sequential approvals (exe, then installer). 12h
+    # gives a full business day of slack.
+    timeout-minutes: 720
 
     steps:
       - name: Checkout
@@ -130,6 +157,9 @@ jobs:
           signing-policy-slug: release-signing
           github-artifact-id: ${{ steps.upload-exe.outputs.artifact-id }}
           wait-for-completion: true
+          # Production cert requires manual approval; action's default poll
+          # timeout (10 min) is far too short. Wait up to 6h for a reviewer.
+          wait-for-completion-timeout-in-seconds: 21600
           output-artifact-directory: cgf-converter\bin\Release\net9.0\win-x64\publish\signed
 
       - name: Replace unsigned exe with signed
@@ -187,6 +217,8 @@ jobs:
           signing-policy-slug: release-signing
           github-artifact-id: ${{ steps.upload-installer.outputs.artifact-id }}
           wait-for-completion: true
+          # See note on Sign cgf-converter.exe — 6h for manual approval.
+          wait-for-completion-timeout-in-seconds: 21600
           output-artifact-directory: installer\output\signed
 
       - name: Replace unsigned installer with signed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,9 +127,7 @@ jobs:
           organization-id: 8379344c-28fc-42b2-94b3-f1303d6ee926
           project-slug: Cryengine-Converter
           artifact-configuration-slug: cgf-converter-exe
-          # TEMPORARY: test-signing for end-to-end pipeline verification.
-          # Flip back to release-signing once the Certum cert lands.
-          signing-policy-slug: test-signing
+          signing-policy-slug: release-signing
           github-artifact-id: ${{ steps.upload-exe.outputs.artifact-id }}
           wait-for-completion: true
           output-artifact-directory: cgf-converter\bin\Release\net9.0\win-x64\publish\signed
@@ -186,9 +184,7 @@ jobs:
           organization-id: 8379344c-28fc-42b2-94b3-f1303d6ee926
           project-slug: Cryengine-Converter
           artifact-configuration-slug: installer
-          # TEMPORARY: test-signing for end-to-end pipeline verification.
-          # Flip back to release-signing once the Certum cert lands.
-          signing-policy-slug: test-signing
+          signing-policy-slug: release-signing
           github-artifact-id: ${{ steps.upload-installer.outputs.artifact-id }}
           wait-for-completion: true
           output-artifact-directory: installer\output\signed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,7 @@ jobs:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: 8379344c-28fc-42b2-94b3-f1303d6ee926
           project-slug: Cryengine-Converter
+          artifact-configuration-slug: cgf-converter-exe
           # TEMPORARY: test-signing for end-to-end pipeline verification.
           # Flip back to release-signing once the Certum cert lands.
           signing-policy-slug: test-signing
@@ -134,9 +135,16 @@ jobs:
           output-artifact-directory: cgf-converter\bin\Release\net9.0\win-x64\publish\signed
 
       - name: Replace unsigned exe with signed
+        # SignPath returns the signed artifact in the same envelope it received
+        # (zip, since our artifact config wraps in <zip-file>). Extract, then
+        # overwrite the original.
         shell: pwsh
         run: |
-          Copy-Item "cgf-converter\bin\Release\net9.0\win-x64\publish\signed\cgf-converter.exe" `
+          $signedDir = "cgf-converter\bin\Release\net9.0\win-x64\publish\signed"
+          $zip = Get-ChildItem "$signedDir\*.zip" | Select-Object -First 1
+          if (-not $zip) { Write-Error "No signed zip found in $signedDir"; exit 1 }
+          Expand-Archive -Path $zip.FullName -DestinationPath "$signedDir\extracted" -Force
+          Copy-Item "$signedDir\extracted\cgf-converter.exe" `
                     "cgf-converter\bin\Release\net9.0\win-x64\publish\cgf-converter.exe" -Force
 
       - name: Compile installer with Inno Setup
@@ -165,6 +173,7 @@ jobs:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: 8379344c-28fc-42b2-94b3-f1303d6ee926
           project-slug: Cryengine-Converter
+          artifact-configuration-slug: installer
           # TEMPORARY: test-signing for end-to-end pipeline verification.
           # Flip back to release-signing once the Certum cert lands.
           signing-policy-slug: test-signing
@@ -173,10 +182,18 @@ jobs:
           output-artifact-directory: installer\output\signed
 
       - name: Replace unsigned installer with signed
+        # SignPath returns the signed artifact in the same envelope it received
+        # (zip, since our artifact config wraps in <zip-file>). Extract, then
+        # overwrite the original.
         shell: pwsh
         run: |
-          Copy-Item "installer\output\signed\cgf-converter-setup-${{ steps.version.outputs.version }}.exe" `
-                    "installer\output\cgf-converter-setup-${{ steps.version.outputs.version }}.exe" -Force
+          $signedDir = "installer\output\signed"
+          $zip = Get-ChildItem "$signedDir\*.zip" | Select-Object -First 1
+          if (-not $zip) { Write-Error "No signed zip found in $signedDir"; exit 1 }
+          Expand-Archive -Path $zip.FullName -DestinationPath "$signedDir\extracted" -Force
+          $installer = "cgf-converter-setup-${{ steps.version.outputs.version }}.exe"
+          Copy-Item "$signedDir\extracted\$installer" `
+                    "installer\output\$installer" -Force
 
       - name: Stage release assets
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,14 +102,16 @@ jobs:
       # ─── Code signing via SignPath ───────────────────────────────────────
       # Signs cgf-converter.exe BEFORE the installer is compiled so the
       # signed binary gets bundled inside the installer. Then signs the
-      # installer itself so users see "Heffay Presents" in SmartScreen.
+      # installer itself so users see the verified publisher
+      # ("Cryengine Converter [OSS]") in SmartScreen.
       #
       # The SignPath action requires an artifact uploaded via upload-artifact
       # to get an artifact ID. After signing, the signed file is downloaded
       # back and copied over the unsigned original.
       #
-      # Swap signing-policy-slug to the production policy once the OSS
-      # cert is approved by SignPath Foundation.
+      # Org / project / policy are scoped to the SignPath Foundation OSS
+      # org. The release-signing policy is gated on the Certum-issued cert
+      # being uploaded to SignPath — until then signing requests will fail.
 
       - name: Upload cgf-converter.exe for signing
         id: upload-exe
@@ -122,8 +124,10 @@ jobs:
         uses: signpath/github-action-submit-signing-request@v1
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
-          organization-id: b57aa812-9618-42c4-842f-96ef43865425
-          project-slug: Cryengine_Converter
+          organization-id: 8379344c-28fc-42b2-94b3-f1303d6ee926
+          project-slug: Cryengine-Converter
+          # TEMPORARY: test-signing for end-to-end pipeline verification.
+          # Flip back to release-signing once the Certum cert lands.
           signing-policy-slug: test-signing
           github-artifact-id: ${{ steps.upload-exe.outputs.artifact-id }}
           wait-for-completion: true
@@ -159,8 +163,10 @@ jobs:
         uses: signpath/github-action-submit-signing-request@v1
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
-          organization-id: b57aa812-9618-42c4-842f-96ef43865425
-          project-slug: Cryengine_Converter
+          organization-id: 8379344c-28fc-42b2-94b3-f1303d6ee926
+          project-slug: Cryengine-Converter
+          # TEMPORARY: test-signing for end-to-end pipeline verification.
+          # Flip back to release-signing once the Certum cert lands.
           signing-policy-slug: test-signing
           github-artifact-id: ${{ steps.upload-installer.outputs.artifact-id }}
           wait-for-completion: true

--- a/installer/cgf-converter.iss
+++ b/installer/cgf-converter.iss
@@ -77,7 +77,7 @@ ArchitecturesInstallIn64BitMode=x64compatible
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Tasks]
-Name: "addtopath"; Description: "Add {#MyAppName} to PATH (recommended — required to run cgf-converter from any directory)"; GroupDescription: "Additional tasks:"; Flags: checkedonce
+Name: "addtopath"; Description: "Add {#MyAppName} to PATH (recommended — required to run cgf-converter from any directory)"; GroupDescription: "Additional tasks:"
 
 [Files]
 Source: "{#PublishDir}\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion


### PR DESCRIPTION
## Summary

- Switch SignPath wiring from the old Heffay Presents org to the SignPath Foundation OSS org "Cryengine Converter [OSS]" (`8379344c-...`); update project slug from `Cryengine_Converter` to `Cryengine-Converter`.
- Add `artifact-configuration-slug` to each signing step (`cgf-converter-exe`, `installer`) so SignPath validates uploads against the right XML config (both wrap their PE in `<zip-file>` because GitHub Actions' `upload-artifact` always zips).
- Flip `signing-policy-slug` to `release-signing` (production Certum/GlobalSign cert via SignPath Foundation) for both the exe and installer signing steps.
- Harden the pipeline for production signing's manual-approval flow:
  - `concurrency: { group: release, cancel-in-progress: false }` — serialize release runs without orphaning an in-flight SignPath request.
  - `environment: production-signing` — gates the job on GitHub Environment approval (required reviewer), enforced server-side before any signing can start.
  - 12h job `timeout-minutes` + 6h `wait-for-completion-timeout-in-seconds` per signing step, to accommodate two sequential manual approvals (exe, then installer).
- Rewrite the "replace unsigned with signed" steps to be tolerant of SignPath's output layout (auto-extracted bare PE, or a returned zip), with a directory dump for diagnostics.
- Default the installer's "Add to PATH" task to checked (was defaulting unchecked on upgrades because of `checkedonce`).

## Verification

End-to-end verified with the **production** cert: run `26373421908` signed both artifacts and published them to the v2.0.0 pre-release. Downloaded installer reports `Status: Valid` via `Get-AuthenticodeSignature`, signed by `CN=SignPath Foundation` (issuer GlobalSign), properly timestamped (DigiCert). Installs cleanly in Windows Sandbox; "Add to PATH" defaults checked.

> Note: SmartScreen still shows an "unrecognized app" warning on first download — expected for an OV cert until it accrues download reputation. Not a signing failure; the file is correctly signed.

The `production-signing` environment is configured in repo settings: required reviewer + deployment branch policies for `release/*` and `v*.*.*` tags (covers this PR's `release/v2.0` base and final release tags).

**Out of band — not in this PR:**
- `SIGNPATH_API_TOKEN` repo secret was rotated to a token from the new OSS org's `CI Builds` user.
- `CI Builds` was granted submitter permission on the `release-signing` policy in the SignPath UI.

## Test plan

- [x] Dispatch workflow with production `release-signing` policy → both signing steps succeed
- [x] Released installer verifies as `Status: Valid`, publisher `SignPath Foundation`, timestamped
- [x] Installer downloads, installs in Windows Sandbox, "Add to PATH" defaults checked
- [x] Installed `cgf-converter -usage` runs and prints the dispatch SHA
- [x] `production-signing` environment gate configured (required reviewer + `release/*`/`v*.*.*` branch policies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
