### PR TITLE
Fix crash on material textures with no File attribute (#263)

### DIFF
--- a/CgfConverter/Renderers/Collada/ColladaModelRenderer.Materials.cs
+++ b/CgfConverter/Renderers/Collada/ColladaModelRenderer.Materials.cs
@@ -248,7 +248,7 @@ public partial class ColladaModelRenderer
         return colladaEffect;
     }
 
-    private ColladaMaterial AddMaterialToMaterialLibrary(string matKey, Material submat)
+    internal ColladaMaterial AddMaterialToMaterialLibrary(string matKey, Material submat)
     {
         var matName = GetMaterialName(matKey, submat?.Name ?? "unknown");
         ColladaMaterial material = new()
@@ -271,6 +271,14 @@ public partial class ColladaModelRenderer
 
         for (int i = 0; i < numberOfTextures; i++)
         {
+            // A <Texture> element with no File attribute deserializes to File == null (issue #263).
+            // It cannot produce an <image>, so skip it rather than crash in ResolveTextureFile.
+            if (string.IsNullOrWhiteSpace(submat.Textures[i].File))
+            {
+                Log.D($"Texture (Map={submat.Textures[i].Map}) on material \"{submat.Name}\" has no file path; skipping");
+                continue;
+            }
+
             // For each texture in the material, we make a new <image> object and add it to the list.
             var name = GetMaterialName(matKey, submat.Name);
             ColladaImage image = new()

--- a/CgfConverter/Renderers/MaterialTextures/MaterialTextureManager.cs
+++ b/CgfConverter/Renderers/MaterialTextures/MaterialTextureManager.cs
@@ -161,6 +161,14 @@ public class MaterialTextureManager
             if (!cryTextures.TryGetValue(mapType, out Texture? t))
                 continue;
 
+            // A <Texture> element with no File attribute deserializes to File == null (issue #263).
+            // Skip it rather than crash in ResolveTextureFile.
+            if (string.IsNullOrWhiteSpace(t.File))
+            {
+                _log.D("Texture (Map={0}) has no file path; skipping", mapType);
+                continue;
+            }
+
             // Build data dirs list: objectDir + material file's directory (for ./ relative paths)
             var dataDirs = new List<string>();
             if (_args.DataDir is not null)

--- a/CgfConverterIntegrationTests/UnitTests/ColladaMaterialTests.cs
+++ b/CgfConverterIntegrationTests/UnitTests/ColladaMaterialTests.cs
@@ -3,6 +3,7 @@ using CgfConverter.Models.Materials;
 using CgfConverter.PackFileSystem;
 using CgfConverter.Renderers.Collada;
 using CgfConverter.Renderers.Collada.Collada.Collada_FX.Effects;
+using CgfConverter.Renderers.Collada.Collada.Collada_FX.Texturing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
 
@@ -105,6 +106,26 @@ public class ColladaMaterialTests
         var specularRef = GetPhongSpecularTextureRef(effect);
         Assert.IsNotNull(specularRef, "Expected phong specular to be bound when only TexSlot10 is present");
         StringAssert.EndsWith(specularRef, "_TexSlot10-sampler");
+    }
+
+    [TestMethod]
+    public void AddMaterial_TextureWithNullFile_DoesNotThrowAndSkipsTexture()
+    {
+        // Issue #263: a <Texture> element with no File attribute deserializes to File == null.
+        // The Collada renderer passed that null straight into ResolveTextureFile, throwing
+        // ArgumentNullException and crashing the whole conversion. A fileless texture cannot
+        // produce an <image>, so it must be skipped (matching the USD renderer's behavior).
+        var subMat = BuildSubMaterial("broken",
+            ("Diffuse", null!),                 // offending fileless texture
+            ("Bumpmap", "valid_ddna.dds"));     // valid texture alongside it
+
+        renderer.DaeObject.Library_Images = new ColladaLibraryImages();
+
+        renderer.AddMaterialToMaterialLibrary("broken.mtl", subMat);
+
+        var images = renderer.DaeObject.Library_Images.Image;
+        Assert.IsNotNull(images, "Expected the valid texture to still produce an <image>");
+        Assert.AreEqual(1, images.Length, "Fileless texture should be skipped; only the valid one emitted");
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

Fixes #263 — converting `gdgt_fps_grin_multitool_mining_parts.skin` (and any asset whose `.mtl` has a `<Texture>` element with no `File` attribute) crashed with `ArgumentNullException` in `ResolveTextureFile`, aborting the whole conversion.

**Root cause:** a `<Texture>` with no `File` attribute deserializes to `File == null`. The Collada renderer and `MaterialTextureManager` passed that null straight into `ResolveTextureFile`. The USD renderer already guarded this case (`UsdRenderer.Materials.cs:294`); these two paths did not.

**Fix:** skip fileless textures in both paths — a texture with no file cannot produce an `<image>`/binding — matching the USD renderer's existing behavior. The unusable texture is logged at Debug level and dropped; the mesh and all valid textures still export.

No version bump (release-branch fix per project policy).

## Test plan

- [x] New regression test `AddMaterial_TextureWithNullFile_DoesNotThrowAndSkipsTexture` drives the Collada material-library path with a null `File`; red before the fix (repro'd the crash), green after.
- [x] Full unit suite: 124 passed, 0 failed.
- [x] Manually converted the issue's asset (`gdgt_fps_grin_multitool_mining_parts.skin`, `-objectdir D:\depot\sc4.6\data`) with the fixed build — `Finished`, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)