### PR TITLE
Discover intermediate .i_caf animations (fixes #242)

### DIFF
--- a/CgfConverter/CryEngine/CryEngine.cs
+++ b/CgfConverter/CryEngine/CryEngine.cs
@@ -1036,7 +1036,7 @@ public partial class CryEngine
     /// Expands a wildcard pattern to find matching CAF files.
     /// Handles wildcards in both directory path (e.g., "path/*/*.caf") and filename (e.g., "path/*.caf").
     /// </summary>
-    private List<string> ExpandCafWildcard(string pattern)
+    internal List<string> ExpandCafWildcard(string pattern)
     {
         var results = new List<string>();
 
@@ -1083,9 +1083,23 @@ public partial class CryEngine
             if (Directory.Exists(baseDirectory))
             {
                 var searchOption = searchRecursively ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
-                var matchingFiles = Directory.GetFiles(baseDirectory, filePattern, searchOption);
-                results.AddRange(matchingFiles.Where(f =>
-                    f.EndsWith(".caf", StringComparison.OrdinalIgnoreCase)));
+
+                results.AddRange(Directory.GetFiles(baseDirectory, filePattern, searchOption)
+                    .Where(f => f.EndsWith(".caf", StringComparison.OrdinalIgnoreCase)));
+
+                // Some animations ship only as intermediate .i_caf files (uncompiled source) with no
+                // compiled .caf counterpart (e.g. Pandemic Express no-weapon anims — issue #242). They
+                // share the same CrCh chunk format, so include them too. Prefer the compiled .caf when
+                // both exist for the same animation, matched by filename stem.
+                var iCafPattern = filePattern.EndsWith(".caf", StringComparison.OrdinalIgnoreCase)
+                    ? string.Concat(filePattern.AsSpan(0, filePattern.Length - 4), ".i_caf")
+                    : filePattern;
+                var compiledStems = results
+                    .Select(Path.GetFileNameWithoutExtension)
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+                results.AddRange(Directory.GetFiles(baseDirectory, iCafPattern, searchOption)
+                    .Where(f => f.EndsWith(".i_caf", StringComparison.OrdinalIgnoreCase)
+                                && !compiledStems.Contains(Path.GetFileNameWithoutExtension(f))));
 
                 Log.D("Searched '{0}' with pattern '{1}', recursive={2}, found {3} files",
                     baseDirectory, filePattern, searchRecursively, results.Count);

--- a/CgfConverterIntegrationTests/UnitTests/IcafAnimationDiscoveryTests.cs
+++ b/CgfConverterIntegrationTests/UnitTests/IcafAnimationDiscoveryTests.cs
@@ -1,0 +1,58 @@
+using CgfConverter;
+using CgfConverter.PackFileSystem;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace CgfConverterTests.UnitTests;
+
+/// <summary>
+/// Regression tests for issue #242: animations that ship only as intermediate
+/// <c>.i_caf</c> files (e.g. Pandemic Express no-weapon animations) were silently
+/// dropped because the wildcard sweep only matched compiled <c>.caf</c> files.
+/// </summary>
+[TestClass]
+[TestCategory("unit")]
+public class IcafAnimationDiscoveryTests
+{
+    private string _tempRoot = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "cgf_icaf_" + Guid.NewGuid().ToString("N"));
+        var animDir = Path.Combine(_tempRoot, "anim", "sub");
+        Directory.CreateDirectory(animDir);
+
+        // a: ships as both compiled + intermediate -> compiled wins, intermediate dropped
+        File.WriteAllText(Path.Combine(animDir, "a.caf"), "");
+        File.WriteAllText(Path.Combine(animDir, "a.i_caf"), "");
+        // b: intermediate only -> must be discovered (the issue #242 case)
+        File.WriteAllText(Path.Combine(animDir, "b.i_caf"), "");
+        // c: compiled only -> discovered as before
+        File.WriteAllText(Path.Combine(animDir, "c.caf"), "");
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, true);
+    }
+
+    [TestMethod]
+    public void ExpandCafWildcard_IncludesIcafWithoutCafSibling_AndPrefersCaf()
+    {
+        var ce = new CryEngine("model.chr", new RealFileSystem(_tempRoot)) { ObjectDir = _tempRoot };
+
+        var results = ce.ExpandCafWildcard(Path.Combine("anim", "*", "*.caf"))
+            .Select(Path.GetFileName)
+            .ToList();
+
+        CollectionAssert.Contains(results, "c.caf", "compiled-only animation should still be found");
+        CollectionAssert.Contains(results, "b.i_caf", "intermediate-only (.i_caf) animation must be discovered");
+        CollectionAssert.Contains(results, "a.caf", "compiled file should be kept when both exist");
+        CollectionAssert.DoesNotContain(results, "a.i_caf", "intermediate should be dropped when a compiled .caf sibling exists");
+    }
+}


### PR DESCRIPTION
## Problem

Issue #242: the Pandemic Express `skeleton_player_generic` skeleton exports most animations but silently drops some — notably the `nw_idle` no-weapon animations the reporter called out.

## Root cause

Not a parse failure — a **discovery filter**. Those animations ship only as intermediate `.i_caf` files (uncompiled source) with no compiled `.caf` counterpart. The animation list reaches them via `skeleton_player_generic.chrparams` → `$Include` → `player.chrparams`, which sweeps with the wildcard `*\*.caf`. `ExpandCafWildcard` matched strictly on `.EndsWith(".caf")`, so the ~130 `.i_caf`-only files were never handed to the parser.

`.i_caf` files share the same `CrCh` / version `0x0746` chunk format and the same controller/timing chunk types (`0x0833`, `0x0919`) as `.caf` — the existing CAF reader parses them fine. The codebase already documented this in `ChunkController_833.cs` ("found in intermediate .i_caf files, not runtime .caf"); discovery just never offered them.

## Fix

`ExpandCafWildcard` now also enumerates the sibling `*.i_caf` pattern and includes those files, **deduping by filename stem with the compiled `.caf` preferred** when both exist — so animations shipping as both aren't exported twice.

## Tests

- New `IcafAnimationDiscoveryTests` (TDD, red→green): asserts an `.i_caf`-only file is discovered and an `.i_caf` with a `.caf` sibling is dropped.
- Full unit suite green (123 passing).
- End-to-end on the real skeleton: export count ~1600 → **1688**; `human_nw_idle_3p_01`, `human_nw_idlecrouch_3p_01`, `human_nw_move_*`, `AttackLeft/Right`, `BattleIdle`, `Block`, `Run3/4` now export, with no duplicate for `Human_NoWeapon_3p_Idle` (which ships as both).

## Follow-up (out of scope)

The `0x744`-only chunk-count workaround in `Model.cs` is also gated on `.caf` and would miss `.i_caf` for 0x744-era games. Irrelevant to Pandemic Express (these files are `0x0746`); worth revisiting only if a 0x744 title surfaces `.i_caf`-only anims.

Fixes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)
